### PR TITLE
fix: stripe transactions having no payouts were causing panic

### DIFF
--- a/internal/pkg/connectors/stripe/translate.go
+++ b/internal/pkg/connectors/stripe/translate.go
@@ -148,6 +148,10 @@ func CreateBatchElement(balanceTransaction *stripe.BalanceTransaction, forward b
 		return ingestion.BatchElement{}, false
 	}
 
+	if balanceTransaction.Source.Payout == nil {
+		return ingestion.BatchElement{}, false
+	}
+
 	formatAsset := func(cur stripe.Currency) string {
 		asset := strings.ToUpper(string(cur))
 


### PR DESCRIPTION
Signed-off-by: Lawrence Zawila <113581282+darkmatterpool@users.noreply.github.com>