### PR TITLE
fix: pagination logic when using previous cursor

### DIFF
--- a/internal/app/storage/accounts.go
+++ b/internal/app/storage/accounts.go
@@ -56,7 +56,11 @@ func (s *Storage) ListAccounts(ctx context.Context, pagination Paginator) ([]*mo
 	)
 
 	if hasMore {
-		accounts = accounts[:pagination.pageSize]
+		if pagination.cursor.Next {
+			accounts = accounts[:pagination.pageSize]
+		} else {
+			accounts = accounts[1:]
+		}
 	}
 
 	if len(accounts) > 0 {

--- a/internal/app/storage/accounts.go
+++ b/internal/app/storage/accounts.go
@@ -51,6 +51,7 @@ func (s *Storage) ListAccounts(ctx context.Context, pagination Paginator) ([]*mo
 
 	var (
 		hasMore                       = len(accounts) > pagination.pageSize
+		hasPrevious                   bool
 		firstReference, lastReference string
 	)
 
@@ -61,9 +62,16 @@ func (s *Storage) ListAccounts(ctx context.Context, pagination Paginator) ([]*mo
 	if len(accounts) > 0 {
 		firstReference = accounts[0].CreatedAt.Format(time.RFC3339Nano)
 		lastReference = accounts[len(accounts)-1].CreatedAt.Format(time.RFC3339Nano)
+
+		query = s.db.NewSelect().Model(&accounts)
+
+		hasPrevious, err = pagination.hasPrevious(ctx, query, "account.created_at", firstReference)
+		if err != nil {
+			return nil, PaginationDetails{}, fmt.Errorf("failed to check if there is a previous page: %w", err)
+		}
 	}
 
-	paginationDetails, err := pagination.paginationDetails(hasMore, firstReference, lastReference)
+	paginationDetails, err := pagination.paginationDetails(hasMore, hasPrevious, firstReference, lastReference)
 	if err != nil {
 		return nil, PaginationDetails{}, fmt.Errorf("failed to get pagination details: %w", err)
 	}

--- a/internal/app/storage/accounts.go
+++ b/internal/app/storage/accounts.go
@@ -57,7 +57,7 @@ func (s *Storage) ListAccounts(ctx context.Context, pagination Paginator) ([]*mo
 	)
 
 	if hasMore {
-		if pagination.cursor.Next {
+		if pagination.cursor.Next || pagination.cursor.Reference == "" {
 			accounts = accounts[:pagination.pageSize]
 		} else {
 			accounts = accounts[1:]

--- a/internal/app/storage/accounts.go
+++ b/internal/app/storage/accounts.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/formancehq/payments/internal/app/models"
@@ -62,6 +63,10 @@ func (s *Storage) ListAccounts(ctx context.Context, pagination Paginator) ([]*mo
 			accounts = accounts[1:]
 		}
 	}
+
+	sort.Slice(accounts, func(i, j int) bool {
+		return accounts[i].CreatedAt.After(accounts[j].CreatedAt)
+	})
 
 	if len(accounts) > 0 {
 		firstReference = accounts[0].CreatedAt.Format(time.RFC3339Nano)

--- a/internal/app/storage/paginate.go
+++ b/internal/app/storage/paginate.go
@@ -71,14 +71,14 @@ func Paginate(pageSize int, token string, sorter Sorter) (Paginator, error) {
 }
 
 func (p Paginator) apply(query *bun.SelectQuery, column string) *bun.SelectQuery {
-	query = query.Limit(p.pageSize + 1).Order(column + " DESC")
+	query = query.Limit(p.pageSize + 1)
 
 	if p.cursor.Reference == "" {
 		if p.sorter != nil {
 			query = p.sorter.apply(query)
 		}
 
-		return query
+		return query.Order(column + " DESC")
 	}
 
 	if p.cursor.Sorter != nil {
@@ -86,10 +86,10 @@ func (p Paginator) apply(query *bun.SelectQuery, column string) *bun.SelectQuery
 	}
 
 	if p.cursor.Next {
-		return query.Where(fmt.Sprintf("%s < ?", column), p.cursor.Reference)
+		return query.Where(fmt.Sprintf("%s < ?", column), p.cursor.Reference).Order(column + " DESC")
 	}
 
-	return query.Where(fmt.Sprintf("%s >= ?", column), p.cursor.Reference)
+	return query.Where(fmt.Sprintf("%s >= ?", column), p.cursor.Reference).Order(column + " ASC")
 }
 
 func (p Paginator) hasPrevious(ctx context.Context, query *bun.SelectQuery, column, reference string) (bool, error) {

--- a/internal/app/storage/paginate_test.go
+++ b/internal/app/storage/paginate_test.go
@@ -159,6 +159,7 @@ func TestPaginatorPaginationDetails(t *testing.T) {
 
 	type args struct {
 		hasMore        bool
+		hasPrevious    bool
 		firstReference string
 		lastReference  string
 	}
@@ -175,7 +176,7 @@ func TestPaginatorPaginationDetails(t *testing.T) {
 	}
 
 	tokenNext, err := baseCursor{
-		Reference: "",
+		Reference: "abc",
 		Sorter:    nil,
 		Next:      true,
 	}.Encode()
@@ -193,21 +194,21 @@ func TestPaginatorPaginationDetails(t *testing.T) {
 		{
 			name:    "no cursor",
 			fields:  fields{pageSize: 10, token: "", cursor: baseCursor{}, sorter: nil},
-			args:    args{hasMore: false, firstReference: "", lastReference: ""},
+			args:    args{hasMore: false, hasPrevious: false, firstReference: "", lastReference: ""},
 			want:    PaginationDetails{PageSize: 10, HasMore: false},
 			wantErr: false,
 		},
 		{
 			name:    "with cursor",
 			fields:  fields{pageSize: 10, token: "", cursor: cursor, sorter: nil},
-			args:    args{hasMore: false, firstReference: "abc", lastReference: ""},
+			args:    args{hasMore: false, hasPrevious: true, firstReference: "abc", lastReference: ""},
 			want:    PaginationDetails{PageSize: 10, HasMore: false, PreviousPage: token},
 			wantErr: false,
 		},
 		{
 			name:    "has more",
 			fields:  fields{pageSize: 10, token: "", cursor: baseCursor{}, sorter: nil},
-			args:    args{hasMore: true, firstReference: "", lastReference: ""},
+			args:    args{hasMore: true, hasPrevious: false, firstReference: "", lastReference: "abc"},
 			want:    PaginationDetails{PageSize: 10, HasMore: true, NextPage: tokenNext},
 			wantErr: false,
 		},
@@ -226,7 +227,7 @@ func TestPaginatorPaginationDetails(t *testing.T) {
 				sorter:   tt.fields.sorter,
 			}
 
-			got, err := p.paginationDetails(tt.args.hasMore, tt.args.firstReference, tt.args.lastReference)
+			got, err := p.paginationDetails(tt.args.hasMore, tt.args.hasPrevious, tt.args.firstReference, tt.args.lastReference)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("paginationDetails() error = %v, wantErr %v", err, tt.wantErr)
 

--- a/internal/app/storage/payments.go
+++ b/internal/app/storage/payments.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -40,6 +41,10 @@ func (s *Storage) ListPayments(ctx context.Context, pagination Paginator) ([]*mo
 			payments = payments[1:]
 		}
 	}
+
+	sort.Slice(payments, func(i, j int) bool {
+		return payments[i].CreatedAt.After(payments[j].CreatedAt)
+	})
 
 	if len(payments) > 0 {
 		firstReference = payments[0].CreatedAt.Format(time.RFC3339Nano)

--- a/internal/app/storage/payments.go
+++ b/internal/app/storage/payments.go
@@ -34,7 +34,11 @@ func (s *Storage) ListPayments(ctx context.Context, pagination Paginator) ([]*mo
 	)
 
 	if hasMore {
-		payments = payments[:pagination.pageSize]
+		if pagination.cursor.Next {
+			payments = payments[:pagination.pageSize]
+		} else {
+			payments = payments[1:]
+		}
 	}
 
 	if len(payments) > 0 {

--- a/internal/app/storage/payments.go
+++ b/internal/app/storage/payments.go
@@ -35,7 +35,7 @@ func (s *Storage) ListPayments(ctx context.Context, pagination Paginator) ([]*mo
 	)
 
 	if hasMore {
-		if pagination.cursor.Next {
+		if pagination.cursor.Next || pagination.cursor.Reference == "" {
 			payments = payments[:pagination.pageSize]
 		} else {
 			payments = payments[1:]

--- a/internal/app/storage/repository.go
+++ b/internal/app/storage/repository.go
@@ -13,7 +13,6 @@ func newStorage(db *bun.DB) *Storage {
 	return &Storage{db: db}
 }
 
-// nolint:unused // used for SQL debugging purposes
 func (s *Storage) debug() {
 	s.db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 }

--- a/internal/app/storage/repository.go
+++ b/internal/app/storage/repository.go
@@ -13,6 +13,7 @@ func newStorage(db *bun.DB) *Storage {
 	return &Storage{db: db}
 }
 
+//nolint:unused // used in debug mode
 func (s *Storage) debug() {
 	s.db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(true)))
 }

--- a/internal/app/storage/task.go
+++ b/internal/app/storage/task.go
@@ -134,7 +134,7 @@ func (s *Storage) ListTasks(ctx context.Context, provider models.ConnectorProvid
 	)
 
 	if hasMore {
-		if pagination.cursor.Next {
+		if pagination.cursor.Next || pagination.cursor.Reference == "" {
 			tasks = tasks[:pagination.pageSize]
 		} else {
 			tasks = tasks[1:]

--- a/internal/app/storage/task.go
+++ b/internal/app/storage/task.go
@@ -109,8 +109,6 @@ func (s *Storage) ListTasksByStatus(ctx context.Context, provider models.Connect
 }
 
 func (s *Storage) ListTasks(ctx context.Context, provider models.ConnectorProvider, pagination Paginator) ([]models.Task, PaginationDetails, error) {
-	s.debug()
-
 	connector, err := s.GetConnector(ctx, provider)
 	if err != nil {
 		return nil, PaginationDetails{}, e("failed to get connector", err)
@@ -135,7 +133,11 @@ func (s *Storage) ListTasks(ctx context.Context, provider models.ConnectorProvid
 	)
 
 	if hasMore {
-		tasks = tasks[:pagination.pageSize]
+		if pagination.cursor.Next {
+			tasks = tasks[:pagination.pageSize]
+		} else {
+			tasks = tasks[1:]
+		}
 	}
 
 	if len(tasks) > 0 {

--- a/internal/app/storage/task.go
+++ b/internal/app/storage/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -139,6 +140,10 @@ func (s *Storage) ListTasks(ctx context.Context, provider models.ConnectorProvid
 			tasks = tasks[1:]
 		}
 	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].CreatedAt.After(tasks[j].CreatedAt)
+	})
 
 	if len(tasks) > 0 {
 		firstReference = tasks[0].CreatedAt.Format(time.RFC3339Nano)


### PR DESCRIPTION
A bug caused the previous cursor to appear in API responses even if no last data was available.

Signed-off-by: Lawrence Zawila <113581282+darkmatterpool@users.noreply.github.com>