### PR TITLE
fix(temporal): continue a new when terminating workflows

### DIFF
--- a/internal/connectors/engine/workflow/plugin_workflow.go
+++ b/internal/connectors/engine/workflow/plugin_workflow.go
@@ -113,6 +113,9 @@ func (w Workflow) run(
 						Every: config.PollingPeriod,
 					},
 					Action: client.ScheduleWorkflowAction{
+						// Use the same ID as the schedule ID, so we can identify the workflows running.
+						// This is useful for debugging purposes.
+						ID:       scheduleID,
 						Workflow: nextWorkflow,
 						Args: []interface{}{
 							request,

--- a/internal/connectors/engine/workflow/uninstall_connector.go
+++ b/internal/connectors/engine/workflow/uninstall_connector.go
@@ -37,6 +37,8 @@ func (w Workflow) runUninstallConnector(
 		return fmt.Errorf("terminate schedules: %w", err)
 	}
 
+	// Since we can have lots of workflows running, we don't need to wait for
+	// them to be terminated before proceeding with the uninstallation.
 	if err := workflow.ExecuteChildWorkflow(
 		workflow.WithChildOptions(
 			ctx,
@@ -49,8 +51,10 @@ func (w Workflow) runUninstallConnector(
 			},
 		),
 		RunTerminateWorkflows,
-		uninstallConnector,
-	).Get(ctx, nil); err != nil {
+		TerminateWorkflows{
+			ConnectorID: uninstallConnector.ConnectorID,
+		},
+	).GetChildWorkflowExecution().Get(ctx, nil); err != nil {
 		return fmt.Errorf("terminate workflows: %w", err)
 	}
 


### PR DESCRIPTION
When having a connector with lots of data, we can have lots of workflows. When uninstalling, we will go through the workflows to terminated them, but we will maybe exceed the history size or length of a worfklow.

This PR adds two things: the termination of workflows in background and continue a new if we reach the limits