### PR TITLE
feat: (payments v3) Disable connector install retry in temporal workflow

### DIFF
--- a/internal/connectors/engine/workflow/context.go
+++ b/internal/connectors/engine/workflow/context.go
@@ -24,3 +24,18 @@ func infiniteRetryContext(ctx workflow.Context) workflow.Context {
 		},
 	})
 }
+
+func maximumAttemptsRetryContext(ctx workflow.Context, attempts int) workflow.Context {
+	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 60 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    int32(attempts),
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    100 * time.Second,
+			NonRetryableErrorTypes: []string{
+				ErrorCodeValidation,
+			},
+		},
+	})
+}

--- a/internal/connectors/engine/workflow/install_connector.go
+++ b/internal/connectors/engine/workflow/install_connector.go
@@ -25,7 +25,9 @@ func (w Workflow) runInstallConnector(
 	// Second step: install the connector via the plugin and get the list of
 	// capabilities and the workflow of polling data
 	installResponse, err := activities.PluginInstallConnector(
-		infiniteRetryContext(ctx),
+		// disable retries as grpc plugin boot command cannot be run more than once by the go-plugin client
+		// this also causes API install calls to fail immediately which is more desirable in the case that a plugin is timing out or not compiled correctly
+		maximumAttemptsRetryContext(ctx, 1),
 		installConnector.ConnectorID,
 		installConnector.RawConfig,
 	)


### PR DESCRIPTION
fixes: ENG-1533

this fixes the "Stdout already set" errors from the plugin client that sometimes occur on the dev cluster.