### PR TITLE
feat(temporal): rename task queue by adding the stack

### DIFF
--- a/internal/connectors/engine/workflow/create_bank_account.go
+++ b/internal/connectors/engine/workflow/create_bank_account.go
@@ -99,7 +99,7 @@ func (w Workflow) createBankAccount(
 		workflow.WithChildOptions(
 			ctx,
 			workflow.ChildWorkflowOptions{
-				TaskQueue:         relatedAccount.ConnectorID.String(),
+				TaskQueue:         w.getConnectorTaskQueue(relatedAccount.ConnectorID),
 				ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 				SearchAttributes: map[string]interface{}{
 					SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/create_payout.go
+++ b/internal/connectors/engine/workflow/create_payout.go
@@ -128,7 +128,7 @@ func (w Workflow) createPayout(
 								ScheduleID:          scheduleID,
 							},
 						},
-						TaskQueue: createPayout.ConnectorID.String(),
+						TaskQueue: w.getConnectorTaskQueue(createPayout.ConnectorID),
 						TypedSearchAttributes: temporal.NewSearchAttributes(
 							temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet(scheduleID),
 							temporal.NewSearchAttributeKeyKeyword(SearchAttributeStack).ValueSet(w.stack),

--- a/internal/connectors/engine/workflow/create_transfer.go
+++ b/internal/connectors/engine/workflow/create_transfer.go
@@ -130,7 +130,7 @@ func (w Workflow) createTransfer(
 								ScheduleID:          scheduleID,
 							},
 						},
-						TaskQueue: createTransfer.ConnectorID.String(),
+						TaskQueue: w.getConnectorTaskQueue(createTransfer.ConnectorID),
 						TypedSearchAttributes: temporal.NewSearchAttributes(
 							temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet(scheduleID),
 							temporal.NewSearchAttributeKeyKeyword(SearchAttributeStack).ValueSet(w.stack),

--- a/internal/connectors/engine/workflow/create_webhooks.go
+++ b/internal/connectors/engine/workflow/create_webhooks.go
@@ -56,7 +56,7 @@ func (w Workflow) createWebhooks(
 			workflow.WithChildOptions(
 				ctx,
 				workflow.ChildWorkflowOptions{
-					TaskQueue:         createWebhooks.ConnectorID.String(),
+					TaskQueue:         w.getConnectorTaskQueue(createWebhooks.ConnectorID),
 					ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 					SearchAttributes: map[string]interface{}{
 						SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/fetch_accounts.go
+++ b/internal/connectors/engine/workflow/fetch_accounts.go
@@ -90,7 +90,7 @@ func (w Workflow) fetchAccounts(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextAccount.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextAccount.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,
@@ -123,7 +123,7 @@ func (w Workflow) fetchAccounts(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextAccount.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextAccount.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/fetch_balances.go
+++ b/internal/connectors/engine/workflow/fetch_balances.go
@@ -88,7 +88,7 @@ func (w Workflow) fetchBalances(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextBalances.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextBalances.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,
@@ -121,7 +121,7 @@ func (w Workflow) fetchBalances(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextBalances.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextBalances.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/fetch_external_accounts.go
+++ b/internal/connectors/engine/workflow/fetch_external_accounts.go
@@ -89,7 +89,7 @@ func (w Workflow) fetchExternalAccounts(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextExternalAccount.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextExternalAccount.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,
@@ -122,7 +122,7 @@ func (w Workflow) fetchExternalAccounts(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextExternalAccount.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextExternalAccount.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/fetch_others.go
+++ b/internal/connectors/engine/workflow/fetch_others.go
@@ -75,7 +75,7 @@ func (w Workflow) fetchNextOthers(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextOthers.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextOthers.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/fetch_payments.go
+++ b/internal/connectors/engine/workflow/fetch_payments.go
@@ -91,7 +91,7 @@ func (w Workflow) fetchNextPayments(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextPayments.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextPayments.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,
@@ -116,7 +116,7 @@ func (w Workflow) fetchNextPayments(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextPayments.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextPayments.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,
@@ -150,7 +150,7 @@ func (w Workflow) fetchNextPayments(
 					workflow.WithChildOptions(
 						ctx,
 						workflow.ChildWorkflowOptions{
-							TaskQueue:         fetchNextPayments.ConnectorID.String(),
+							TaskQueue:         w.getConnectorTaskQueue(fetchNextPayments.ConnectorID),
 							ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 							SearchAttributes: map[string]interface{}{
 								SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/handle_webhooks.go
+++ b/internal/connectors/engine/workflow/handle_webhooks.go
@@ -73,7 +73,7 @@ func (w Workflow) runHandleWebhooks(
 				ctx,
 				workflow.ChildWorkflowOptions{
 					WorkflowID:            fmt.Sprintf("store-webhook-%s-%s-%s", w.stack, handleWebhooks.ConnectorID.String(), response.IdempotencyKey),
-					TaskQueue:             handleWebhooks.ConnectorID.String(),
+					TaskQueue:             w.getConnectorTaskQueue(handleWebhooks.ConnectorID),
 					ParentClosePolicy:     enums.PARENT_CLOSE_POLICY_ABANDON,
 					WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 					SearchAttributes: map[string]interface{}{
@@ -180,7 +180,7 @@ func (w Workflow) runStoreWebhookTranslation(
 			workflow.WithChildOptions(
 				ctx,
 				workflow.ChildWorkflowOptions{
-					TaskQueue:         storeWebhookTranslation.ConnectorID.String(),
+					TaskQueue:         w.getConnectorTaskQueue(storeWebhookTranslation.ConnectorID),
 					ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 					SearchAttributes: map[string]interface{}{
 						SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/install_connector.go
+++ b/internal/connectors/engine/workflow/install_connector.go
@@ -63,7 +63,7 @@ func (w Workflow) runInstallConnector(
 			workflow.ChildWorkflowOptions{
 				WorkflowID:            fmt.Sprintf("run-tasks-%s-%s", w.stack, installConnector.ConnectorID.String()),
 				WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-				TaskQueue:             installConnector.ConnectorID.String(),
+				TaskQueue:             w.getConnectorTaskQueue(installConnector.ConnectorID),
 				ParentClosePolicy:     enums.PARENT_CLOSE_POLICY_ABANDON,
 				SearchAttributes: map[string]interface{}{
 					SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/plugin_workflow.go
+++ b/internal/connectors/engine/workflow/plugin_workflow.go
@@ -121,7 +121,7 @@ func (w Workflow) run(
 							request,
 							task.NextTasks,
 						},
-						TaskQueue: connectorID.String(),
+						TaskQueue: w.getConnectorTaskQueue(connectorID),
 					},
 					Overlap:            enums.SCHEDULE_OVERLAP_POLICY_SKIP,
 					TriggerImmediately: true,
@@ -151,7 +151,7 @@ func (w Workflow) run(
 				workflow.WithChildOptions(
 					ctx,
 					workflow.ChildWorkflowOptions{
-						TaskQueue:         connectorID.String(),
+						TaskQueue:         w.getConnectorTaskQueue(connectorID),
 						ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 						SearchAttributes: map[string]interface{}{
 							SearchAttributeStack: w.stack,

--- a/internal/connectors/engine/workflow/utils.go
+++ b/internal/connectors/engine/workflow/utils.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
@@ -29,7 +30,7 @@ func (w Workflow) storePIPaymentWithStatus(
 		workflow.WithChildOptions(
 			ctx,
 			workflow.ChildWorkflowOptions{
-				TaskQueue:         connectorID.String(),
+				TaskQueue:         w.getConnectorTaskQueue(connectorID),
 				ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
 				SearchAttributes: map[string]interface{}{
 					SearchAttributeStack: w.stack,
@@ -148,4 +149,8 @@ func getPIStatusFromPayment(status models.PaymentStatus) models.PaymentInitiatio
 	default:
 		return models.PAYMENT_INITIATION_ADJUSTMENT_STATUS_UNKNOWN
 	}
+}
+
+func (w Workflow) getConnectorTaskQueue(connectorID models.ConnectorID) string {
+	return fmt.Sprintf("%s-%s", w.stack, connectorID.String())
 }


### PR DESCRIPTION
Since clients can be in the same namespace, and in the rare case two clients have the same connectorID, we need to have the stack for the worker name.