### PR TITLE
fix(temporal): fix missing default worker

### DIFF
--- a/internal/connectors/engine/workers.go
+++ b/internal/connectors/engine/workers.go
@@ -37,15 +37,17 @@ func (w *Workers) getDefaultWorkerName() string {
 	return defaultWorker
 }
 
-func (w *Workers) CreateDefaultWorker() {
-	w.AddWorker(w.getDefaultWorkerName())
+func (w *Workers) CreateDefaultWorker() error {
+	return w.AddWorker(w.getDefaultWorkerName())
 }
 
 // Returns the default worker name and create it if it doesn't exist yet.
-func (w *Workers) GetDefaultWorker() string {
+func (w *Workers) GetDefaultWorker() (string, error) {
 	defaultWorker := w.getDefaultWorkerName()
-	w.AddWorker(defaultWorker)
-	return defaultWorker
+	if err := w.AddWorker(defaultWorker); err != nil {
+		return "", err
+	}
+	return defaultWorker, nil
 }
 
 func NewWorkers(logger logging.Logger, stack string, temporalClient client.Client, workflows, activities []temporal.DefinitionSet, options worker.Options) *Workers {

--- a/internal/connectors/engine/workers.go
+++ b/internal/connectors/engine/workers.go
@@ -32,9 +32,18 @@ type Worker struct {
 	worker worker.Worker
 }
 
+func (w *Workers) getDefaultWorkerName() string {
+	defaultWorker := fmt.Sprintf("%s-default", w.stack)
+	return defaultWorker
+}
+
+func (w *Workers) CreateDefaultWorker() {
+	w.AddWorker(w.getDefaultWorkerName())
+}
+
 // Returns the default worker name and create it if it doesn't exist yet.
 func (w *Workers) GetDefaultWorker() string {
-	defaultWorker := fmt.Sprintf("%s-default", w.stack)
+	defaultWorker := w.getDefaultWorkerName()
 	w.AddWorker(defaultWorker)
 	return defaultWorker
 }


### PR DESCRIPTION
When payments is rebooting, we do not recreate the default worker unless a connector is currently being deleted. This may cause a bug with workflows to create accounts, payments or pools

Fixes ENG-1570