### PR TITLE
fix: (v2) ensure connector install v2 response is compatible to fctl

### DIFF
--- a/internal/api/v2/handler_connectors_install.go
+++ b/internal/api/v2/handler_connectors_install.go
@@ -12,6 +12,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+// NOTE: in order to maintain previous version compatibility, we need to keep the
+// same response structure as the previous version of the API
+type ConnectorInstallResponse struct {
+	ConnectorID string `json:"connectorID"`
+}
+
 func connectorsInstall(backend backend.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := otel.Tracer().Start(r.Context(), "v2_connectorsInstall")
@@ -41,6 +47,8 @@ func connectorsInstall(backend backend.Backend) http.HandlerFunc {
 			return
 		}
 
-		api.Created(w, connectorID.String())
+		api.Created(w, ConnectorInstallResponse{
+			ConnectorID: connectorID.String(),
+		})
 	}
 }

--- a/test/e2e/api_accounts_test.go
+++ b/test/e2e/api_accounts_test.go
@@ -65,7 +65,7 @@ var _ = Context("Payments API Accounts", func() {
 			func(ver int) {
 				e = Subscribe(GinkgoT(), app.GetValue())
 				connectorConf := newConnectorConfigurationFn()(uuid.New())
-				err = ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, &connectorRes)
+				err = ConnectorInstall(ctx, app.GetValue(), 3, connectorConf, &connectorRes)
 				Expect(err).To(BeNil())
 
 				createRequest.ConnectorID = connectorRes.Data
@@ -98,9 +98,8 @@ var _ = Context("Payments API Accounts", func() {
 				connectorConf := newConnectorConfigurationFn()(uuid.New())
 				_, err := GeneratePSPData(connectorConf.Directory)
 				Expect(err).To(BeNil())
-				ver = 3
 
-				err = ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, &connectorRes)
+				err = ConnectorInstall(ctx, app.GetValue(), 3, connectorConf, &connectorRes)
 				Expect(err).To(BeNil())
 				Eventually(e).WithTimeout(2 * time.Second).Should(Receive(Event(evts.EventTypeSavedAccounts)))
 

--- a/test/e2e/api_bank_accounts_test.go
+++ b/test/e2e/api_bank_accounts_test.go
@@ -178,7 +178,7 @@ var _ = Context("Payments API Bank Accounts", func() {
 			ver          int
 			createRes    struct{ Data v2.BankAccountResponse }
 			forwardReq   v2.BankAccountsForwardToConnectorRequest
-			connectorRes struct{ Data string }
+			connectorRes struct{ Data v2.ConnectorInstallResponse }
 			res          struct{ Data v2.BankAccountResponse }
 			e            chan *nats.Msg
 			err          error
@@ -202,11 +202,11 @@ var _ = Context("Payments API Bank Accounts", func() {
 			Expect(err.Error()).To(ContainSubstring("400"))
 		})
 		It("should be ok", func() {
-			forwardReq = v2.BankAccountsForwardToConnectorRequest{ConnectorID: connectorRes.Data}
+			forwardReq = v2.BankAccountsForwardToConnectorRequest{ConnectorID: connectorRes.Data.ConnectorID}
 			err = ForwardBankAccount(ctx, app.GetValue(), ver, id.String(), &forwardReq, &res)
 			Expect(err).To(BeNil())
 			Expect(res.Data.RelatedAccounts).To(HaveLen(1))
-			Expect(res.Data.RelatedAccounts[0].ConnectorID).To(Equal(connectorRes.Data))
+			Expect(res.Data.RelatedAccounts[0].ConnectorID).To(Equal(connectorRes.Data.ConnectorID))
 
 			Eventually(e).Should(Receive(Event(evts.EventTypeSavedBankAccount)))
 		})

--- a/test/e2e/api_payments_test.go
+++ b/test/e2e/api_payments_test.go
@@ -104,7 +104,7 @@ var _ = Context("Payments API Payments", func() {
 
 	When("creating a new payment with v2", func() {
 		var (
-			connectorRes   struct{ Data string }
+			connectorRes   struct{ Data v2.ConnectorInstallResponse }
 			createResponse struct{ Data v2.PaymentResponse }
 			getResponse    struct{ Data v2.PaymentResponse }
 			e              chan *nats.Msg
@@ -127,10 +127,10 @@ var _ = Context("Payments API Payments", func() {
 		})
 
 		It("should be ok", func() {
-			debtorID, creditorID := setupDebtorAndCreditorAccounts(ctx, app.GetValue(), e, ver, connectorRes.Data, createdAt)
+			debtorID, creditorID := setupDebtorAndCreditorAccounts(ctx, app.GetValue(), e, ver, connectorRes.Data.ConnectorID, createdAt)
 			createRequest := v2.CreatePaymentRequest{
 				Reference:            "ref",
-				ConnectorID:          connectorRes.Data,
+				ConnectorID:          connectorRes.Data.ConnectorID,
 				CreatedAt:            createdAt,
 				Amount:               initialAmount,
 				Asset:                asset,

--- a/test/e2e/api_pools_test.go
+++ b/test/e2e/api_pools_test.go
@@ -119,7 +119,7 @@ var _ = Context("Payments API Pools", func() {
 
 	When("creating a new pool with v2", func() {
 		var (
-			connectorRes struct{ Data string }
+			connectorRes struct{ Data v2.ConnectorInstallResponse }
 			connectorID  string
 			e            chan *nats.Msg
 			ver          int
@@ -131,7 +131,7 @@ var _ = Context("Payments API Pools", func() {
 			connectorConf := newConnectorConfigurationFn()(uuid.New())
 			err := ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, &connectorRes)
 			Expect(err).To(BeNil())
-			connectorID = connectorRes.Data
+			connectorID = connectorRes.Data.ConnectorID
 		})
 
 		It("should be ok when underlying accounts exist", func() {
@@ -268,7 +268,7 @@ var _ = Context("Payments API Pools", func() {
 
 	When("adding and removing accounts to a pool with v2", func() {
 		var (
-			connectorRes    struct{ Data string }
+			connectorRes    struct{ Data v2.ConnectorInstallResponse }
 			connectorID     string
 			accountIDs      []string
 			extraAccountIDs []string
@@ -285,7 +285,7 @@ var _ = Context("Payments API Pools", func() {
 			connectorConf := newConnectorConfigurationFn()(uuid.New())
 			err := ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, &connectorRes)
 			Expect(err).To(BeNil())
-			connectorID = connectorRes.Data
+			connectorID = connectorRes.Data.ConnectorID
 			ids := setupAccounts(ctx, app.GetValue(), e, ver, connectorID, 4)
 			accountIDs = ids[0:2]
 			extraAccountIDs = ids[2:4]


### PR DESCRIPTION
fixes: ENG-1575

```
$ fctl payments connectors install moneycorp moneycorp.json
You are about to install connector 'moneycorp'.
Do you want to continue [Y/n]y
 SUCCESS  Connector installed!
 SUCCESS  moneycorp: connector 'eyJQcm92aWRlciI6Im1vbmV5Y29ycCIsIlJlZmVyZW5jZSI6IjYxMDc2ZTc0LWZhNmMtNGE5Yy04OGFkLTdhYmRjODEyZjdkZiJ9' installed!
```