### PR TITLE
feat: (temporal) add initial delay when being rate-limited by PSP

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ const (
 	StackFlag                                    = "stack"
 	stackPublicURLFlag                           = "stack-public-url"
 	temporalMaxConcurrentWorkflowTaskPollersFlag = "temporal-max-concurrent-workflow-task-pollers"
+	temporalRateLimitingRetryDelay               = "temporal-rate-limiting-retry-delay"
 )
 
 func NewRootCommand() *cobra.Command {

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/formancehq/go-libs/v2/service"
 	"github.com/formancehq/go-libs/v2/temporal"
@@ -25,6 +26,7 @@ func newWorker() *cobra.Command {
 	// their recommendation.
 	cmd.Flags().Int(temporalMaxConcurrentWorkflowTaskPollersFlag, 20, "Max concurrent workflow task pollers")
 	cmd.Flags().String(stackPublicURLFlag, "", "Stack public url")
+	cmd.Flags().Duration(temporalRateLimitingRetryDelay, 5*time.Second, "Additional delay before a rate limited request is retried by Temporal workers")
 	return cmd
 }
 
@@ -54,6 +56,7 @@ func workerOptions(cmd *cobra.Command) (fx.Option, error) {
 	stack, _ := cmd.Flags().GetString(StackFlag)
 	stackPublicURL, _ := cmd.Flags().GetString(stackPublicURLFlag)
 	temporalNamespace, _ := cmd.Flags().GetString(temporal.TemporalNamespaceFlag)
+	temporalRateLimitingRetryDelay, _ := cmd.Flags().GetDuration(temporalRateLimitingRetryDelay)
 	temporalMaxConcurrentWorkflowTaskPollers, _ := cmd.Flags().GetInt(temporalMaxConcurrentWorkflowTaskPollersFlag)
 	return fx.Options(
 		worker.NewHealthCheckModule(listen, service.IsDebug(cmd)),
@@ -61,6 +64,7 @@ func workerOptions(cmd *cobra.Command) (fx.Option, error) {
 			stack,
 			stackPublicURL,
 			temporalNamespace,
+			temporalRateLimitingRetryDelay,
 			temporalMaxConcurrentWorkflowTaskPollers,
 			service.IsDebug(cmd),
 		),

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgx/v5 v5.7.2
@@ -126,6 +125,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/internal/api/backend/backend.go
+++ b/internal/api/backend/backend.go
@@ -33,6 +33,7 @@ type Backend interface {
 	// Connectors
 	ConnectorsConfigs() plugins.Configs
 	ConnectorsConfig(ctx context.Context, connectorID models.ConnectorID) (json.RawMessage, error)
+	ConnectorsConfigUpdate(ctx context.Context, connector models.Connector) error
 	ConnectorsList(ctx context.Context, query storage.ListConnectorsQuery) (*bunpaginate.Cursor[models.Connector], error)
 	ConnectorsInstall(ctx context.Context, provider string, config json.RawMessage) (models.ConnectorID, error)
 	ConnectorsUninstall(ctx context.Context, connectorID models.ConnectorID) (models.Task, error)

--- a/internal/api/backend/backend_generated.go
+++ b/internal/api/backend/backend_generated.go
@@ -27,6 +27,7 @@ import (
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
+	isgomock struct{}
 }
 
 // MockBackendMockRecorder is the mock recorder for MockBackend.
@@ -191,6 +192,20 @@ func (m *MockBackend) ConnectorsConfig(ctx context.Context, connectorID models.C
 func (mr *MockBackendMockRecorder) ConnectorsConfig(ctx, connectorID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectorsConfig", reflect.TypeOf((*MockBackend)(nil).ConnectorsConfig), ctx, connectorID)
+}
+
+// ConnectorsConfigUpdate mocks base method.
+func (m *MockBackend) ConnectorsConfigUpdate(ctx context.Context, connector models.Connector) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectorsConfigUpdate", ctx, connector)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConnectorsConfigUpdate indicates an expected call of ConnectorsConfigUpdate.
+func (mr *MockBackendMockRecorder) ConnectorsConfigUpdate(ctx, connector any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectorsConfigUpdate", reflect.TypeOf((*MockBackend)(nil).ConnectorsConfigUpdate), ctx, connector)
 }
 
 // ConnectorsConfigs mocks base method.

--- a/internal/api/services/connectors_config_update.go
+++ b/internal/api/services/connectors_config_update.go
@@ -1,0 +1,15 @@
+package services
+
+import (
+	"context"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+func (s *Service) ConnectorsConfigUpdate(ctx context.Context, connector models.Connector) error {
+	err := s.storage.ConnectorsConfigUpdate(ctx, connector)
+	if err != nil {
+		return newStorageError(err, "update connector")
+	}
+	return nil
+}

--- a/internal/api/v3/handler_connectors_config_update.go
+++ b/internal/api/v3/handler_connectors_config_update.go
@@ -1,0 +1,64 @@
+package v3
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/formancehq/go-libs/v2/api"
+	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/internal/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func connectorsConfigUpdate(backend backend.Backend) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := otel.Tracer().Start(r.Context(), "v3_connectorsConfigUpdate")
+		defer span.End()
+
+		span.SetAttributes(attribute.String("connectorID", connectorID(r)))
+		connectorID, err := models.ConnectorIDFromString(connectorID(r))
+		if err != nil {
+			otel.RecordError(span, err)
+			api.BadRequest(w, ErrInvalidID, err)
+			return
+		}
+
+		rawConfig, err := io.ReadAll(r.Body)
+		if err != nil {
+			otel.RecordError(span, err)
+			api.BadRequest(w, ErrMissingOrInvalidBody, err)
+			return
+		}
+
+		span.SetAttributes(attribute.String("config", string(rawConfig)))
+
+		config := models.DefaultConfig()
+		if err := json.Unmarshal(rawConfig, &config); err != nil {
+			otel.RecordError(span, err)
+			api.BadRequest(w, ErrMissingOrInvalidBody, err)
+			return
+		}
+
+		if err := config.Validate(); err != nil {
+			otel.RecordError(span, err)
+			api.BadRequest(w, ErrValidation, err)
+			return
+		}
+
+		connector := models.Connector{
+			ID:       connectorID,
+			Name:     config.Name,
+			Provider: connectorID.Provider,
+			Config:   rawConfig,
+		}
+		err = backend.ConnectorsConfigUpdate(ctx, connector)
+		if err != nil {
+			otel.RecordError(span, err)
+			handleServiceErrors(w, r, err)
+			return
+		}
+		api.NoContent(w)
+	}
+}

--- a/internal/api/v3/handler_connectors_config_update_test.go
+++ b/internal/api/v3/handler_connectors_config_update_test.go
@@ -1,0 +1,79 @@
+package v3
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("API v3 Connector Config Update", func() {
+	var (
+		handlerFn http.HandlerFunc
+	)
+
+	Context("update a connector config", func() {
+		var (
+			w *httptest.ResponseRecorder
+			m *backend.MockBackend
+
+			connectorID models.ConnectorID
+			connector   models.Connector
+			config      models.Config
+		)
+		BeforeEach(func() {
+			w = httptest.NewRecorder()
+			ctrl := gomock.NewController(GinkgoT())
+			m = backend.NewMockBackend(ctrl)
+			handlerFn = connectorsConfigUpdate(m)
+			connectorID = models.ConnectorID{
+				Reference: uuid.New(),
+				Provider:  "dummypay",
+			}
+			connectorName := "some-name"
+			connector = models.Connector{
+				ID:       connectorID,
+				Name:     connectorName,
+				Provider: connectorID.Provider,
+			}
+			config = models.DefaultConfig()
+			config.Name = connectorName
+			conf, err := config.MarshalJSON()
+			require.Nil(GinkgoT(), err)
+			connector.Config = conf
+		})
+
+		It("should return a validation error when name missing", func(ctx SpecContext) {
+			config.Name = ""
+			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPatch, "connectorID", connectorID.String(), &config))
+
+			assertExpectedResponse(w.Result(), http.StatusBadRequest, "VALIDATION")
+		})
+
+		It("should return a validation error when connector ID is invalid", func(ctx SpecContext) {
+			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPatch, "connectorID", "invalidID", &config))
+
+			assertExpectedResponse(w.Result(), http.StatusBadRequest, "INVALID_ID")
+		})
+
+		It("should return an internal server error when backend returns error", func(ctx SpecContext) {
+			m.EXPECT().ConnectorsConfigUpdate(gomock.Any(), gomock.Any()).Return(
+				fmt.Errorf("connector update err"),
+			)
+			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPatch, "connectorID", connectorID.String(), &config))
+			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
+		})
+
+		It("should return status no content on success", func(ctx SpecContext) {
+			m.EXPECT().ConnectorsConfigUpdate(gomock.Any(), connector).Return(nil)
+			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPatch, "connectorID", connectorID.String(), &config))
+			assertExpectedResponse(w.Result(), http.StatusNoContent, "")
+		})
+	})
+})

--- a/internal/api/v3/handler_test.go
+++ b/internal/api/v3/handler_test.go
@@ -27,7 +27,7 @@ func assertExpectedResponse(res *http.Response, expectedStatusCode int, expected
 
 	data, err := ioutil.ReadAll(res.Body)
 	Expect(err).To(BeNil())
-	Expect(data).To(ContainSubstring(expectedBodyString))
+	Expect(string(data)).To(ContainSubstring(expectedBodyString))
 }
 
 func prepareJSONRequest(method string, a any) *http.Request {

--- a/internal/api/v3/router.go
+++ b/internal/api/v3/router.go
@@ -88,13 +88,13 @@ func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticat
 				r.Route("/{connectorID}", func(r chi.Router) {
 					r.Delete("/", connectorsUninstall(backend))
 					r.Get("/config", connectorsConfig(backend))
+					r.Patch("/config", connectorsConfigUpdate(backend))
 					r.Post("/reset", connectorsReset(backend))
 
 					r.Get("/schedules", schedulesList(backend))
 					r.Route("/schedules/{scheduleID}", func(r chi.Router) {
 						r.Get("/instances", workflowsInstancesList(backend))
 					})
-					// TODO(polo): add update config handler
 				})
 			})
 

--- a/internal/connectors/engine/activities/activity.go
+++ b/internal/connectors/engine/activities/activity.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"errors"
+	"time"
 
 	temporalworker "github.com/formancehq/go-libs/v2/temporal"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
@@ -16,6 +17,8 @@ type Activities struct {
 	storage        storage.Storage
 	events         *events.Events
 	temporalClient client.Client
+
+	rateLimitingRetryDelay time.Duration
 
 	plugins plugins.Plugins
 }
@@ -320,12 +323,19 @@ func (a Activities) DefinitionSet() temporalworker.DefinitionSet {
 		})
 }
 
-func New(temporalClient client.Client, storage storage.Storage, events *events.Events, plugins plugins.Plugins) Activities {
+func New(
+	temporalClient client.Client,
+	storage storage.Storage,
+	events *events.Events,
+	plugins plugins.Plugins,
+	rateLimitingRetryDelay time.Duration,
+) Activities {
 	return Activities{
-		temporalClient: temporalClient,
-		storage:        storage,
-		plugins:        plugins,
-		events:         events,
+		temporalClient:         temporalClient,
+		storage:                storage,
+		plugins:                plugins,
+		events:                 events,
+		rateLimitingRetryDelay: rateLimitingRetryDelay,
 	}
 }
 

--- a/internal/connectors/engine/activities/activity.go
+++ b/internal/connectors/engine/activities/activity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	temporalworker "github.com/formancehq/go-libs/v2/temporal"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	"github.com/formancehq/payments/internal/events"
@@ -14,6 +15,7 @@ import (
 )
 
 type Activities struct {
+	logger         logging.Logger
 	storage        storage.Storage
 	events         *events.Events
 	temporalClient client.Client
@@ -324,6 +326,7 @@ func (a Activities) DefinitionSet() temporalworker.DefinitionSet {
 }
 
 func New(
+	logger logging.Logger,
 	temporalClient client.Client,
 	storage storage.Storage,
 	events *events.Events,
@@ -331,6 +334,7 @@ func New(
 	rateLimitingRetryDelay time.Duration,
 ) Activities {
 	return Activities{
+		logger:                 logger,
 		temporalClient:         temporalClient,
 		storage:                storage,
 		plugins:                plugins,

--- a/internal/connectors/engine/activities/errors.go
+++ b/internal/connectors/engine/activities/errors.go
@@ -3,7 +3,6 @@ package activities
 import (
 	"context"
 	"errors"
-	"regexp"
 
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/storage"
@@ -18,8 +17,6 @@ const (
 	ErrTypeRateLimited     = "RATE_LIMITED"
 	ErrTypeUnimplemented   = "UNIMPLEMENTED"
 )
-
-var scheduleSuffix = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
 
 func (a Activities) temporalPluginError(ctx context.Context, err error) error {
 	return a.temporalPluginErrorCheck(ctx, err, false)

--- a/internal/connectors/engine/activities/errors.go
+++ b/internal/connectors/engine/activities/errors.go
@@ -2,7 +2,6 @@ package activities
 
 import (
 	"errors"
-	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/storage"
@@ -17,15 +16,15 @@ const (
 	ErrTypeUnimplemented   = "UNIMPLEMENTED"
 )
 
-func temporalPluginError(err error) error {
-	return temporalPluginErrorCheck(err, false)
+func (a Activities) temporalPluginError(err error) error {
+	return a.temporalPluginErrorCheck(err, false)
 }
 
-func temporalPluginPollingError(err error) error {
-	return temporalPluginErrorCheck(err, true)
+func (a Activities) temporalPluginPollingError(err error) error {
+	return a.temporalPluginErrorCheck(err, true)
 }
 
-func temporalPluginErrorCheck(err error, isPolling bool) error {
+func (a Activities) temporalPluginErrorCheck(err error, isPolling bool) error {
 	switch {
 	// Do not retry the following errors
 	case errors.Is(err, plugins.ErrNotImplemented):
@@ -45,7 +44,7 @@ func temporalPluginErrorCheck(err error, isPolling bool) error {
 		return temporal.NewApplicationErrorWithOptions(err.Error(), ErrTypeRateLimited, temporal.ApplicationErrorOptions{
 			// temporal already implements a backoff strategy, but let's add an extra delay before the next retry
 			// https://docs.temporal.io/encyclopedia/retry-policies#per-error-next-retry-delay
-			NextRetryDelay: 5 * time.Second,
+			NextRetryDelay: a.rateLimitingRetryDelay,
 		})
 
 	// Retry the following errors

--- a/internal/connectors/engine/activities/plugin_create_bank_account.go
+++ b/internal/connectors/engine/activities/plugin_create_bank_account.go
@@ -15,12 +15,12 @@ type CreateBankAccountRequest struct {
 func (a Activities) PluginCreateBankAccount(ctx context.Context, request CreateBankAccountRequest) (*models.CreateBankAccountResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.CreateBankAccount(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_bank_account.go
+++ b/internal/connectors/engine/activities/plugin_create_bank_account.go
@@ -15,12 +15,12 @@ type CreateBankAccountRequest struct {
 func (a Activities) PluginCreateBankAccount(ctx context.Context, request CreateBankAccountRequest) (*models.CreateBankAccountResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.CreateBankAccount(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_bank_account_test.go
+++ b/internal/connectors/engine/activities/plugin_create_bank_account_test.go
@@ -3,7 +3,9 @@ package activities_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -41,6 +43,8 @@ var _ = Describe("Plugin Create Bank Account", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.CreateBankAccountRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -48,7 +52,7 @@ var _ = Describe("Plugin Create Bank Account", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.CreateBankAccountRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_create_payout.go
+++ b/internal/connectors/engine/activities/plugin_create_payout.go
@@ -15,12 +15,12 @@ type CreatePayoutRequest struct {
 func (a Activities) PluginCreatePayout(ctx context.Context, request CreatePayoutRequest) (*models.CreatePayoutResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.CreatePayout(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_payout.go
+++ b/internal/connectors/engine/activities/plugin_create_payout.go
@@ -15,12 +15,12 @@ type CreatePayoutRequest struct {
 func (a Activities) PluginCreatePayout(ctx context.Context, request CreatePayoutRequest) (*models.CreatePayoutResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.CreatePayout(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_payout_test.go
+++ b/internal/connectors/engine/activities/plugin_create_payout_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -35,6 +37,8 @@ var _ = Describe("Plugin Create Payout", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.CreatePayoutRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -42,7 +46,7 @@ var _ = Describe("Plugin Create Payout", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.CreatePayoutRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_create_transfer.go
+++ b/internal/connectors/engine/activities/plugin_create_transfer.go
@@ -15,12 +15,12 @@ type CreateTransferRequest struct {
 func (a Activities) PluginCreateTransfer(ctx context.Context, request CreateTransferRequest) (*models.CreateTransferResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.CreateTransfer(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_transfer.go
+++ b/internal/connectors/engine/activities/plugin_create_transfer.go
@@ -15,12 +15,12 @@ type CreateTransferRequest struct {
 func (a Activities) PluginCreateTransfer(ctx context.Context, request CreateTransferRequest) (*models.CreateTransferResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.CreateTransfer(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_transfer_test.go
+++ b/internal/connectors/engine/activities/plugin_create_transfer_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -35,6 +37,8 @@ var _ = Describe("Plugin Create Transfer", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.CreateTransferRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -42,7 +46,7 @@ var _ = Describe("Plugin Create Transfer", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.CreateTransferRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_create_webhooks.go
+++ b/internal/connectors/engine/activities/plugin_create_webhooks.go
@@ -15,12 +15,12 @@ type CreateWebhooksRequest struct {
 func (a Activities) PluginCreateWebhooks(ctx context.Context, request CreateWebhooksRequest) (*models.CreateWebhooksResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.CreateWebhooks(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_webhooks.go
+++ b/internal/connectors/engine/activities/plugin_create_webhooks.go
@@ -15,12 +15,12 @@ type CreateWebhooksRequest struct {
 func (a Activities) PluginCreateWebhooks(ctx context.Context, request CreateWebhooksRequest) (*models.CreateWebhooksResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.CreateWebhooks(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_create_webhooks_test.go
+++ b/internal/connectors/engine/activities/plugin_create_webhooks_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,6 +35,8 @@ var _ = Describe("Plugin Create Webhooks", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.CreateWebhooksRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Create Webhooks", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.CreateWebhooksRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
@@ -16,12 +16,12 @@ type FetchNextAccountsRequest struct {
 func (a Activities) PluginFetchNextAccounts(ctx context.Context, request FetchNextAccountsRequest) (*models.FetchNextAccountsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.FetchNextAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
@@ -16,12 +16,12 @@ type FetchNextAccountsRequest struct {
 func (a Activities) PluginFetchNextAccounts(ctx context.Context, request FetchNextAccountsRequest) (*models.FetchNextAccountsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.FetchNextAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_accounts.go
@@ -21,7 +21,7 @@ func (a Activities) PluginFetchNextAccounts(ctx context.Context, request FetchNe
 
 	resp, err := plugin.FetchNextAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, temporalPluginPollingError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_accounts_test.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_accounts_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,6 +35,8 @@ var _ = Describe("Plugin Fetch Next Accounts", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.FetchNextAccountsRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Fetch Next Accounts", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.FetchNextAccountsRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_fetch_next_balances.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_balances.go
@@ -16,12 +16,12 @@ type FetchNextBalancesRequest struct {
 func (a Activities) PluginFetchNextBalances(ctx context.Context, request FetchNextBalancesRequest) (*models.FetchNextBalancesResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.FetchNextBalances(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_balances.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_balances.go
@@ -21,7 +21,7 @@ func (a Activities) PluginFetchNextBalances(ctx context.Context, request FetchNe
 
 	resp, err := plugin.FetchNextBalances(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, temporalPluginPollingError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_balances.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_balances.go
@@ -16,12 +16,12 @@ type FetchNextBalancesRequest struct {
 func (a Activities) PluginFetchNextBalances(ctx context.Context, request FetchNextBalancesRequest) (*models.FetchNextBalancesResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.FetchNextBalances(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_fetch_next_balances_test.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_balances_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,6 +35,8 @@ var _ = Describe("Plugin Fetch Next Balances", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.FetchNextBalancesRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Fetch Next Balances", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.FetchNextBalancesRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
@@ -21,7 +21,7 @@ func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request
 
 	resp, err := plugin.FetchNextExternalAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
@@ -11,6 +11,7 @@ import (
 type FetchNextExternalAccountsRequest struct {
 	ConnectorID models.ConnectorID
 	Req         models.FetchNextExternalAccountsRequest
+	Periodic    bool
 }
 
 func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request FetchNextExternalAccountsRequest) (*models.FetchNextExternalAccountsResponse, error) {
@@ -21,7 +22,7 @@ func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request
 
 	resp, err := plugin.FetchNextExternalAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(ctx, err)
+		return nil, a.temporalPluginPollingError(ctx, err, request.Periodic)
 	}
 
 	return &resp, nil
@@ -29,7 +30,7 @@ func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request
 
 var PluginFetchNextExternalAccountsActivity = Activities{}.PluginFetchNextExternalAccounts
 
-func PluginFetchNextExternalAccounts(ctx workflow.Context, connectorID models.ConnectorID, fromPayload, state json.RawMessage, pageSize int) (*models.FetchNextExternalAccountsResponse, error) {
+func PluginFetchNextExternalAccounts(ctx workflow.Context, connectorID models.ConnectorID, fromPayload, state json.RawMessage, pageSize int, periodic bool) (*models.FetchNextExternalAccountsResponse, error) {
 	ret := models.FetchNextExternalAccountsResponse{}
 	if err := executeActivity(ctx, PluginFetchNextExternalAccountsActivity, &ret, FetchNextExternalAccountsRequest{
 		ConnectorID: connectorID,
@@ -38,6 +39,7 @@ func PluginFetchNextExternalAccounts(ctx workflow.Context, connectorID models.Co
 			State:       state,
 			PageSize:    pageSize,
 		},
+		Periodic: periodic,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
@@ -16,12 +16,12 @@ type FetchNextExternalAccountsRequest struct {
 func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request FetchNextExternalAccountsRequest) (*models.FetchNextExternalAccountsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.FetchNextExternalAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_external_accounts.go
@@ -16,12 +16,12 @@ type FetchNextExternalAccountsRequest struct {
 func (a Activities) PluginFetchNextExternalAccounts(ctx context.Context, request FetchNextExternalAccountsRequest) (*models.FetchNextExternalAccountsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.FetchNextExternalAccounts(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_external_accounts_test.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_external_accounts_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -22,6 +24,8 @@ var _ = Describe("Plugin Fetch Next ExternalAccounts", func() {
 		s              *storage.MockStorage
 		evts           *events.Events
 		sampleResponse models.FetchNextExternalAccountsResponse
+		logger         = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		delay          = 50 * time.Millisecond
 	)
 
 	BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Fetch Next ExternalAccounts", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.FetchNextExternalAccountsRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_fetch_next_others.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_others.go
@@ -16,12 +16,12 @@ type FetchNextOthersRequest struct {
 func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNextOthersRequest) (*models.FetchNextOthersResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.FetchNextOthers(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_others.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_others.go
@@ -21,7 +21,7 @@ func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNext
 
 	resp, err := plugin.FetchNextOthers(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_others.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_others.go
@@ -11,6 +11,7 @@ import (
 type FetchNextOthersRequest struct {
 	ConnectorID models.ConnectorID
 	Req         models.FetchNextOthersRequest
+	Periodic    bool
 }
 
 func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNextOthersRequest) (*models.FetchNextOthersResponse, error) {
@@ -21,7 +22,7 @@ func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNext
 
 	resp, err := plugin.FetchNextOthers(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(ctx, err)
+		return nil, a.temporalPluginPollingError(ctx, err, request.Periodic)
 	}
 
 	return &resp, nil
@@ -29,7 +30,7 @@ func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNext
 
 var PluginFetchNextOthersActivity = Activities{}.PluginFetchNextOthers
 
-func PluginFetchNextOthers(ctx workflow.Context, connectorID models.ConnectorID, name string, fromPayload, state json.RawMessage, pageSize int) (*models.FetchNextOthersResponse, error) {
+func PluginFetchNextOthers(ctx workflow.Context, connectorID models.ConnectorID, name string, fromPayload, state json.RawMessage, pageSize int, periodic bool) (*models.FetchNextOthersResponse, error) {
 	ret := models.FetchNextOthersResponse{}
 	if err := executeActivity(ctx, PluginFetchNextOthersActivity, &ret, FetchNextOthersRequest{
 		ConnectorID: connectorID,
@@ -39,6 +40,7 @@ func PluginFetchNextOthers(ctx workflow.Context, connectorID models.ConnectorID,
 			State:       state,
 			PageSize:    pageSize,
 		},
+		Periodic: periodic,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/connectors/engine/activities/plugin_fetch_next_others.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_others.go
@@ -16,12 +16,12 @@ type FetchNextOthersRequest struct {
 func (a Activities) PluginFetchNextOthers(ctx context.Context, request FetchNextOthersRequest) (*models.FetchNextOthersResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.FetchNextOthers(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_others_test.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_others_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -22,6 +24,8 @@ var _ = Describe("Plugin Fetch Next Others", func() {
 		s              *storage.MockStorage
 		evts           *events.Events
 		sampleResponse models.FetchNextOthersResponse
+		logger         = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		delay          = 50 * time.Millisecond
 	)
 
 	BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Fetch Next Others", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.FetchNextOthersRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_fetch_next_payments.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_payments.go
@@ -21,7 +21,7 @@ func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNe
 
 	resp, err := plugin.FetchNextPayments(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_payments.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_payments.go
@@ -11,6 +11,7 @@ import (
 type FetchNextPaymentsRequest struct {
 	ConnectorID models.ConnectorID
 	Req         models.FetchNextPaymentsRequest
+	Periodic    bool
 }
 
 func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNextPaymentsRequest) (*models.FetchNextPaymentsResponse, error) {
@@ -21,7 +22,7 @@ func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNe
 
 	resp, err := plugin.FetchNextPayments(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(ctx, err)
+		return nil, a.temporalPluginPollingError(ctx, err, request.Periodic)
 	}
 
 	return &resp, nil
@@ -29,7 +30,7 @@ func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNe
 
 var PluginFetchNextPaymentsActivity = Activities{}.PluginFetchNextPayments
 
-func PluginFetchNextPayments(ctx workflow.Context, connectorID models.ConnectorID, fromPayload, state json.RawMessage, pageSize int) (*models.FetchNextPaymentsResponse, error) {
+func PluginFetchNextPayments(ctx workflow.Context, connectorID models.ConnectorID, fromPayload, state json.RawMessage, pageSize int, periodic bool) (*models.FetchNextPaymentsResponse, error) {
 	ret := models.FetchNextPaymentsResponse{}
 	if err := executeActivity(ctx, PluginFetchNextPaymentsActivity, &ret, FetchNextPaymentsRequest{
 		ConnectorID: connectorID,
@@ -38,6 +39,7 @@ func PluginFetchNextPayments(ctx workflow.Context, connectorID models.ConnectorI
 			State:       state,
 			PageSize:    pageSize,
 		},
+		Periodic: periodic,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/connectors/engine/activities/plugin_fetch_next_payments.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_payments.go
@@ -16,12 +16,12 @@ type FetchNextPaymentsRequest struct {
 func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNextPaymentsRequest) (*models.FetchNextPaymentsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.FetchNextPayments(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_payments.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_payments.go
@@ -16,12 +16,12 @@ type FetchNextPaymentsRequest struct {
 func (a Activities) PluginFetchNextPayments(ctx context.Context, request FetchNextPaymentsRequest) (*models.FetchNextPaymentsResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.FetchNextPayments(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginPollingError(err)
+		return nil, a.temporalPluginPollingError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_fetch_next_payments_test.go
+++ b/internal/connectors/engine/activities/plugin_fetch_next_payments_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -22,6 +24,8 @@ var _ = Describe("Plugin Fetch Next Payments", func() {
 		s              *storage.MockStorage
 		evts           *events.Events
 		sampleResponse models.FetchNextPaymentsResponse
+		logger         = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		delay          = 50 * time.Millisecond
 	)
 
 	BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Fetch Next Payments", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.FetchNextPaymentsRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_install_connector.go
+++ b/internal/connectors/engine/activities/plugin_install_connector.go
@@ -15,12 +15,12 @@ type InstallConnectorRequest struct {
 func (a Activities) PluginInstallConnector(ctx context.Context, request InstallConnectorRequest) (*models.InstallResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.Install(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_install_connector.go
+++ b/internal/connectors/engine/activities/plugin_install_connector.go
@@ -15,12 +15,12 @@ type InstallConnectorRequest struct {
 func (a Activities) PluginInstallConnector(ctx context.Context, request InstallConnectorRequest) (*models.InstallResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.Install(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_install_connector_test.go
+++ b/internal/connectors/engine/activities/plugin_install_connector_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -22,6 +24,8 @@ var _ = Describe("Plugin Install Connector", func() {
 		s              *storage.MockStorage
 		evts           *events.Events
 		sampleResponse models.InstallResponse
+		logger         = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		delay          = 50 * time.Millisecond
 	)
 
 	BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Install Connector", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.InstallConnectorRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_poll_payout_status.go
+++ b/internal/connectors/engine/activities/plugin_poll_payout_status.go
@@ -15,12 +15,12 @@ type PollPayoutStatusRequest struct {
 func (a Activities) PluginPollPayoutStatus(ctx context.Context, request PollPayoutStatusRequest) (*models.PollPayoutStatusResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.PollPayoutStatus(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_poll_payout_status.go
+++ b/internal/connectors/engine/activities/plugin_poll_payout_status.go
@@ -15,12 +15,12 @@ type PollPayoutStatusRequest struct {
 func (a Activities) PluginPollPayoutStatus(ctx context.Context, request PollPayoutStatusRequest) (*models.PollPayoutStatusResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.PollPayoutStatus(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_poll_payout_status_test.go
+++ b/internal/connectors/engine/activities/plugin_poll_payout_status_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -22,6 +24,8 @@ var _ = Describe("Plugin Poll Payout Status", func() {
 		s              *storage.MockStorage
 		evts           *events.Events
 		sampleResponse models.PollPayoutStatusResponse
+		logger         = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		delay          = 50 * time.Millisecond
 	)
 
 	BeforeEach(func() {
@@ -42,7 +46,7 @@ var _ = Describe("Plugin Poll Payout Status", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.PollPayoutStatusRequest{
 				ConnectorID: models.ConnectorID{Provider: "some_provider"},
 				Req: models.PollPayoutStatusRequest{

--- a/internal/connectors/engine/activities/plugin_poll_transfer_status.go
+++ b/internal/connectors/engine/activities/plugin_poll_transfer_status.go
@@ -15,12 +15,12 @@ type PollTransferStatusRequest struct {
 func (a Activities) PluginPollTransferStatus(ctx context.Context, request PollTransferStatusRequest) (*models.PollTransferStatusResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.PollTransferStatus(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_poll_transfer_status.go
+++ b/internal/connectors/engine/activities/plugin_poll_transfer_status.go
@@ -15,12 +15,12 @@ type PollTransferStatusRequest struct {
 func (a Activities) PluginPollTransferStatus(ctx context.Context, request PollTransferStatusRequest) (*models.PollTransferStatusResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.PollTransferStatus(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_poll_transfer_status_test.go
+++ b/internal/connectors/engine/activities/plugin_poll_transfer_status_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -35,6 +37,8 @@ var _ = Describe("Plugin Poll Transfer Status", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.PollTransferStatusRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -42,7 +46,7 @@ var _ = Describe("Plugin Poll Transfer Status", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.PollTransferStatusRequest{
 				ConnectorID: models.ConnectorID{Provider: "some_provider"},
 				Req: models.PollTransferStatusRequest{

--- a/internal/connectors/engine/activities/plugin_reverse_payout.go
+++ b/internal/connectors/engine/activities/plugin_reverse_payout.go
@@ -15,12 +15,12 @@ type ReversePayoutRequest struct {
 func (a Activities) PluginReversePayout(ctx context.Context, request ReversePayoutRequest) (*models.ReversePayoutResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.ReversePayout(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_reverse_payout.go
+++ b/internal/connectors/engine/activities/plugin_reverse_payout.go
@@ -15,12 +15,12 @@ type ReversePayoutRequest struct {
 func (a Activities) PluginReversePayout(ctx context.Context, request ReversePayoutRequest) (*models.ReversePayoutResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.ReversePayout(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_reverse_payout_test.go
+++ b/internal/connectors/engine/activities/plugin_reverse_payout_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,13 +35,15 @@ var _ = Describe("Plugin Reverse Payout", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.ReversePayoutRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 		BeforeEach(func() {
 			ctrl := gomock.NewController(GinkgoT())
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.ReversePayoutRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_reverse_transfer.go
+++ b/internal/connectors/engine/activities/plugin_reverse_transfer.go
@@ -15,12 +15,12 @@ type ReverseTransferRequest struct {
 func (a Activities) PluginReverseTransfer(ctx context.Context, request ReverseTransferRequest) (*models.ReverseTransferResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.ReverseTransfer(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_reverse_transfer.go
+++ b/internal/connectors/engine/activities/plugin_reverse_transfer.go
@@ -15,12 +15,12 @@ type ReverseTransferRequest struct {
 func (a Activities) PluginReverseTransfer(ctx context.Context, request ReverseTransferRequest) (*models.ReverseTransferResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.ReverseTransfer(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_reverse_transfer_test.go
+++ b/internal/connectors/engine/activities/plugin_reverse_transfer_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,13 +35,15 @@ var _ = Describe("Plugin Reverse Transfer", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.ReverseTransferRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 		BeforeEach(func() {
 			ctrl := gomock.NewController(GinkgoT())
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.ReverseTransferRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/activities/plugin_translate_webhook.go
+++ b/internal/connectors/engine/activities/plugin_translate_webhook.go
@@ -15,12 +15,12 @@ type TranslateWebhookRequest struct {
 func (a Activities) PluginTranslateWebhook(ctx context.Context, request TranslateWebhookRequest) (*models.TranslateWebhookResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	resp, err := plugin.TranslateWebhook(ctx, request.Req)
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_translate_webhook.go
+++ b/internal/connectors/engine/activities/plugin_translate_webhook.go
@@ -15,12 +15,12 @@ type TranslateWebhookRequest struct {
 func (a Activities) PluginTranslateWebhook(ctx context.Context, request TranslateWebhookRequest) (*models.TranslateWebhookResponse, error) {
 	plugin, err := a.plugins.Get(request.ConnectorID)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	resp, err := plugin.TranslateWebhook(ctx, request.Req)
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 	return &resp, nil
 }

--- a/internal/connectors/engine/activities/plugin_uninstall_connector.go
+++ b/internal/connectors/engine/activities/plugin_uninstall_connector.go
@@ -25,7 +25,7 @@ func (a Activities) PluginUninstallConnector(ctx context.Context, request Uninst
 
 	resp, err := plugin.Uninstall(ctx, models.UninstallRequest{})
 	if err != nil {
-		return nil, temporalPluginError(err)
+		return nil, a.temporalPluginError(err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_uninstall_connector.go
+++ b/internal/connectors/engine/activities/plugin_uninstall_connector.go
@@ -25,7 +25,7 @@ func (a Activities) PluginUninstallConnector(ctx context.Context, request Uninst
 
 	resp, err := plugin.Uninstall(ctx, models.UninstallRequest{})
 	if err != nil {
-		return nil, a.temporalPluginError(err)
+		return nil, a.temporalPluginError(ctx, err)
 	}
 
 	return &resp, nil

--- a/internal/connectors/engine/activities/plugin_uninstall_connector_test.go
+++ b/internal/connectors/engine/activities/plugin_uninstall_connector_test.go
@@ -2,7 +2,9 @@ package activities_test
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
@@ -33,6 +35,8 @@ var _ = Describe("Plugin Uninstall", func() {
 		var (
 			plugin *models.MockPlugin
 			req    activities.UninstallConnectorRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
 		)
 
 		BeforeEach(func() {
@@ -40,7 +44,7 @@ var _ = Describe("Plugin Uninstall", func() {
 			p = plugins.NewMockPlugins(ctrl)
 			s = storage.NewMockStorage(ctrl)
 			plugin = models.NewMockPlugin(ctrl)
-			act = activities.New(nil, s, evts, p)
+			act = activities.New(logger, nil, s, evts, p, delay)
 			req = activities.UninstallConnectorRequest{
 				ConnectorID: models.ConnectorID{
 					Provider: "some_provider",

--- a/internal/connectors/engine/plugins/plugin.go
+++ b/internal/connectors/engine/plugins/plugin.go
@@ -19,7 +19,7 @@ var (
 
 //go:generate mockgen -source plugin.go -destination plugin_generated.go -package plugins . Plugins
 type Plugins interface {
-	RegisterPlugin(models.ConnectorID, string, models.Config, json.RawMessage) error
+	RegisterPlugin(models.ConnectorID, string, models.Config, json.RawMessage, bool) error
 	UnregisterPlugin(models.ConnectorID) error
 	GetConfig(models.ConnectorID) (models.Config, error)
 	Get(models.ConnectorID) (models.Plugin, error)
@@ -56,13 +56,14 @@ func (p *plugins) RegisterPlugin(
 	connectorName string,
 	config models.Config,
 	rawConfig json.RawMessage,
+	updateExisting bool,
 ) error {
 	p.rwMutex.Lock()
 	defer p.rwMutex.Unlock()
 
 	// Check if plugin is already installed
 	_, ok := p.plugins[connectorID.String()]
-	if ok {
+	if ok && !updateExisting {
 		return nil
 	}
 

--- a/internal/connectors/engine/plugins/plugin_generated.go
+++ b/internal/connectors/engine/plugins/plugin_generated.go
@@ -21,6 +21,7 @@ import (
 type MockPlugins struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginsMockRecorder
+	isgomock struct{}
 }
 
 // MockPluginsMockRecorder is the mock recorder for MockPlugins.
@@ -53,21 +54,6 @@ func (m *MockPlugins) Get(arg0 models.ConnectorID) (models.Plugin, error) {
 func (mr *MockPluginsMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPlugins)(nil).Get), arg0)
-}
-
-// GetCapabilities mocks base method.
-func (m *MockPlugins) GetCapabilities(arg0 models.ConnectorID) ([]models.Capability, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCapabilities", arg0)
-	ret0, _ := ret[0].([]models.Capability)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCapabilities indicates an expected call of GetCapabilities.
-func (mr *MockPluginsMockRecorder) GetCapabilities(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapabilities", reflect.TypeOf((*MockPlugins)(nil).GetCapabilities), arg0)
 }
 
 // GetConfig mocks base method.

--- a/internal/connectors/engine/plugins/plugin_generated.go
+++ b/internal/connectors/engine/plugins/plugin_generated.go
@@ -72,17 +72,17 @@ func (mr *MockPluginsMockRecorder) GetConfig(arg0 any) *gomock.Call {
 }
 
 // RegisterPlugin mocks base method.
-func (m *MockPlugins) RegisterPlugin(arg0 models.ConnectorID, arg1 string, arg2 models.Config, arg3 json.RawMessage) error {
+func (m *MockPlugins) RegisterPlugin(arg0 models.ConnectorID, arg1 string, arg2 models.Config, arg3 json.RawMessage, arg4 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterPlugin", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RegisterPlugin", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RegisterPlugin indicates an expected call of RegisterPlugin.
-func (mr *MockPluginsMockRecorder) RegisterPlugin(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockPluginsMockRecorder) RegisterPlugin(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPlugin", reflect.TypeOf((*MockPlugins)(nil).RegisterPlugin), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPlugin", reflect.TypeOf((*MockPlugins)(nil).RegisterPlugin), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UnregisterPlugin mocks base method.

--- a/internal/connectors/engine/workers.go
+++ b/internal/connectors/engine/workers.go
@@ -122,7 +122,7 @@ func (w *WorkerPool) onStartPlugin(ctx context.Context, connector models.Connect
 		return err
 	}
 
-	err := w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config)
+	err := w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config, false)
 	if err != nil {
 		w.logger.Errorf("failed to register plugin: %w", err)
 		// We don't want to crash the pod if the plugin registration fails,
@@ -153,7 +153,7 @@ func (w *WorkerPool) onInsertPlugin(ctx context.Context, connectorID models.Conn
 		return err
 	}
 
-	if err := w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config); err != nil {
+	if err := w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config, false); err != nil {
 		return err
 	}
 
@@ -194,7 +194,7 @@ func (w *WorkerPool) onUpdatePlugin(ctx context.Context, connectorID models.Conn
 		return err
 	}
 
-	err = w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config)
+	err = w.plugins.RegisterPlugin(connector.ID, connector.Name, config, connector.Config, true)
 	if err != nil {
 		w.logger.Errorf("failed to register plugin after update to connector %q: %w", connector.ID.String(), err)
 		return err

--- a/internal/connectors/engine/workflow/fetch_accounts.go
+++ b/internal/connectors/engine/workflow/fetch_accounts.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FetchNextAccounts struct {
-	Config      models.Config      `json:"config"`
-	ConnectorID models.ConnectorID `json:"connectorID"`
-	FromPayload *FromPayload       `json:"fromPayload"`
+	Config       models.Config      `json:"config"`
+	ConnectorID  models.ConnectorID `json:"connectorID"`
+	FromPayload  *FromPayload       `json:"fromPayload"`
+	Periodically bool               `json:"periodically"`
 }
 
 func (w Workflow) runFetchNextAccounts(
@@ -56,6 +57,7 @@ func (w Workflow) fetchAccounts(
 			fetchNextAccount.FromPayload.GetPayload(),
 			state.State,
 			fetchNextAccount.Config.PageSize,
+			fetchNextAccount.Periodically,
 		)
 		if err != nil {
 			return errors.Wrap(err, "fetching next accounts")

--- a/internal/connectors/engine/workflow/fetch_balances.go
+++ b/internal/connectors/engine/workflow/fetch_balances.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FetchNextBalances struct {
-	Config      models.Config      `json:"config"`
-	ConnectorID models.ConnectorID `json:"connectorID"`
-	FromPayload *FromPayload       `json:"fromPayload"`
+	Config       models.Config      `json:"config"`
+	ConnectorID  models.ConnectorID `json:"connectorID"`
+	FromPayload  *FromPayload       `json:"fromPayload"`
+	Periodically bool               `json:"periodically"`
 }
 
 func (w Workflow) runFetchNextBalances(
@@ -56,6 +57,7 @@ func (w Workflow) fetchBalances(
 			fetchNextBalances.FromPayload.GetPayload(),
 			state.State,
 			fetchNextBalances.Config.PageSize,
+			fetchNextBalances.Periodically,
 		)
 		if err != nil {
 			return errors.Wrap(err, "fetching next accounts")

--- a/internal/connectors/engine/workflow/fetch_external_accounts.go
+++ b/internal/connectors/engine/workflow/fetch_external_accounts.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FetchNextExternalAccounts struct {
-	Config      models.Config      `json:"config"`
-	ConnectorID models.ConnectorID `json:"connectorID"`
-	FromPayload *FromPayload       `json:"fromPayload"`
+	Config       models.Config      `json:"config"`
+	ConnectorID  models.ConnectorID `json:"connectorID"`
+	FromPayload  *FromPayload       `json:"fromPayload"`
+	Periodically bool               `json:"periodically"`
 }
 
 func (w Workflow) runFetchNextExternalAccounts(
@@ -56,6 +57,7 @@ func (w Workflow) fetchExternalAccounts(
 			fetchNextExternalAccount.FromPayload.GetPayload(),
 			state.State,
 			fetchNextExternalAccount.Config.PageSize,
+			fetchNextExternalAccount.Periodically,
 		)
 		if err != nil {
 			return errors.Wrap(err, "fetching next accounts")

--- a/internal/connectors/engine/workflow/fetch_others.go
+++ b/internal/connectors/engine/workflow/fetch_others.go
@@ -11,10 +11,11 @@ import (
 )
 
 type FetchNextOthers struct {
-	Config      models.Config      `json:"config"`
-	ConnectorID models.ConnectorID `json:"connectorID"`
-	Name        string             `json:"name"`
-	FromPayload *FromPayload       `json:"fromPayload"`
+	Config       models.Config      `json:"config"`
+	ConnectorID  models.ConnectorID `json:"connectorID"`
+	Name         string             `json:"name"`
+	FromPayload  *FromPayload       `json:"fromPayload"`
+	Periodically bool               `json:"periodically"`
 }
 
 func (w Workflow) runFetchNextOthers(
@@ -57,6 +58,7 @@ func (w Workflow) fetchNextOthers(
 			fetchNextOthers.FromPayload.GetPayload(),
 			state.State,
 			fetchNextOthers.Config.PageSize,
+			fetchNextOthers.Periodically,
 		)
 		if err != nil {
 			return errors.Wrap(err, "fetching next others")

--- a/internal/connectors/engine/workflow/fetch_payments.go
+++ b/internal/connectors/engine/workflow/fetch_payments.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FetchNextPayments struct {
-	Config      models.Config      `json:"config"`
-	ConnectorID models.ConnectorID `json:"connectorID"`
-	FromPayload *FromPayload       `json:"fromPayload"`
+	Config       models.Config      `json:"config"`
+	ConnectorID  models.ConnectorID `json:"connectorID"`
+	FromPayload  *FromPayload       `json:"fromPayload"`
+	Periodically bool               `json:"periodically"`
 }
 
 func (w Workflow) runFetchNextPayments(
@@ -56,6 +57,7 @@ func (w Workflow) fetchNextPayments(
 			fetchNextPayments.FromPayload.GetPayload(),
 			state.State,
 			fetchNextPayments.Config.PageSize,
+			fetchNextPayments.Periodically,
 		)
 		if err != nil {
 			return errors.Wrap(err, "fetching next payments")

--- a/internal/connectors/engine/workflow/plugin_workflow.go
+++ b/internal/connectors/engine/workflow/plugin_workflow.go
@@ -25,9 +25,10 @@ func (w Workflow) run(
 		switch task.TaskType {
 		case models.TASK_FETCH_ACCOUNTS:
 			req := FetchNextAccounts{
-				Config:      config,
-				ConnectorID: connectorID,
-				FromPayload: fromPayload,
+				Config:       config,
+				ConnectorID:  connectorID,
+				FromPayload:  fromPayload,
+				Periodically: task.Periodically,
 			}
 
 			nextWorkflow = RunFetchNextAccounts
@@ -36,9 +37,10 @@ func (w Workflow) run(
 
 		case models.TASK_FETCH_EXTERNAL_ACCOUNTS:
 			req := FetchNextExternalAccounts{
-				Config:      config,
-				ConnectorID: connectorID,
-				FromPayload: fromPayload,
+				Config:       config,
+				ConnectorID:  connectorID,
+				FromPayload:  fromPayload,
+				Periodically: task.Periodically,
 			}
 
 			nextWorkflow = RunFetchNextExternalAccounts
@@ -47,10 +49,11 @@ func (w Workflow) run(
 
 		case models.TASK_FETCH_OTHERS:
 			req := FetchNextOthers{
-				Config:      config,
-				ConnectorID: connectorID,
-				Name:        task.Name,
-				FromPayload: fromPayload,
+				Config:       config,
+				ConnectorID:  connectorID,
+				Name:         task.Name,
+				FromPayload:  fromPayload,
+				Periodically: task.Periodically,
 			}
 
 			nextWorkflow = RunFetchNextOthers
@@ -59,9 +62,10 @@ func (w Workflow) run(
 
 		case models.TASK_FETCH_PAYMENTS:
 			req := FetchNextPayments{
-				Config:      config,
-				ConnectorID: connectorID,
-				FromPayload: fromPayload,
+				Config:       config,
+				ConnectorID:  connectorID,
+				FromPayload:  fromPayload,
+				Periodically: task.Periodically,
 			}
 
 			nextWorkflow = RunFetchNextPayments
@@ -70,9 +74,10 @@ func (w Workflow) run(
 
 		case models.TASK_FETCH_BALANCES:
 			req := FetchNextBalances{
-				Config:      config,
-				ConnectorID: connectorID,
-				FromPayload: fromPayload,
+				Config:       config,
+				ConnectorID:  connectorID,
+				FromPayload:  fromPayload,
+				Periodically: task.Periodically,
 			}
 
 			nextWorkflow = RunFetchNextBalances

--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/models"
-	"github.com/hashicorp/go-hclog"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
 )
@@ -92,7 +92,7 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			hclog.Default().Error("failed to close response body", "error", err)
+			logging.FromContext(ctx).Errorf("failed to close response body: %w", err)
 		}
 	}()
 

--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -15,11 +15,16 @@ import (
 )
 
 var (
-	ErrStatusCodeUnexpected  = errors.New("unexpected status code")
-	ErrStatusCodeClientError = fmt.Errorf("%w: http client error", ErrStatusCodeUnexpected)
-	ErrStatusCodeServerError = fmt.Errorf("%w: http server error", ErrStatusCodeUnexpected)
+	ErrStatusCodeUnexpected      = errors.New("unexpected status code")
+	ErrStatusCodeClientError     = fmt.Errorf("%w: http client error", ErrStatusCodeUnexpected)
+	ErrStatusCodeServerError     = fmt.Errorf("%w: http server error", ErrStatusCodeUnexpected)
+	ErrStatusCodeTooManyRequests = fmt.Errorf("%w: http too many requests error", ErrStatusCodeUnexpected)
 
 	defaultHttpErrorCheckerFn = func(statusCode int) error {
+		if statusCode == http.StatusTooManyRequests {
+			return ErrStatusCodeTooManyRequests
+		}
+
 		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
 			return ErrStatusCodeClientError
 		} else if statusCode >= http.StatusInternalServerError {

--- a/internal/connectors/plugins/errors.go
+++ b/internal/connectors/plugins/errors.go
@@ -8,5 +8,6 @@ var (
 	ErrNotImplemented       = errors.New("not implemented")
 	ErrNotYetInstalled      = errors.New("not yet installed")
 	ErrInvalidClientRequest = errors.New("invalid client request")
+	ErrUpstreamRatelimit    = errors.New("rate limited by upstream server")
 	ErrCurrencyNotSupported = errors.New("currency not supported")
 )

--- a/internal/connectors/plugins/public/adyen/client/client.go
+++ b/internal/connectors/plugins/public/adyen/client/client.go
@@ -70,6 +70,10 @@ func New(
 // wrap a public error for cases that we don't want to retry
 // so that activities can classify this error for temporal
 func (c *client) wrapSDKError(err error, statusCode int) error {
+	if statusCode == http.StatusTooManyRequests {
+		return fmt.Errorf("rate-limited by adyen %w: %w", httpwrapper.ErrStatusCodeTooManyRequests, err)
+	}
+
 	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
 		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeClientError, err)
 	}

--- a/internal/connectors/plugins/public/adyen/plugin.go
+++ b/internal/connectors/plugins/public/adyen/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/adyen/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -14,13 +15,14 @@ import (
 const ProviderName = "adyen"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client         client.Client
 	webhookConfigs map[string]webhookConfig
@@ -28,7 +30,7 @@ type Plugin struct {
 	connectorID string
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -45,6 +47,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	p := &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}
 

--- a/internal/connectors/plugins/public/adyen/plugin_test.go
+++ b/internal/connectors/plugins/public/adyen/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/adyen/client"
 	"github.com/formancehq/payments/internal/models"
@@ -19,8 +20,9 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Adyen Plugin", func() {
 	var (
-		plg *Plugin
-		m   *client.MockClient
+		plg    *Plugin
+		m      *client.MockClient
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -31,15 +33,15 @@ var _ = Describe("Adyen Plugin", func() {
 
 	Context("install", func() {
 		It("reports validation errors in the config - apiKey", func(ctx SpecContext) {
-			_, err := New("adyen", json.RawMessage(`{"companyID": "test"}`))
+			_, err := New("adyen", logger, json.RawMessage(`{"companyID": "test"}`))
 			Expect(err).To(MatchError("missing apiKey in config: invalid config"))
 		})
 		It("reports validation errors in the config - companyID", func(ctx SpecContext) {
-			_, err := New("adyen", json.RawMessage(`{"apiKey": "test"}`))
+			_, err := New("adyen", logger, json.RawMessage(`{"apiKey": "test"}`))
 			Expect(err).To(MatchError("missing companyID in config: invalid config"))
 		})
 		It("returns valid install response", func(ctx SpecContext) {
-			_, err := New("adyen", json.RawMessage(`{"apiKey":"test", "companyID": "test"}`))
+			_, err := New("adyen", logger, json.RawMessage(`{"apiKey":"test", "companyID": "test"}`))
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/atlar/client/client.go
+++ b/internal/connectors/plugins/public/atlar/client/client.go
@@ -78,6 +78,10 @@ func wrapSDKErr(err error) error {
 		return err
 	}
 
+	if atlarErr.Code == http.StatusTooManyRequests {
+		return fmt.Errorf("atlar error: %w: %w", err, httpwrapper.ErrStatusCodeTooManyRequests)
+	}
+
 	if atlarErr.Code >= http.StatusBadRequest && atlarErr.Code < http.StatusInternalServerError {
 		return fmt.Errorf("atlar error: %w: %w", err, httpwrapper.ErrStatusCodeClientError)
 	} else if atlarErr.Code >= http.StatusInternalServerError {

--- a/internal/connectors/plugins/public/atlar/client/client_generated.go
+++ b/internal/connectors/plugins/public/atlar/client/client_generated.go
@@ -28,6 +28,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.

--- a/internal/connectors/plugins/public/atlar/plugin.go
+++ b/internal/connectors/plugins/public/atlar/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/atlar/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -14,18 +15,19 @@ import (
 const ProviderName = "atlar"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -38,6 +40,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client.New(ProviderName, baseUrl, config.AccessKey, config.Secret),
 	}, nil
 }

--- a/internal/connectors/plugins/public/atlar/plugin_test.go
+++ b/internal/connectors/plugins/public/atlar/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Atlar Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,25 +29,25 @@ var _ = Describe("Atlar Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - baseURL", func(ctx SpecContext) {
 			config := json.RawMessage(`{"accessKey": "test", "secret": "test"}`)
-			_, err := New("atlar", config)
+			_, err := New("atlar", logger, config)
 			Expect(err).To(MatchError("missing baseURL in config: invalid config"))
 		})
 
 		It("should report errors in config - accessKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{"baseURL": "test", "secret": "test"}`)
-			_, err := New("atlar", config)
+			_, err := New("atlar", logger, config)
 			Expect(err).To(MatchError("missing access key in config: invalid config"))
 		})
 
 		It("should report errors in config - secret", func(ctx SpecContext) {
 			config := json.RawMessage(`{"baseURL": "test", "accessKey": "test"}`)
-			_, err := New("atlar", config)
+			_, err := New("atlar", logger, config)
 			Expect(err).To(MatchError("missing secret in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"baseURL": "http://localhost:8080/", "accessKey": "test", "secret": "test"}`)
-			_, err := New("atlar", config)
+			_, err := New("atlar", logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/bankingcircle/plugin.go
+++ b/internal/connectors/plugins/public/bankingcircle/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/bankingcircle/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "bankingcircle"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -37,6 +39,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/bankingcircle/plugin_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("BankingCircle Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,43 +29,43 @@ var _ = Describe("BankingCircle Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - username", func(ctx SpecContext) {
 			config := json.RawMessage(`{}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing username in config: invalid config"))
 		})
 
 		It("should report errors in config - password", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing password in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test", "password": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should report errors in config - authorization endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test", "password": "test", "endpoint": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing authorization endpoint in config: invalid config"))
 		})
 
 		It("should report errors in config - certificate", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test", "password": "test", "endpoint": "test", "authorizationEndpoint": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing user certificate in config: invalid config"))
 		})
 
 		It("should report errors in config - certificate key", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test", "password": "test", "endpoint": "test", "authorizationEndpoint": "test", "userCertificate": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("missing user certificate key in config: invalid config"))
 		})
 
 		It("should report errors in config - invalid certificate", func(ctx SpecContext) {
 			config := json.RawMessage(`{"username": "test", "password": "test", "endpoint": "test", "authorizationEndpoint": "test", "userCertificate": "test", "userCertificateKey": "test"}`)
-			_, err := New("bankingcircle", config)
+			_, err := New("bankingcircle", logger, config)
 			Expect(err).To(MatchError("failed to load user certificate: tls: failed to find any PEM data in certificate input: invalid config"))
 		})
 	})

--- a/internal/connectors/plugins/public/currencycloud/plugin.go
+++ b/internal/connectors/plugins/public/currencycloud/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/currencycloud/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "currencycloud"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -34,6 +36,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/currencycloud/plugin_test.go
+++ b/internal/connectors/plugins/public/currencycloud/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("CurrencyCloud Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,25 +29,25 @@ var _ = Describe("CurrencyCloud Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - loginID", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test", "endpoint": "test"}`)
-			_, err := New("currencycloud", config)
+			_, err := New("currencycloud", logger, config)
 			Expect(err).To(MatchError("missing clientID in config: invalid config"))
 		})
 
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{"loginID": "test", "endpoint": "test"}`)
-			_, err := New("currencycloud", config)
+			_, err := New("currencycloud", logger, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"loginID": "test", "apiKey": "test"}`)
-			_, err := New("currencycloud", config)
+			_, err := New("currencycloud", logger, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"loginID": "test", "apiKey": "test", "endpoint": "test"}`)
-			_, err := New("currencycloud", config)
+			_, err := New("currencycloud", logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/dummypay/plugin.go
+++ b/internal/connectors/plugins/public/dummypay/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/dummypay/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -12,17 +13,18 @@ import (
 )
 
 func init() {
-	registry.RegisterPlugin("dummypay", func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin("dummypay", func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
 	name   string
+	logger logging.Logger
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	conf, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -30,6 +32,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client.New(conf.Directory),
 	}, nil
 }

--- a/internal/connectors/plugins/public/generic/plugin.go
+++ b/internal/connectors/plugins/public/generic/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/generic/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "generic"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -34,6 +36,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/generic/plugin_test.go
+++ b/internal/connectors/plugins/public/generic/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Generic Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,19 +29,19 @@ var _ = Describe("Generic Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{}`)
-			_, err := New("generic", config)
+			_, err := New("generic", logger, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test"}`)
-			_, err := New("generic", config)
+			_, err := New("generic", logger, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test", "endpoint": "test"}`)
-			_, err := New("generic", config)
+			_, err := New("generic", logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/mangopay/plugin.go
+++ b/internal/connectors/plugins/public/mangopay/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/mangopay/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -15,19 +16,20 @@ import (
 const ProviderName = "mangopay"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client         client.Client
 	webhookConfigs map[client.EventType]webhookConfig
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -37,6 +39,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	p := &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}
 

--- a/internal/connectors/plugins/public/mangopay/plugin_test.go
+++ b/internal/connectors/plugins/public/mangopay/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Mangopay Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,25 +29,25 @@ var _ = Describe("Mangopay Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - clientID", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test", "endpoint": "test"}`)
-			_, err := New("mangopay", config)
+			_, err := New("mangopay", logger, config)
 			Expect(err).To(MatchError("missing clientID in config: invalid config"))
 		})
 
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{"clientID": "test", "endpoint": "test"}`)
-			_, err := New("mangopay", config)
+			_, err := New("mangopay", logger, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"clientID": "test", "apiKey": "test"}`)
-			_, err := New("mangopay", config)
+			_, err := New("mangopay", logger, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"clientID": "test", "apiKey": "test", "endpoint": "test"}`)
-			_, err := New("mangopay", config)
+			_, err := New("mangopay", logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/modulr/plugin.go
+++ b/internal/connectors/plugins/public/modulr/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/modulr/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "modulr"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -37,6 +39,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/modulr/plugin_test.go
+++ b/internal/connectors/plugins/public/modulr/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Modulr Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,25 +29,25 @@ var _ = Describe("Modulr Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - apiSecret", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test", "endpoint": "test"}`)
-			_, err := New(ProviderName, config)
+			_, err := New(ProviderName, logger, config)
 			Expect(err).To(MatchError("missing api secret in config: invalid config"))
 		})
 
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "endpoint": "test"}`)
-			_, err := New(ProviderName, config)
+			_, err := New(ProviderName, logger, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "apiKey": "test"}`)
-			_, err := New(ProviderName, config)
+			_, err := New(ProviderName, logger, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "apiKey": "test", "endpoint": "test"}`)
-			_, err := New(ProviderName, config)
+			_, err := New(ProviderName, logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/moneycorp/client/client.go
+++ b/internal/connectors/plugins/public/moneycorp/client/client.go
@@ -37,6 +37,10 @@ func New(connectorName, clientID, apiKey, endpoint string) *client {
 			underlying:    otelhttp.NewTransport(http.DefaultTransport),
 		}}),
 		HttpErrorCheckerFn: func(statusCode int) error {
+			if statusCode == http.StatusTooManyRequests {
+				return httpwrapper.ErrStatusCodeTooManyRequests
+			}
+
 			if statusCode == http.StatusNotFound {
 				return nil
 			} else if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {

--- a/internal/connectors/plugins/public/moneycorp/plugin.go
+++ b/internal/connectors/plugins/public/moneycorp/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "moneycorp"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -34,6 +36,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/moneycorp/plugin_test.go
+++ b/internal/connectors/plugins/public/moneycorp/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp"
 	"github.com/formancehq/payments/internal/models"
@@ -21,6 +22,7 @@ var _ = Describe("Moneycorp *Plugin", func() {
 	var (
 		plg    *moneycorp.Plugin
 		config json.RawMessage
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -31,11 +33,11 @@ var _ = Describe("Moneycorp *Plugin", func() {
 	Context("install", func() {
 		It("reports validation errors in the config", func(ctx SpecContext) {
 			config := json.RawMessage(`{}`)
-			_, err := moneycorp.New("moneycorp", config)
+			_, err := moneycorp.New("moneycorp", logger, config)
 			Expect(err).To(MatchError(ContainSubstring("config")))
 		})
 		It("returns valid install response", func(ctx SpecContext) {
-			_, err := moneycorp.New("moneycorp", config)
+			_, err := moneycorp.New("moneycorp", logger, config)
 			Expect(err).To(BeNil())
 			res, err := plg.Install(context.Background(), models.InstallRequest{})
 			Expect(err).To(BeNil())

--- a/internal/connectors/plugins/public/stripe/client/client.go
+++ b/internal/connectors/plugins/public/stripe/client/client.go
@@ -71,10 +71,13 @@ func wrapSDKErr(err error) error {
 		return err
 	}
 
+	if stripeErr.Code == stripe.ErrorCodeRateLimit {
+		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeTooManyRequests, err)
+	}
+
 	switch stripeErr.Type {
 	case stripe.ErrorTypeInvalidRequest, stripe.ErrorTypeIdempotency:
 		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeClientError, err)
-
 	}
 	return err
 }

--- a/internal/connectors/plugins/public/stripe/client/client_generated.go
+++ b/internal/connectors/plugins/public/stripe/client/client_generated.go
@@ -21,6 +21,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.

--- a/internal/connectors/plugins/public/stripe/payments_test.go
+++ b/internal/connectors/plugins/public/stripe/payments_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -14,11 +15,12 @@ import (
 
 var _ = Describe("Stripe Plugin Payments", func() {
 	var (
-		plg *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+		plg    *Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		plg = &Plugin{logger: logger}
 	})
 
 	Context("fetch next Payments", func() {

--- a/internal/connectors/plugins/public/stripe/plugin.go
+++ b/internal/connectors/plugins/public/stripe/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,17 +14,18 @@ import (
 const ProviderName = "stripe"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
 	name   string
+	logger logging.Logger
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -33,6 +35,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }

--- a/internal/connectors/plugins/public/stripe/plugin_test.go
+++ b/internal/connectors/plugins/public/stripe/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,7 +18,8 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Stripe Plugin", func() {
 	var (
-		plg *Plugin
+		plg    *Plugin
+		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -27,13 +29,13 @@ var _ = Describe("Stripe Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{}`)
-			_, err := New("stripe", config)
+			_, err := New("stripe", logger, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test"}`)
-			_, err := New("stripe", config)
+			_, err := New("stripe", logger, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/wise/plugin.go
+++ b/internal/connectors/plugins/public/wise/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/wise/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -14,8 +15,8 @@ import (
 const ProviderName = "wise"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
@@ -31,14 +32,15 @@ var (
 )
 
 type Plugin struct {
-	name string
+	name   string
+	logger logging.Logger
 
 	config         Config
 	client         client.Client
 	webhookConfigs map[string]webhookConfig
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -48,6 +50,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	p := &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 		config: config,
 	}

--- a/internal/connectors/plugins/public/wise/plugin_test.go
+++ b/internal/connectors/plugins/public/wise/plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/wise/client"
 	"github.com/formancehq/payments/internal/models"
@@ -34,6 +35,7 @@ var _ = Describe("Wise Plugin", func() {
 		block      *pem.Block
 		pemKey     *bytes.Buffer
 		privatekey *rsa.PrivateKey
+		logger     = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
 
 	BeforeEach(func() {
@@ -72,12 +74,12 @@ var _ = Describe("Wise Plugin", func() {
 
 	Context("install", func() {
 		It("reports validation errors in the config", func(ctx SpecContext) {
-			_, err := New("wise", json.RawMessage(`{}`))
+			_, err := New("wise", logger, json.RawMessage(`{}`))
 			Expect(err).To(MatchError(ContainSubstring("config")))
 		})
 		It("rejects malformed pem keys", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey":"dummy","webhookPublicKey":"badKey"}`)
-			_, err := New("wise", config)
+			_, err := New("wise", logger, config)
 			Expect(err).To(MatchError(ContainSubstring("public key")))
 		})
 		It("returns valid install response", func(ctx SpecContext) {
@@ -87,7 +89,7 @@ var _ = Describe("Wise Plugin", func() {
 			}
 			configJson, err := json.Marshal(config)
 			Expect(err).To(BeNil())
-			_, err = New("wise", configJson)
+			_, err = New("wise", logger, configJson)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(context.Background(), req)
@@ -111,7 +113,7 @@ var _ = Describe("Wise Plugin", func() {
 			}
 			configJson, err := json.Marshal(config)
 			Expect(err).To(BeNil())
-			plg, err = New("wise", configJson)
+			plg, err = New("wise", logger, configJson)
 			Expect(err).To(BeNil())
 
 			ctrl := gomock.NewController(GinkgoT())

--- a/internal/connectors/plugins/registry/errors.go
+++ b/internal/connectors/plugins/registry/errors.go
@@ -20,6 +20,8 @@ func translateError(err error) error {
 		errors.Is(err, httpwrapper.ErrStatusCodeClientError),
 		errors.Is(err, models.ErrInvalidConfig):
 		return fmt.Errorf("%w: %w", err, plugins.ErrInvalidClientRequest)
+	case errors.Is(err, httpwrapper.ErrStatusCodeTooManyRequests):
+		return fmt.Errorf("%w: %w", err, plugins.ErrUpstreamRatelimit)
 	default:
 		return err
 	}

--- a/internal/connectors/plugins/registry/plugins.go
+++ b/internal/connectors/plugins/registry/plugins.go
@@ -9,7 +9,7 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
-type PluginCreateFunction func(string, json.RawMessage) (models.Plugin, error)
+type PluginCreateFunction func(string, logging.Logger, json.RawMessage) (models.Plugin, error)
 
 type PluginInformation struct {
 	capabilities []models.Capability
@@ -35,7 +35,7 @@ func GetPlugin(logger logging.Logger, provider string, connectorName string, raw
 		return nil, ErrPluginNotFound
 	}
 
-	p, err := info.createFunc(connectorName, rawConfig)
+	p, err := info.createFunc(connectorName, logger, rawConfig)
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/internal/models/plugin_generated.go
+++ b/internal/models/plugin_generated.go
@@ -20,6 +20,7 @@ import (
 type MockPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginMockRecorder
+	isgomock struct{}
 }
 
 // MockPluginMockRecorder is the mock recorder for MockPlugin.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -41,6 +41,7 @@ type Storage interface {
 	ListenConnectorsChanges(ctx context.Context, handler HandlerConnectorsChanges) error
 	ConnectorsInstall(ctx context.Context, c models.Connector) error
 	ConnectorsUninstall(ctx context.Context, id models.ConnectorID) error
+	ConnectorsConfigUpdate(ctx context.Context, c models.Connector) error
 	ConnectorsGet(ctx context.Context, id models.ConnectorID) (*models.Connector, error)
 	ConnectorsList(ctx context.Context, q ListConnectorsQuery) (*bunpaginate.Cursor[models.Connector], error)
 	ConnectorsScheduleForDeletion(ctx context.Context, id models.ConnectorID) error

--- a/internal/storage/storage_generated.go
+++ b/internal/storage/storage_generated.go
@@ -24,6 +24,7 @@ import (
 type MockStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageMockRecorder
+	isgomock struct{}
 }
 
 // MockStorageMockRecorder is the mock recorder for MockStorage.
@@ -300,6 +301,20 @@ func (m *MockStorage) ConnectorTasksTreeUpsert(ctx context.Context, connectorID 
 func (mr *MockStorageMockRecorder) ConnectorTasksTreeUpsert(ctx, connectorID, tasks any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectorTasksTreeUpsert", reflect.TypeOf((*MockStorage)(nil).ConnectorTasksTreeUpsert), ctx, connectorID, tasks)
+}
+
+// ConnectorsConfigUpdate mocks base method.
+func (m *MockStorage) ConnectorsConfigUpdate(ctx context.Context, c models.Connector) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectorsConfigUpdate", ctx, c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConnectorsConfigUpdate indicates an expected call of ConnectorsConfigUpdate.
+func (mr *MockStorageMockRecorder) ConnectorsConfigUpdate(ctx, c any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectorsConfigUpdate", reflect.TypeOf((*MockStorage)(nil).ConnectorsConfigUpdate), ctx, c)
 }
 
 // ConnectorsGet mocks base method.

--- a/internal/worker/module.go
+++ b/internal/worker/module.go
@@ -50,8 +50,14 @@ func NewModule(
 		fx.Provide(func(temporalClient client.Client, plugins plugins.Plugins) workflow.Workflow {
 			return workflow.New(temporalClient, temporalNamespace, plugins, stack, stackURL)
 		}),
-		fx.Provide(func(temporalClient client.Client, storage storage.Storage, events *events.Events, plugins plugins.Plugins) activities.Activities {
-			return activities.New(temporalClient, storage, events, plugins, temporalRateLimitingRetryDelay)
+		fx.Provide(func(
+			logger logging.Logger,
+			temporalClient client.Client,
+			storage storage.Storage,
+			events *events.Events,
+			plugins plugins.Plugins,
+		) activities.Activities {
+			return activities.New(logger, temporalClient, storage, events, plugins, temporalRateLimitingRetryDelay)
 		}),
 		fx.Provide(
 			fx.Annotate(func(

--- a/internal/worker/module.go
+++ b/internal/worker/module.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/formancehq/go-libs/v2/httpserver"
@@ -32,6 +33,7 @@ func NewModule(
 	stack string,
 	stackURL string,
 	temporalNamespace string,
+	temporalRateLimitingRetryDelay time.Duration,
 	temporalMaxConcurrentWorkflowTaskPollers int,
 	debug bool,
 ) fx.Option {
@@ -49,7 +51,7 @@ func NewModule(
 			return workflow.New(temporalClient, temporalNamespace, plugins, stack, stackURL)
 		}),
 		fx.Provide(func(temporalClient client.Client, storage storage.Storage, events *events.Events, plugins plugins.Plugins) activities.Activities {
-			return activities.New(temporalClient, storage, events, plugins)
+			return activities.New(temporalClient, storage, events, plugins, temporalRateLimitingRetryDelay)
 		}),
 		fx.Provide(
 			fx.Annotate(func(

--- a/pkg/testserver/api.go
+++ b/pkg/testserver/api.go
@@ -40,6 +40,14 @@ func ConnectorUninstall(ctx context.Context, srv *Server, ver int, id string, re
 	return srv.Client().Do(ctx, http.MethodDelete, pathPrefix(ver, path), nil, res)
 }
 
+func ConnectorConfigUpdate(ctx context.Context, srv *Server, ver int, id string, reqBody any) error {
+	path := "connectors/" + id + "/config"
+	if ver == 2 {
+		return fmt.Errorf("connector update not supported by version %d", ver)
+	}
+	return srv.Client().Do(ctx, http.MethodPatch, pathPrefix(ver, path), reqBody, nil)
+}
+
 func ConnectorConfig(ctx context.Context, srv *Server, ver int, id string, res any) error {
 	path := "connectors/" + id + "/config"
 	if ver == 2 {

--- a/test/e2e/api_connectors_test.go
+++ b/test/e2e/api_connectors_test.go
@@ -84,6 +84,37 @@ var _ = Context("Payments API Connectors", func() {
 		})
 	})
 
+	When("updating a connector config", func() {
+		var (
+			id           uuid.UUID
+			ver          int
+			connectorRes struct{ Data string }
+			connectorID  string
+		)
+		JustBeforeEach(func() {
+			id = uuid.New()
+			ver = 3
+
+			connectorConf := newConnectorConfigurationFn()(id)
+			err := ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, &connectorRes)
+			Expect(err).To(BeNil())
+			connectorID = connectorRes.Data
+			blockTillWorkflowComplete(ctx, connectorID, "run-tasks-")
+		})
+
+		It("should be ok with v3", func() {
+			config := newConnectorConfigurationFn()(id)
+			config.PollingPeriod = "2m"
+			err := ConnectorConfigUpdate(ctx, app.GetValue(), ver, connectorID, &config)
+			Expect(err).To(BeNil())
+
+			getRes := struct{ Data ConnectorConf }{}
+			err = ConnectorConfig(ctx, app.GetValue(), ver, connectorID, &getRes)
+			Expect(err).To(BeNil())
+			Expect(getRes.Data).To(Equal(config))
+		})
+	})
+
 	When("uninstalling a connector", func() {
 		var (
 			id uuid.UUID

--- a/tools/connector-template/template/plugin.gotpl
+++ b/tools/connector-template/template/plugin.gotpl
@@ -4,6 +4,7 @@ import (
     "context"
 	"encoding/json"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/{{ .Connector }}/client"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
@@ -13,18 +14,19 @@ import (
 const ProviderName = "{{ .Connector }}"
 
 func init() {
-	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
-		return New(name, rm)
+	registry.RegisterPlugin(ProviderName, func(name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
 	}, capabilities)
 }
 
 type Plugin struct {
 	name string
+	logger logging.Logger
 
 	client client.Client
 }
 
-func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
 	config, err := unmarshalAndValidateConfig(rawConfig)
 	if err != nil {
 		return nil, err
@@ -35,6 +37,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
+		logger: logger,
 		client: client,
 	}, nil
 }


### PR DESCRIPTION
fixes: ENG-1554
fixes: ENG-1521

### Suggested rate-limiting strategy:

* if a PSP call is rate-limited, add a delay before trying to retry
* if a PSP call in a polled function is rate-limited (fetch accounts etc), disable retry all together to avoid flooding the PSP since the polling activity will be re-executed regardless of failure
* alert on rate-limited requests (https://github.com/formancehq/infra/pull/122)
  * an on-call engineer can reconfigure the polling interval of a connector using the new update endpoint if the interval appears too frequent