### PR TITLE
fix: (metrics) ensure that connectors using SDKs record metrics consistently

### DIFF
--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const MetricOperationContextKey string = "_metric_operation_context_key"
-
 var (
 	ErrStatusCodeUnexpected  = errors.New("unexpected status code")
 	ErrStatusCodeClientError = fmt.Errorf("%w: http client error", ErrStatusCodeUnexpected)

--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
-	"github.com/formancehq/payments/internal/connectors/metrics"
+	"github.com/formancehq/payments/internal/models"
 	"github.com/hashicorp/go-hclog"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/oauth2"
 )
 
@@ -42,15 +39,14 @@ type Client interface {
 }
 
 type client struct {
-	httpClient              *http.Client
-	commonMetricsAttributes []attribute.KeyValue
+	httpClient *http.Client
 
 	httpErrorCheckerFn func(statusCode int) error
 }
 
 func NewClient(config *Config) Client {
 	if config.Timeout == 0 {
-		config.Timeout = 10 * time.Second
+		config.Timeout = models.DefaultConnectorClientTimeout
 	}
 	if config.Transport != nil {
 		config.Transport = otelhttp.NewTransport(config.Transport)
@@ -72,31 +68,17 @@ func NewClient(config *Config) Client {
 		config.HttpErrorCheckerFn = defaultHttpErrorCheckerFn
 	}
 
-	metricsAttributes := make([]attribute.KeyValue, 0)
-	metricsAttributes = append(metricsAttributes, config.CommonMetricsAttributes...)
-
 	return &client{
-		httpErrorCheckerFn:      config.HttpErrorCheckerFn,
-		httpClient:              httpClient,
-		commonMetricsAttributes: metricsAttributes,
+		httpErrorCheckerFn: config.HttpErrorCheckerFn,
+		httpClient:         httpClient,
 	}
 }
 
 func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorBody any) (int, error) {
-	start := time.Now()
-	attrs := c.metricsAttributes(ctx, req)
-	defer func() {
-		registry := metrics.GetMetricsRegistry()
-		opts := metric.WithAttributes(attrs...)
-		registry.ConnectorPSPCalls().Add(ctx, 1, opts)
-		registry.ConnectorPSPCallLatencies().Record(ctx, time.Since(start).Milliseconds(), opts)
-	}()
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to make request: %w", err)
 	}
-	attrs = append(attrs, attribute.Int("status", resp.StatusCode))
 
 	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
 	// the caller doesn't care about the response body so we return early
@@ -129,17 +111,4 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 		return resp.StatusCode, fmt.Errorf("failed to unmarshal response with status %d: %w", resp.StatusCode, err)
 	}
 	return resp.StatusCode, nil
-}
-
-func (c *client) metricsAttributes(ctx context.Context, req *http.Request) []attribute.KeyValue {
-	attrs := c.commonMetricsAttributes
-	attrs = append(attrs, attribute.String("endpoint", req.URL.Path))
-
-	val := ctx.Value(MetricOperationContextKey)
-	if val != nil {
-		if name, ok := val.(string); ok {
-			attrs = append(attrs, attribute.String("operation", name))
-		}
-	}
-	return attrs
 }

--- a/internal/connectors/httpwrapper/config.go
+++ b/internal/connectors/httpwrapper/config.go
@@ -4,22 +4,13 @@ import (
 	"net/http"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
 type Config struct {
-	HttpErrorCheckerFn      func(code int) error
-	CommonMetricsAttributes []attribute.KeyValue
+	HttpErrorCheckerFn func(code int) error
 
 	Timeout     time.Duration
 	Transport   http.RoundTripper
 	OAuthConfig *clientcredentials.Config
-}
-
-func CommonMetricsAttributesFor(connectorName string) []attribute.KeyValue {
-	metricsAttributes := []attribute.KeyValue{
-		attribute.String("connector", connectorName),
-	}
-	return metricsAttributes
 }

--- a/internal/connectors/metrics/client.go
+++ b/internal/connectors/metrics/client.go
@@ -3,16 +3,15 @@ package metrics
 import (
 	"net/http"
 	"time"
-
-	"go.opentelemetry.io/otel/attribute"
 )
 
-func NewHTTPClient(commonAttributesFn func() []attribute.KeyValue) *http.Client {
-	opts := TransportOpts{
-		CommonMetricAttributesFn: commonAttributesFn,
-	}
+type ClientOptions struct {
+	Timeout time.Duration
+}
+
+func NewHTTPClient(connectorName string, timeout time.Duration) *http.Client {
 	return &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: NewTransport(opts),
+		Timeout:   timeout,
+		Transport: NewTransport(connectorName, TransportOpts{}),
 	}
 }

--- a/internal/connectors/metrics/client.go
+++ b/internal/connectors/metrics/client.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-type ClientOptions struct {
-	Timeout time.Duration
-}
-
 func NewHTTPClient(connectorName string, timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,

--- a/internal/connectors/metrics/client.go
+++ b/internal/connectors/metrics/client.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func NewHTTPClient(commonAttributesFn func() []attribute.KeyValue) *http.Client {
+	opts := TransportOpts{
+		CommonMetricAttributesFn: commonAttributesFn,
+	}
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: NewTransport(opts),
+	}
+}

--- a/internal/connectors/metrics/transport.go
+++ b/internal/connectors/metrics/transport.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const MetricOperationContextKey string = "_metric_operation_context_key"
+
+func OperationContext(ctx context.Context, operation string) context.Context {
+	return context.WithValue(ctx, MetricOperationContextKey, operation)
+}
+
+type TransportOpts struct {
+	Transport                http.RoundTripper
+	CommonMetricAttributesFn func() []attribute.KeyValue
+}
+
+type Transport struct {
+	parent                 http.RoundTripper
+	commonMetricAttributes []attribute.KeyValue
+}
+
+func NewTransport(opts TransportOpts) http.RoundTripper {
+	if opts.Transport == nil {
+		opts.Transport = http.DefaultTransport
+	}
+
+	if opts.CommonMetricAttributesFn == nil {
+		opts.CommonMetricAttributesFn = func() []attribute.KeyValue { return []attribute.KeyValue{} }
+	}
+
+	return &Transport{
+		parent:                 opts.Transport,
+		commonMetricAttributes: opts.CommonMetricAttributesFn(),
+	}
+}
+
+func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	res, err := r.parent.RoundTrip(req)
+	registry := GetMetricsRegistry()
+
+	attrs := r.commonMetricAttributes
+	attrs = append(attrs, attribute.String("endpoint", req.URL.Path))
+	if val := req.Context().Value(MetricOperationContextKey); val != nil {
+		if name, ok := val.(string); ok {
+			attrs = append(attrs, attribute.String("operation", name))
+		}
+	}
+
+	if res != nil {
+		attrs = append(attrs, attribute.Int("status", res.StatusCode))
+	} else {
+		// if request could not be executed
+		attrs = append(attrs, attribute.Int("status", 0))
+	}
+	opts := metric.WithAttributes(attrs...)
+
+	registry.ConnectorPSPCalls().Add(req.Context(), 1, opts)
+	registry.ConnectorPSPCallLatencies().Record(req.Context(), time.Since(start).Milliseconds(), opts)
+	return res, err
+}

--- a/internal/connectors/plugins/public/adyen/client/accounts.go
+++ b/internal/connectors/plugins/public/adyen/client/accounts.go
@@ -2,17 +2,14 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"github.com/adyen/adyen-go-api-library/v7/src/management"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) GetMerchantAccounts(ctx context.Context, pageNumber, pageSize int32) ([]management.Merchant, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_merchant_accounts")
-
 	listMerchantsResponse, raw, err := c.client.Management().AccountMerchantLevelApi.ListMerchantAccounts(
-		ctx,
+		metrics.OperationContext(ctx, "list_merchant_accounts"),
 		c.client.Management().AccountMerchantLevelApi.ListMerchantAccountsInput().PageNumber(pageNumber).PageSize(pageSize),
 	)
 	err = c.wrapSDKError(err, raw.StatusCode)

--- a/internal/connectors/plugins/public/adyen/plugin.go
+++ b/internal/connectors/plugins/public/adyen/plugin.go
@@ -11,8 +11,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "adyen"
+
 func init() {
-	registry.RegisterPlugin("adyen", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -33,6 +35,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 	}
 
 	client := client.New(
+		ProviderName,
 		config.APIKey,
 		config.WebhookUsername,
 		config.WebhookPassword,

--- a/internal/connectors/plugins/public/atlar/client/accounts.go
+++ b/internal/connectors/plugins/public/atlar/client/accounts.go
@@ -2,18 +2,16 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/get-momo/atlar-v1-go-client/client/accounts"
 )
 
 func (c *client) GetV1AccountsID(ctx context.Context, id string) (*accounts.GetV1AccountsIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_account")
-
 	accountsParams := accounts.GetV1AccountsIDParams{
-		Context: ctx,
-		ID:      id,
+		Context:    metrics.OperationContext(ctx, "get_account"),
+		ID:         id,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.Accounts.GetV1AccountsID(&accountsParams)
@@ -21,13 +19,11 @@ func (c *client) GetV1AccountsID(ctx context.Context, id string) (*accounts.GetV
 }
 
 func (c *client) GetV1Accounts(ctx context.Context, token string, pageSize int64) (*accounts.GetV1AccountsOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_accounts")
-
 	accountsParams := accounts.GetV1AccountsParams{
-		Limit:   &pageSize,
-		Context: ctx,
-		Token:   &token,
+		Limit:      &pageSize,
+		Context:    metrics.OperationContext(ctx, "list_accounts"),
+		Token:      &token,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.Accounts.GetV1Accounts(&accountsParams)

--- a/internal/connectors/plugins/public/atlar/client/client.go
+++ b/internal/connectors/plugins/public/atlar/client/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
@@ -22,7 +21,6 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -46,17 +44,15 @@ type Client interface {
 }
 
 type client struct {
-	client                 *atlar_client.Rest
-	commonMetricAttributes []attribute.KeyValue
+	client     *atlar_client.Rest
+	httpClient *http.Client
 }
 
 func New(baseURL *url.URL, accessKey, secret string) Client {
-	c := &client{
-		client:                 createAtlarClient(baseURL, accessKey, secret),
-		commonMetricAttributes: CommonMetricsAttributes(),
+	return &client{
+		client:     createAtlarClient(baseURL, accessKey, secret),
+		httpClient: metrics.NewHTTPClient(CommonMetricsAttributes),
 	}
-
-	return c
 }
 
 func createAtlarClient(baseURL *url.URL, accessKey, secret string) *atlar_client.Rest {
@@ -69,18 +65,6 @@ func createAtlarClient(baseURL *url.URL, accessKey, secret string) *atlar_client
 	transport.DefaultAuthentication = basicAuth
 	client := atlar_client.New(transport, strfmt.Default)
 	return client
-}
-
-// recordMetrics is meant to be called in a defer
-func (c *client) recordMetrics(ctx context.Context, start time.Time, operation string) {
-	registry := metrics.GetMetricsRegistry()
-
-	attrs := c.commonMetricAttributes
-	attrs = append(attrs, attribute.String("operation", operation))
-	opts := metric.WithAttributes(attrs...)
-
-	registry.ConnectorPSPCalls().Add(ctx, 1, opts)
-	registry.ConnectorPSPCallLatencies().Record(ctx, time.Since(start).Milliseconds(), opts)
 }
 
 func CommonMetricsAttributes() []attribute.KeyValue {

--- a/internal/connectors/plugins/public/atlar/client/client.go
+++ b/internal/connectors/plugins/public/atlar/client/client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -48,10 +47,10 @@ type client struct {
 	httpClient *http.Client
 }
 
-func New(baseURL *url.URL, accessKey, secret string) Client {
+func New(name string, baseURL *url.URL, accessKey, secret string) Client {
 	return &client{
 		client:     createAtlarClient(baseURL, accessKey, secret),
-		httpClient: metrics.NewHTTPClient(CommonMetricsAttributes),
+		httpClient: metrics.NewHTTPClient(name, models.DefaultConnectorClientTimeout),
 	}
 }
 
@@ -65,13 +64,6 @@ func createAtlarClient(baseURL *url.URL, accessKey, secret string) *atlar_client
 	transport.DefaultAuthentication = basicAuth
 	client := atlar_client.New(transport, strfmt.Default)
 	return client
-}
-
-func CommonMetricsAttributes() []attribute.KeyValue {
-	metricsAttributes := []attribute.KeyValue{
-		attribute.String("connector", "generic"),
-	}
-	return metricsAttributes
 }
 
 // wrap a public error for cases that we don't want to retry

--- a/internal/connectors/plugins/public/atlar/client/counter_parties.go
+++ b/internal/connectors/plugins/public/atlar/client/counter_parties.go
@@ -3,30 +3,25 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/get-momo/atlar-v1-go-client/client/counterparties"
 	atlar_models "github.com/get-momo/atlar-v1-go-client/models"
 )
 
 func (c *client) GetV1CounterpartiesID(ctx context.Context, counterPartyID string) (*counterparties.GetV1CounterpartiesIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_counterparty")
-
 	getCounterpartyParams := counterparties.GetV1CounterpartiesIDParams{
-		Context: ctx,
-		ID:      counterPartyID,
+		Context:    metrics.OperationContext(ctx, "get_counter_party"),
+		ID:         counterPartyID,
+		HTTPClient: c.httpClient,
 	}
 	counterpartyResponse, err := c.client.Counterparties.GetV1CounterpartiesID(&getCounterpartyParams)
 	return counterpartyResponse, wrapSDKErr(err)
 }
 
 func (c *client) PostV1CounterParties(ctx context.Context, newExternalBankAccount models.BankAccount) (*counterparties.PostV1CounterpartiesCreated, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "create_counter_party")
-
 	// TODO: make sure an account with that IBAN does not already exist (Atlar API v2 needed, v1 lacks the filters)
 	// alternatively we could query the local DB
 
@@ -60,8 +55,9 @@ func (c *client) PostV1CounterParties(ctx context.Context, newExternalBankAccoun
 		},
 	}
 	postCounterpartiesParams := counterparties.PostV1CounterpartiesParams{
-		Context:      ctx,
+		Context:      metrics.OperationContext(ctx, "create_counter_party"),
 		Counterparty: &createCounterpartyRequest,
+		HTTPClient:   c.httpClient,
 	}
 	postCounterpartiesResponse, err := c.client.Counterparties.PostV1Counterparties(&postCounterpartiesParams)
 	if err != nil {

--- a/internal/connectors/plugins/public/atlar/client/external_accounts.go
+++ b/internal/connectors/plugins/public/atlar/client/external_accounts.go
@@ -2,18 +2,16 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/get-momo/atlar-v1-go-client/client/external_accounts"
 )
 
 func (c *client) GetV1ExternalAccountsID(ctx context.Context, externalAccountID string) (*external_accounts.GetV1ExternalAccountsIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_external_account")
-
 	getExternalAccountParams := external_accounts.GetV1ExternalAccountsIDParams{
-		Context: ctx,
-		ID:      externalAccountID,
+		Context:    metrics.OperationContext(ctx, "get_external_account"),
+		ID:         externalAccountID,
+		HTTPClient: c.httpClient,
 	}
 
 	externalAccountResponse, err := c.client.ExternalAccounts.GetV1ExternalAccountsID(&getExternalAccountParams)
@@ -21,13 +19,11 @@ func (c *client) GetV1ExternalAccountsID(ctx context.Context, externalAccountID 
 }
 
 func (c *client) GetV1ExternalAccounts(ctx context.Context, token string, pageSize int64) (*external_accounts.GetV1ExternalAccountsOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_external_accounts")
-
 	externalAccountsParams := external_accounts.GetV1ExternalAccountsParams{
-		Limit:   &pageSize,
-		Context: ctx,
-		Token:   &token,
+		Limit:      &pageSize,
+		Context:    metrics.OperationContext(ctx, "list_external_accounts"),
+		Token:      &token,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.ExternalAccounts.GetV1ExternalAccounts(&externalAccountsParams)

--- a/internal/connectors/plugins/public/atlar/client/third_parties.go
+++ b/internal/connectors/plugins/public/atlar/client/third_parties.go
@@ -2,18 +2,16 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/get-momo/atlar-v1-go-client/client/third_parties"
 )
 
 func (c *client) GetV1BetaThirdPartiesID(ctx context.Context, id string) (*third_parties.GetV1betaThirdPartiesIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_third_party")
-
 	params := third_parties.GetV1betaThirdPartiesIDParams{
-		Context: ctx,
-		ID:      id,
+		Context:    metrics.OperationContext(ctx, "get_third_party"),
+		ID:         id,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.ThirdParties.GetV1betaThirdPartiesID(&params)

--- a/internal/connectors/plugins/public/atlar/client/transactions.go
+++ b/internal/connectors/plugins/public/atlar/client/transactions.go
@@ -2,19 +2,17 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/get-momo/atlar-v1-go-client/client/transactions"
 )
 
 func (c *client) GetV1Transactions(ctx context.Context, token string, pageSize int64) (*transactions.GetV1TransactionsOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_transactions")
-
 	params := transactions.GetV1TransactionsParams{
-		Limit:   &pageSize,
-		Context: ctx,
-		Token:   &token,
+		Limit:      &pageSize,
+		Context:    metrics.OperationContext(ctx, "list_transactions"),
+		Token:      &token,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.Transactions.GetV1Transactions(&params)
@@ -22,12 +20,10 @@ func (c *client) GetV1Transactions(ctx context.Context, token string, pageSize i
 }
 
 func (c *client) GetV1TransactionsID(ctx context.Context, id string) (*transactions.GetV1TransactionsIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_transaction")
-
 	params := transactions.GetV1TransactionsIDParams{
-		Context: ctx,
-		ID:      id,
+		Context:    metrics.OperationContext(ctx, "get_transaction"),
+		ID:         id,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.Transactions.GetV1TransactionsID(&params)

--- a/internal/connectors/plugins/public/atlar/client/transfers.go
+++ b/internal/connectors/plugins/public/atlar/client/transfers.go
@@ -2,19 +2,17 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/get-momo/atlar-v1-go-client/client/credit_transfers"
 	atlar_models "github.com/get-momo/atlar-v1-go-client/models"
 )
 
 func (c *client) PostV1CreditTransfers(ctx context.Context, req *atlar_models.CreatePaymentRequest) (*credit_transfers.PostV1CreditTransfersCreated, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "create_credit_transfer")
-
 	postCreditTransfersParams := credit_transfers.PostV1CreditTransfersParams{
-		Context:        ctx,
+		Context:        metrics.OperationContext(ctx, "create_credit_transfer"),
 		CreditTransfer: req,
+		HTTPClient:     c.httpClient,
 	}
 
 	resp, err := c.client.CreditTransfers.PostV1CreditTransfers(&postCreditTransfersParams)
@@ -22,12 +20,10 @@ func (c *client) PostV1CreditTransfers(ctx context.Context, req *atlar_models.Cr
 }
 
 func (c *client) GetV1CreditTransfersGetByExternalIDExternalID(ctx context.Context, externalID string) (*credit_transfers.GetV1CreditTransfersGetByExternalIDExternalIDOK, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "get_credit_transfer")
-
 	getCreditTransferParams := credit_transfers.GetV1CreditTransfersGetByExternalIDExternalIDParams{
-		Context:    ctx,
+		Context:    metrics.OperationContext(ctx, "get_credit_transfer"),
 		ExternalID: externalID,
+		HTTPClient: c.httpClient,
 	}
 
 	resp, err := c.client.CreditTransfers.GetV1CreditTransfersGetByExternalIDExternalID(&getCreditTransferParams)

--- a/internal/connectors/plugins/public/atlar/plugin.go
+++ b/internal/connectors/plugins/public/atlar/plugin.go
@@ -11,8 +11,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "atlar"
+
 func init() {
-	registry.RegisterPlugin("atlar", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -36,7 +38,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 
 	return &Plugin{
 		name:   name,
-		client: client.New(baseUrl, config.AccessKey, config.Secret),
+		client: client.New(ProviderName, baseUrl, config.AccessKey, config.Secret),
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/bankingcircle/client/accounts.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/accounts.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Balance struct {
@@ -43,7 +43,7 @@ func (c *client) GetAccounts(ctx context.Context, page int, pageSize int, fromOp
 		return nil, err
 	}
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_accounts")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/api/v1/accounts", http.NoBody)
 	if err != nil {
@@ -80,7 +80,7 @@ func (c *client) GetAccount(ctx context.Context, accountID string) (*Account, er
 	if err := c.ensureAccessTokenIsValid(ctx); err != nil {
 		return nil, err
 	}
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_account")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/accounts/%s", c.endpoint, accountID), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/bankingcircle/client/auth.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/auth.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) login(ctx context.Context) error {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "authenticate")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "authenticate")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		c.authorizationEndpoint+"/api/v1/authorizations/authorize", http.NoBody)

--- a/internal/connectors/plugins/public/bankingcircle/client/client.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
 )
 
@@ -35,6 +36,7 @@ type client struct {
 }
 
 func New(
+	connectorName string,
 	username, password,
 	endpoint, authorizationEndpoint,
 	uCertificate, uCertificateKey string,
@@ -50,8 +52,7 @@ func New(
 	}
 
 	config := &httpwrapper.Config{
-		CommonMetricsAttributes: httpwrapper.CommonMetricsAttributesFor("bankingcircle"),
-		Transport:               tr,
+		Transport: metrics.NewTransport(connectorName, metrics.TransportOpts{Transport: tr}),
 	}
 
 	c := &client{

--- a/internal/connectors/plugins/public/bankingcircle/client/payments.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/payments.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type DebtorInformation struct {
@@ -94,7 +94,7 @@ func (c *client) GetPayments(ctx context.Context, page int, pageSize int) ([]Pay
 		return nil, err
 	}
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_payments")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_payments")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/api/v1/payments/singles", http.NoBody)
 	if err != nil {
@@ -129,7 +129,7 @@ func (c *client) GetPayment(ctx context.Context, paymentID string) (*Payment, er
 		return nil, err
 	}
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payment")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payment")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/payments/singles/%s", c.endpoint, paymentID), http.NoBody)
 	if err != nil {
@@ -153,7 +153,7 @@ func (c *client) GetPaymentStatus(ctx context.Context, paymentID string) (*Statu
 	if err := c.ensureAccessTokenIsValid(ctx); err != nil {
 		return nil, err
 	}
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payment_status")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payment_status")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/payments/singles/%s/status", c.endpoint, paymentID), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/bankingcircle/client/transfer_payouts.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/transfer_payouts.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PaymentAccount struct {
@@ -38,7 +38,7 @@ func (c *client) InitiateTransferOrPayouts(ctx context.Context, transferRequest 
 		return nil, err
 	}
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_transfers_payouts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_transfers_payouts")
 
 	body, err := json.Marshal(transferRequest)
 	if err != nil {

--- a/internal/connectors/plugins/public/bankingcircle/plugin.go
+++ b/internal/connectors/plugins/public/bankingcircle/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "bankingcircle"
+
 func init() {
-	registry.RegisterPlugin("bankingcircle", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -28,7 +30,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client, err := client.New(config.Username, config.Password, config.Endpoint, config.AuthorizationEndpoint, config.UserCertificate, config.UserCertificateKey)
+	client, err := client.New(ProviderName, config.Username, config.Password, config.Endpoint, config.AuthorizationEndpoint, config.UserCertificate, config.UserCertificateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connectors/plugins/public/currencycloud/client/accounts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/accounts.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Account struct {
@@ -20,7 +20,7 @@ func (c *client) GetAccounts(ctx context.Context, page int, pageSize int) ([]*Ac
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, 0, err
 	}
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_accounts")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.buildEndpoint("v2/accounts/find"), http.NoBody)

--- a/internal/connectors/plugins/public/currencycloud/client/auth.go
+++ b/internal/connectors/plugins/public/currencycloud/client/auth.go
@@ -7,11 +7,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) authenticate(ctx context.Context) error {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "authenticate")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "authenticate")
 
 	form := make(url.Values)
 

--- a/internal/connectors/plugins/public/currencycloud/client/balances.go
+++ b/internal/connectors/plugins/public/currencycloud/client/balances.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Balance struct {
@@ -20,7 +20,7 @@ type Balance struct {
 }
 
 func (c *client) GetBalances(ctx context.Context, page int, pageSize int) ([]*Balance, int, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_balances")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_balances")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, 0, err

--- a/internal/connectors/plugins/public/currencycloud/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/currencycloud/client/beneficiaries.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Beneficiary struct {
@@ -19,7 +19,7 @@ type Beneficiary struct {
 }
 
 func (c *client) GetBeneficiaries(ctx context.Context, page int, pageSize int) ([]*Beneficiary, int, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_beneficiaries")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_beneficiaries")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, 0, err

--- a/internal/connectors/plugins/public/currencycloud/client/contacts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/contacts.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
 )
 
@@ -16,7 +16,7 @@ type Contact struct {
 }
 
 func (c *client) GetContactID(ctx context.Context, accountID string) (*Contact, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_contacts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_contacts")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, err

--- a/internal/connectors/plugins/public/currencycloud/client/payouts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/payouts.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PayoutRequest struct {
@@ -54,7 +54,7 @@ type PayoutResponse struct {
 }
 
 func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutRequest) (*PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_payout")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, err

--- a/internal/connectors/plugins/public/currencycloud/client/transactions.go
+++ b/internal/connectors/plugins/public/currencycloud/client/transactions.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 //nolint:tagliatelle // allow different styled tags in client
@@ -29,7 +29,7 @@ func (c *client) GetTransactions(ctx context.Context, page int, pageSize int, up
 		return nil, 0, fmt.Errorf("page must be greater than 0")
 	}
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_transactions")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transactions")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, 0, err

--- a/internal/connectors/plugins/public/currencycloud/client/transfers.go
+++ b/internal/connectors/plugins/public/currencycloud/client/transfers.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type TransferRequest struct {
@@ -55,7 +55,7 @@ type TransferResponse struct {
 }
 
 func (c *client) InitiateTransfer(ctx context.Context, transferRequest *TransferRequest) (*TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_transfer")
 
 	if err := c.ensureLogin(ctx); err != nil {
 		return nil, err

--- a/internal/connectors/plugins/public/currencycloud/plugin.go
+++ b/internal/connectors/plugins/public/currencycloud/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "currencycloud"
+
 func init() {
-	registry.RegisterPlugin("currencycloud", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -28,7 +30,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(config.LoginID, config.APIKey, config.Endpoint)
+	client := client.New(ProviderName, config.LoginID, config.APIKey, config.Endpoint)
 
 	return &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/public/generic/client/accounts.go
+++ b/internal/connectors/plugins/public/generic/client/accounts.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/genericclient"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) ListAccounts(ctx context.Context, page, pageSize int64, createdAtFrom time.Time) ([]genericclient.Account, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_accounts")
-
 	req := c.apiClient.DefaultApi.
-		GetAccounts(ctx).
+		GetAccounts(metrics.OperationContext(ctx, "list_accounts")).
 		Page(page).
 		PageSize(pageSize)
 

--- a/internal/connectors/plugins/public/generic/client/balances.go
+++ b/internal/connectors/plugins/public/generic/client/balances.go
@@ -2,16 +2,13 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"github.com/formancehq/payments/genericclient"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) GetBalances(ctx context.Context, accountID string) (*genericclient.Balances, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_balances")
-
-	req := c.apiClient.DefaultApi.GetAccountBalances(ctx, accountID)
+	req := c.apiClient.DefaultApi.GetAccountBalances(metrics.OperationContext(ctx, "list_balances"), accountID)
 
 	balances, _, err := req.Execute()
 	if err != nil {

--- a/internal/connectors/plugins/public/generic/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/generic/client/beneficiaries.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/genericclient"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) ListBeneficiaries(ctx context.Context, page, pageSize int64, createdAtFrom time.Time) ([]genericclient.Beneficiary, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_beneficiaries")
-
 	req := c.apiClient.DefaultApi.
-		GetBeneficiaries(ctx).
+		GetBeneficiaries(metrics.OperationContext(ctx, "list_beneficiaries")).
 		Page(page).
 		PageSize(pageSize)
 

--- a/internal/connectors/plugins/public/generic/client/client.go
+++ b/internal/connectors/plugins/public/generic/client/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/formancehq/payments/genericclient"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -35,13 +34,12 @@ type client struct {
 	apiClient *genericclient.APIClient
 }
 
-func New(apiKey, baseURL string) Client {
-	transport := metrics.NewTransport(metrics.TransportOpts{
+func New(connectorName string, apiKey, baseURL string) Client {
+	transport := metrics.NewTransport(connectorName, metrics.TransportOpts{
 		Transport: &apiTransport{
 			APIKey:     apiKey,
 			underlying: otelhttp.NewTransport(http.DefaultTransport),
 		},
-		CommonMetricAttributesFn: CommonMetricsAttributes,
 	})
 
 	configuration := genericclient.NewConfiguration()
@@ -53,11 +51,4 @@ func New(apiKey, baseURL string) Client {
 	return &client{
 		apiClient: genericClient,
 	}
-}
-
-func CommonMetricsAttributes() []attribute.KeyValue {
-	metricsAttributes := []attribute.KeyValue{
-		attribute.String("connector", "generic"),
-	}
-	return metricsAttributes
 }

--- a/internal/connectors/plugins/public/generic/client/client.go
+++ b/internal/connectors/plugins/public/generic/client/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -33,40 +32,27 @@ func (t *apiTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type client struct {
-	apiClient              *genericclient.APIClient
-	commonMetricAttributes []attribute.KeyValue
+	apiClient *genericclient.APIClient
 }
 
 func New(apiKey, baseURL string) Client {
-	httpClient := &http.Client{
+	transport := metrics.NewTransport(metrics.TransportOpts{
 		Transport: &apiTransport{
 			APIKey:     apiKey,
 			underlying: otelhttp.NewTransport(http.DefaultTransport),
 		},
-	}
+		CommonMetricAttributesFn: CommonMetricsAttributes,
+	})
 
 	configuration := genericclient.NewConfiguration()
-	configuration.HTTPClient = httpClient
+	configuration.HTTPClient = &http.Client{Timeout: 5 * time.Second, Transport: transport}
 	configuration.Servers[0].URL = baseURL
 
 	genericClient := genericclient.NewAPIClient(configuration)
 
 	return &client{
-		apiClient:              genericClient,
-		commonMetricAttributes: CommonMetricsAttributes(),
+		apiClient: genericClient,
 	}
-}
-
-// recordMetrics is meant to be called in a defer
-func (c *client) recordMetrics(ctx context.Context, start time.Time, operation string) {
-	registry := metrics.GetMetricsRegistry()
-
-	attrs := c.commonMetricAttributes
-	attrs = append(attrs, attribute.String("operation", operation))
-	opts := metric.WithAttributes(attrs...)
-
-	registry.ConnectorPSPCalls().Add(ctx, 1, opts)
-	registry.ConnectorPSPCallLatencies().Record(ctx, time.Since(start).Milliseconds(), opts)
 }
 
 func CommonMetricsAttributes() []attribute.KeyValue {

--- a/internal/connectors/plugins/public/generic/client/client.go
+++ b/internal/connectors/plugins/public/generic/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/formancehq/payments/genericclient"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	"github.com/formancehq/payments/internal/models"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -43,7 +44,7 @@ func New(connectorName string, apiKey, baseURL string) Client {
 	})
 
 	configuration := genericclient.NewConfiguration()
-	configuration.HTTPClient = &http.Client{Timeout: 5 * time.Second, Transport: transport}
+	configuration.HTTPClient = &http.Client{Timeout: models.DefaultConnectorClientTimeout, Transport: transport}
 	configuration.Servers[0].URL = baseURL
 
 	genericClient := genericclient.NewAPIClient(configuration)

--- a/internal/connectors/plugins/public/generic/client/transactions.go
+++ b/internal/connectors/plugins/public/generic/client/transactions.go
@@ -5,13 +5,11 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/genericclient"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 func (c *client) ListTransactions(ctx context.Context, page, pageSize int64, updatedAtFrom time.Time) ([]genericclient.Transaction, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_transactions")
-
-	req := c.apiClient.DefaultApi.GetTransactions(ctx).
+	req := c.apiClient.DefaultApi.GetTransactions(metrics.OperationContext(ctx, "list_transactions")).
 		Page(page).
 		PageSize(pageSize)
 

--- a/internal/connectors/plugins/public/generic/plugin.go
+++ b/internal/connectors/plugins/public/generic/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "generic"
+
 func init() {
-	registry.RegisterPlugin("generic", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -28,7 +30,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(config.APIKey, config.Endpoint)
+	client := client.New(ProviderName, config.APIKey, config.Endpoint)
 
 	return &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/public/mangopay/client/bank_accounts.go
+++ b/internal/connectors/plugins/public/mangopay/client/bank_accounts.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type OwnerAddress struct {
@@ -33,7 +33,7 @@ type CreateIBANBankAccountRequest struct {
 }
 
 func (c *client) CreateIBANBankAccount(ctx context.Context, userID string, req *CreateIBANBankAccountRequest) (*BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_iban_bank_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_iban_bank_account")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts/iban", c.endpoint, c.clientID, userID)
 	return c.createBankAccount(ctx, endpoint, req)
@@ -49,7 +49,7 @@ type CreateUSBankAccountRequest struct {
 }
 
 func (c *client) CreateUSBankAccount(ctx context.Context, userID string, req *CreateUSBankAccountRequest) (*BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_us_bank_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_us_bank_account")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts/us", c.endpoint, c.clientID, userID)
 	return c.createBankAccount(ctx, endpoint, req)
@@ -66,7 +66,7 @@ type CreateCABankAccountRequest struct {
 }
 
 func (c *client) CreateCABankAccount(ctx context.Context, userID string, req *CreateCABankAccountRequest) (*BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_ca_bank_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_ca_bank_account")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts/ca", c.endpoint, c.clientID, userID)
 	return c.createBankAccount(ctx, endpoint, req)
@@ -81,7 +81,7 @@ type CreateGBBankAccountRequest struct {
 }
 
 func (c *client) CreateGBBankAccount(ctx context.Context, userID string, req *CreateGBBankAccountRequest) (*BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_gb_bank_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_gb_bank_account")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts/gb", c.endpoint, c.clientID, userID)
 	return c.createBankAccount(ctx, endpoint, req)
@@ -97,7 +97,7 @@ type CreateOtherBankAccountRequest struct {
 }
 
 func (c *client) CreateOtherBankAccount(ctx context.Context, userID string, req *CreateOtherBankAccountRequest) (*BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_other_bank_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_other_bank_account")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts/other", c.endpoint, c.clientID, userID)
 	return c.createBankAccount(ctx, endpoint, req)
@@ -130,7 +130,7 @@ type BankAccount struct {
 }
 
 func (c *client) GetBankAccounts(ctx context.Context, userID string, page, pageSize int) ([]BankAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_bank_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_bank_accounts")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/bankaccounts", c.endpoint, c.clientID, userID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/mangopay/client/client.go
+++ b/internal/connectors/plugins/public/mangopay/client/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -40,11 +41,11 @@ type client struct {
 	endpoint string
 }
 
-func New(clientID, apiKey, endpoint string) Client {
+func New(connectorName, clientID, apiKey, endpoint string) Client {
 	endpoint = strings.TrimSuffix(endpoint, "/")
 
 	config := &httpwrapper.Config{
-		CommonMetricsAttributes: httpwrapper.CommonMetricsAttributesFor("mangopay"),
+		Transport: metrics.NewTransport(connectorName, metrics.TransportOpts{}),
 		OAuthConfig: &clientcredentials.Config{
 			ClientID:     clientID,
 			ClientSecret: apiKey,

--- a/internal/connectors/plugins/public/mangopay/client/payin.go
+++ b/internal/connectors/plugins/public/mangopay/client/payin.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PayinResponse struct {
@@ -29,7 +29,7 @@ type PayinResponse struct {
 }
 
 func (c *client) GetPayin(ctx context.Context, payinID string) (*PayinResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payin")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payin")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/payins/%s", c.endpoint, c.clientID, payinID)
 

--- a/internal/connectors/plugins/public/mangopay/client/payout.go
+++ b/internal/connectors/plugins/public/mangopay/client/payout.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PayoutRequest struct {
@@ -45,7 +45,7 @@ type PayoutResponse struct {
 }
 
 func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutRequest) (*PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_payout")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/payouts/bankwire", c.endpoint, c.clientID)
 
@@ -70,7 +70,7 @@ func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutReques
 }
 
 func (c *client) GetPayout(ctx context.Context, payoutID string) (*PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payout")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/payouts/%s", c.endpoint, c.clientID, payoutID)
 

--- a/internal/connectors/plugins/public/mangopay/client/refund.go
+++ b/internal/connectors/plugins/public/mangopay/client/refund.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Refund struct {
@@ -30,7 +30,7 @@ type Refund struct {
 }
 
 func (c *client) GetRefund(ctx context.Context, refundID string) (*Refund, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_refund")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_refund")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/refunds/%s", c.endpoint, c.clientID, refundID)
 

--- a/internal/connectors/plugins/public/mangopay/client/transactions.go
+++ b/internal/connectors/plugins/public/mangopay/client/transactions.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Payment struct {
@@ -31,7 +31,7 @@ type Payment struct {
 }
 
 func (c *client) GetTransactions(ctx context.Context, walletsID string, page, pageSize int, afterCreatedAt time.Time) ([]Payment, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_transactions")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transactions")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/wallets/%s/transactions", c.endpoint, c.clientID, walletsID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/mangopay/client/transfer.go
+++ b/internal/connectors/plugins/public/mangopay/client/transfer.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Funds struct {
@@ -45,7 +45,7 @@ type TransferResponse struct {
 }
 
 func (c *client) InitiateWalletTransfer(ctx context.Context, transferRequest *TransferRequest) (*TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_transfer")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/transfers", c.endpoint, c.clientID)
 
@@ -72,7 +72,7 @@ func (c *client) InitiateWalletTransfer(ctx context.Context, transferRequest *Tr
 }
 
 func (c *client) GetWalletTransfer(ctx context.Context, transferID string) (TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_transfer")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/transfers/%s", c.endpoint, c.clientID, transferID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/mangopay/client/users.go
+++ b/internal/connectors/plugins/public/mangopay/client/users.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type User struct {
@@ -16,7 +16,7 @@ type User struct {
 }
 
 func (c *client) GetUsers(ctx context.Context, page int, pageSize int) ([]User, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_users")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_users")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users", c.endpoint, c.clientID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/mangopay/client/wallets.go
+++ b/internal/connectors/plugins/public/mangopay/client/wallets.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Wallet struct {
@@ -24,7 +24,7 @@ type Wallet struct {
 }
 
 func (c *client) GetWallets(ctx context.Context, userID string, page, pageSize int) ([]Wallet, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_wallets")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_wallets")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/users/%s/wallets", c.endpoint, c.clientID, userID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
@@ -48,7 +48,7 @@ func (c *client) GetWallets(ctx context.Context, userID string, page, pageSize i
 }
 
 func (c *client) GetWallet(ctx context.Context, walletID string) (*Wallet, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_wallet")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_wallet")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/wallets/%s", c.endpoint, c.clientID, walletID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/mangopay/client/webhooks.go
+++ b/internal/connectors/plugins/public/mangopay/client/webhooks.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v2/errorsutils"
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type EventType string
@@ -83,7 +83,7 @@ type Hook struct {
 }
 
 func (c *client) ListAllHooks(ctx context.Context) ([]*Hook, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_hooks")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_hooks")
 
 	endpoint := fmt.Sprintf("%s/v2.01/%s/hooks", c.endpoint, c.clientID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
@@ -111,7 +111,7 @@ type CreateHookRequest struct {
 }
 
 func (c *client) CreateHook(ctx context.Context, eventType EventType, URL string) error {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_hook")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_hook")
 
 	body, err := json.Marshal(&CreateHookRequest{
 		EventType: eventType,
@@ -142,7 +142,7 @@ type UpdateHookRequest struct {
 }
 
 func (c *client) UpdateHook(ctx context.Context, hookID string, URL string) error {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "update_hook")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "update_hook")
 
 	body, err := json.Marshal(&UpdateHookRequest{
 		URL:    URL,

--- a/internal/connectors/plugins/public/mangopay/plugin.go
+++ b/internal/connectors/plugins/public/mangopay/plugin.go
@@ -12,8 +12,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "mangopay"
+
 func init() {
-	registry.RegisterPlugin("mangopay", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -31,7 +33,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(config.ClientID, config.APIKey, config.Endpoint)
+	client := client.New(ProviderName, config.ClientID, config.APIKey, config.Endpoint)
 
 	p := &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/public/modulr/client/accounts.go
+++ b/internal/connectors/plugins/public/modulr/client/accounts.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 //nolint:tagliatelle // allow for clients
@@ -28,7 +28,7 @@ type Account struct {
 }
 
 func (c *client) GetAccounts(ctx context.Context, page, pageSize int, fromCreatedAt time.Time) ([]Account, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_accounts")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("accounts"), http.NoBody)
 	if err != nil {
@@ -55,7 +55,7 @@ func (c *client) GetAccounts(ctx context.Context, page, pageSize int, fromCreate
 }
 
 func (c *client) GetAccount(ctx context.Context, accountID string) (*Account, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_account")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_account")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("accounts/%s", accountID), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/modulr/client/beneficiaries.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Beneficiary struct {
@@ -17,7 +17,7 @@ type Beneficiary struct {
 }
 
 func (c *client) GetBeneficiaries(ctx context.Context, page, pageSize int, modifiedSince time.Time) ([]Beneficiary, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_beneficiaries")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_beneficiaries")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("beneficiaries"), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/client/payments.go
+++ b/internal/connectors/plugins/public/modulr/client/payments.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PaymentType string
@@ -39,7 +39,7 @@ type Payment struct {
 }
 
 func (c *client) GetPayments(ctx context.Context, paymentType PaymentType, page, pageSize int, modifiedSince time.Time) ([]Payment, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_payments")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_payments")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("payments"), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/client/payout.go
+++ b/internal/connectors/plugins/public/modulr/client/payout.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type PayoutRequest struct {
@@ -31,7 +31,7 @@ type PayoutResponse struct {
 }
 
 func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutRequest) (*PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_payout")
 
 	body, err := json.Marshal(payoutRequest)
 	if err != nil {
@@ -55,7 +55,7 @@ func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutReques
 }
 
 func (c *client) GetPayout(ctx context.Context, payoutID string) (PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payout")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("payments?id=%s", payoutID), nil)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/client/transactions.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 //nolint:tagliatelle // allow different styled tags in client
@@ -26,7 +26,7 @@ type Transaction struct {
 }
 
 func (c *client) GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate time.Time) ([]Transaction, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_transactions")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transactions")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("accounts/%s/transactions", accountID), http.NoBody)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/client/transfer.go
+++ b/internal/connectors/plugins/public/modulr/client/transfer.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type DestinationType string
@@ -54,7 +54,7 @@ type TransferResponse struct {
 }
 
 func (c *client) InitiateTransfer(ctx context.Context, transferRequest *TransferRequest) (*TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_transfer")
 
 	body, err := json.Marshal(transferRequest)
 	if err != nil {
@@ -78,7 +78,7 @@ func (c *client) InitiateTransfer(ctx context.Context, transferRequest *Transfer
 }
 
 func (c *client) GetTransfer(ctx context.Context, transferID string) (TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_transfer")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("payments?id=%s", transferID), nil)
 	if err != nil {

--- a/internal/connectors/plugins/public/modulr/plugin.go
+++ b/internal/connectors/plugins/public/modulr/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "modulr"
+
 func init() {
-	registry.RegisterPlugin("modulr", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -28,7 +30,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client, err := client.New(config.APIKey, config.APISecret, config.Endpoint)
+	client, err := client.New(ProviderName, config.APIKey, config.APISecret, config.Endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connectors/plugins/public/modulr/plugin_test.go
+++ b/internal/connectors/plugins/public/modulr/plugin_test.go
@@ -27,25 +27,25 @@ var _ = Describe("Modulr Plugin", func() {
 	Context("install", func() {
 		It("should report errors in config - apiSecret", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiKey": "test", "endpoint": "test"}`)
-			_, err := New("modulr", config)
+			_, err := New(ProviderName, config)
 			Expect(err).To(MatchError("missing api secret in config: invalid config"))
 		})
 
 		It("should report errors in config - apiKey", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "endpoint": "test"}`)
-			_, err := New("modulr", config)
+			_, err := New(ProviderName, config)
 			Expect(err).To(MatchError("missing api key in config: invalid config"))
 		})
 
 		It("should report errors in config - endpoint", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "apiKey": "test"}`)
-			_, err := New("modulr", config)
+			_, err := New(ProviderName, config)
 			Expect(err).To(MatchError("missing endpoint in config: invalid config"))
 		})
 
 		It("should return valid install response", func(ctx SpecContext) {
 			config := json.RawMessage(`{"apiSecret": "test", "apiKey": "test", "endpoint": "test"}`)
-			_, err := New("modulr", config)
+			_, err := New(ProviderName, config)
 			Expect(err).To(BeNil())
 			req := models.InstallRequest{}
 			res, err := plg.Install(ctx, req)

--- a/internal/connectors/plugins/public/moneycorp/client/accounts.go
+++ b/internal/connectors/plugins/public/moneycorp/client/accounts.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type accountsResponse struct {
@@ -21,7 +21,7 @@ type Account struct {
 }
 
 func (c *client) GetAccounts(ctx context.Context, page int, pageSize int) ([]*Account, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_accounts")
 
 	endpoint := fmt.Sprintf("%s/accounts", c.endpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/moneycorp/client/auth.go
+++ b/internal/connectors/plugins/public/moneycorp/client/auth.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -16,6 +17,8 @@ import (
 // is only accepting request with "application/json" content type, and the lib
 // sets it as application/x-www-form-urlencoded, giving us a 415 error.
 type apiTransport struct {
+	connectorName string
+
 	clientID string
 	apiKey   string
 	endpoint string
@@ -68,7 +71,7 @@ func (t *apiTransport) login(ctx context.Context) error {
 	}
 
 	config := &httpwrapper.Config{
-		CommonMetricsAttributes: httpwrapper.CommonMetricsAttributesFor("moneycorp"),
+		Transport: metrics.NewTransport(t.connectorName, metrics.TransportOpts{}),
 	}
 	httpClient := httpwrapper.NewClient(config)
 

--- a/internal/connectors/plugins/public/moneycorp/client/auth.go
+++ b/internal/connectors/plugins/public/moneycorp/client/auth.go
@@ -83,7 +83,7 @@ func (t *apiTransport) login(ctx context.Context) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "authenticate")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "authenticate")
 
 	var res loginResponse
 	var errRes moneycorpErrors

--- a/internal/connectors/plugins/public/moneycorp/client/balances.go
+++ b/internal/connectors/plugins/public/moneycorp/client/balances.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type balancesResponse struct {
@@ -28,7 +28,7 @@ type Attributes struct {
 }
 
 func (c *client) GetAccountBalances(ctx context.Context, accountID string) ([]*Balance, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_account_balances")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_account_balances")
 
 	endpoint := fmt.Sprintf("%s/accounts/%s/balances", c.endpoint, accountID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/moneycorp/client/payouts.go
+++ b/internal/connectors/plugins/public/moneycorp/client/payouts.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type payoutRequest struct {
@@ -61,7 +61,7 @@ type PayoutResponse struct {
 }
 
 func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*PayoutResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_payout")
 
 	endpoint := fmt.Sprintf("%s/accounts/%s/payments", c.endpoint, pr.SourceAccountID)
 

--- a/internal/connectors/plugins/public/moneycorp/client/recipients.go
+++ b/internal/connectors/plugins/public/moneycorp/client/recipients.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type recipientsResponse struct {
@@ -25,7 +25,7 @@ type RecipientAttributes struct {
 }
 
 func (c *client) GetRecipients(ctx context.Context, accountID string, page int, pageSize int) ([]*Recipient, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_recipients")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_recipients")
 
 	endpoint := fmt.Sprintf("%s/accounts/%s/recipients", c.endpoint, accountID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/moneycorp/client/transactions.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transactions.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type transactionsResponse struct {
@@ -53,7 +53,7 @@ type TransactionAttributes struct {
 }
 
 func (c *client) GetTransactions(ctx context.Context, accountID string, page, pageSize int, lastCreatedAt time.Time) ([]*Transaction, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_transactions")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transactions")
 
 	var body io.Reader
 	if !lastCreatedAt.IsZero() {

--- a/internal/connectors/plugins/public/moneycorp/client/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transfers.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type transferRequest struct {
@@ -52,7 +52,7 @@ type TransferResponse struct {
 }
 
 func (c *client) InitiateTransfer(ctx context.Context, tr *TransferRequest) (*TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_transfer")
 
 	endpoint := fmt.Sprintf("%s/accounts/%s/transfers", c.endpoint, tr.SourceAccountID)
 
@@ -81,7 +81,7 @@ func (c *client) InitiateTransfer(ctx context.Context, tr *TransferRequest) (*Tr
 }
 
 func (c *client) GetTransfer(ctx context.Context, accountID string, transferID string) (*TransferResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_transfer")
 
 	endpoint := fmt.Sprintf("%s/accounts/%s/transfers/%s", c.endpoint, accountID, transferID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)

--- a/internal/connectors/plugins/public/moneycorp/plugin.go
+++ b/internal/connectors/plugins/public/moneycorp/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "moneycorp"
+
 func init() {
-	registry.RegisterPlugin("moneycorp", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -28,7 +30,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(config.ClientID, config.APIKey, config.Endpoint)
+	client := client.New(ProviderName, config.ClientID, config.APIKey, config.Endpoint)
 
 	return &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/public/stripe/client/balances.go
+++ b/internal/connectors/plugins/public/stripe/client/balances.go
@@ -3,16 +3,13 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/stripe/stripe-go/v79"
 )
 
 func (c *client) GetAccountBalances(ctx context.Context, accountID string) (*stripe.Balance, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "list_balances")
-
-	var filters stripe.Params
+	filters := stripe.Params{Context: metrics.OperationContext(ctx, "list_balances")}
 	if accountID != "" {
 		filters.StripeAccount = &accountID
 	}

--- a/internal/connectors/plugins/public/stripe/client/client.go
+++ b/internal/connectors/plugins/public/stripe/client/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	"github.com/formancehq/payments/internal/models"
 	"github.com/stripe/stripe-go/v79"
 	"github.com/stripe/stripe-go/v79/account"
 	"github.com/stripe/stripe-go/v79/balance"
@@ -14,7 +15,6 @@ import (
 	"github.com/stripe/stripe-go/v79/payout"
 	"github.com/stripe/stripe-go/v79/transfer"
 	"github.com/stripe/stripe-go/v79/transferreversal"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -38,9 +38,9 @@ type client struct {
 	balanceTransactionClient balancetransaction.Client
 }
 
-func New(backend stripe.Backend, apiKey string) Client {
+func New(name string, backend stripe.Backend, apiKey string) Client {
 	if backend == nil {
-		backends := stripe.NewBackends(metrics.NewHTTPClient(CommonMetricsAttributes))
+		backends := stripe.NewBackends(metrics.NewHTTPClient(name, models.DefaultConnectorClientTimeout))
 		backend = backends.API
 	}
 
@@ -77,11 +77,4 @@ func wrapSDKErr(err error) error {
 
 	}
 	return err
-}
-
-func CommonMetricsAttributes() []attribute.KeyValue {
-	metricsAttributes := []attribute.KeyValue{
-		attribute.String("connector", "stripe"),
-	}
-	return metricsAttributes
 }

--- a/internal/connectors/plugins/public/stripe/client/client.go
+++ b/internal/connectors/plugins/public/stripe/client/client.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"time"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
@@ -42,14 +40,7 @@ type client struct {
 
 func New(backend stripe.Backend, apiKey string) Client {
 	if backend == nil {
-		opts := metrics.TransportOpts{
-			CommonMetricAttributesFn: CommonMetricsAttributes,
-		}
-
-		backends := stripe.NewBackends(&http.Client{
-			Timeout:   10 * time.Second,
-			Transport: metrics.NewTransport(opts),
-		})
+		backends := stripe.NewBackends(metrics.NewHTTPClient(CommonMetricsAttributes))
 		backend = backends.API
 	}
 

--- a/internal/connectors/plugins/public/stripe/client/payouts.go
+++ b/internal/connectors/plugins/public/stripe/client/payouts.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/stripe/stripe-go/v79"
 	"github.com/stripe/stripe-go/v79/payout"
 )
@@ -19,12 +19,9 @@ type CreatePayoutRequest struct {
 }
 
 func (c *client) CreatePayout(ctx context.Context, createPayoutRequest *CreatePayoutRequest) (*stripe.Payout, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "initiate_payout")
-
 	params := &stripe.PayoutParams{
 		Params: stripe.Params{
-			Context:       ctx,
+			Context:       metrics.OperationContext(ctx, "initiate_payout"),
 			StripeAccount: createPayoutRequest.Source,
 		},
 		Amount:      stripe.Int64(createPayoutRequest.Amount),

--- a/internal/connectors/plugins/public/stripe/client/reversals.go
+++ b/internal/connectors/plugins/public/stripe/client/reversals.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/stripe/stripe-go/v79"
 )
 
@@ -17,12 +17,9 @@ type ReverseTransferRequest struct {
 }
 
 func (c *client) ReverseTransfer(ctx context.Context, reverseTransferRequest ReverseTransferRequest) (*stripe.TransferReversal, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "reverse_transfer")
-
 	params := &stripe.TransferReversalParams{
 		Params: stripe.Params{
-			Context:       ctx,
+			Context:       metrics.OperationContext(ctx, "reverse_transfer"),
 			StripeAccount: reverseTransferRequest.Account,
 		},
 		ID:          stripe.String(reverseTransferRequest.StripeTransferID),

--- a/internal/connectors/plugins/public/stripe/client/transfers.go
+++ b/internal/connectors/plugins/public/stripe/client/transfers.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"context"
-	"time"
 
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/stripe/stripe-go/v79"
 )
 
@@ -18,12 +18,9 @@ type CreateTransferRequest struct {
 }
 
 func (c *client) CreateTransfer(ctx context.Context, createTransferRequest *CreateTransferRequest) (*stripe.Transfer, error) {
-	start := time.Now()
-	defer c.recordMetrics(ctx, start, "initiate_transfer")
-
 	params := &stripe.TransferParams{
 		Params: stripe.Params{
-			Context:       ctx,
+			Context:       metrics.OperationContext(ctx, "initiate_transfer"),
 			StripeAccount: createTransferRequest.Source,
 		},
 		Amount:      stripe.Int64(createTransferRequest.Amount),

--- a/internal/connectors/plugins/public/stripe/plugin.go
+++ b/internal/connectors/plugins/public/stripe/plugin.go
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "stripe"
+
 func init() {
-	registry.RegisterPlugin("stripe", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -27,7 +29,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(nil, config.APIKey)
+	client := client.New(ProviderName, nil, config.APIKey)
 
 	return &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/public/wise/client/balances.go
+++ b/internal/connectors/plugins/public/wise/client/balances.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type BalanceAmount struct {
@@ -39,7 +39,7 @@ type Balance struct {
 }
 
 func (c *client) GetBalances(ctx context.Context, profileID uint64) ([]Balance, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_balances")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_balances")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint(fmt.Sprintf("v4/profiles/%d/balances?types=STANDARD", profileID)), http.NoBody)
@@ -57,7 +57,7 @@ func (c *client) GetBalances(ctx context.Context, profileID uint64) ([]Balance, 
 }
 
 func (c *client) GetBalance(ctx context.Context, profileID uint64, balanceID uint64) (*Balance, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_balance")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_balance")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint(fmt.Sprintf("v4/profiles/%d/balances/%d", profileID, balanceID)), http.NoBody)

--- a/internal/connectors/plugins/public/wise/client/payouts.go
+++ b/internal/connectors/plugins/public/wise/client/payouts.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Payout struct {
@@ -62,7 +62,7 @@ func (t *Payout) UnmarshalJSON(data []byte) error {
 }
 
 func (c *client) GetPayout(ctx context.Context, payoutID string) (*Payout, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_payout")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint("v1/transfers/"+payoutID), http.NoBody)
@@ -80,7 +80,7 @@ func (c *client) GetPayout(ctx context.Context, payoutID string) (*Payout, error
 }
 
 func (c *client) CreatePayout(ctx context.Context, quote Quote, targetAccount uint64, transactionID string) (*Payout, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_payout")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_payout")
 
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"targetAccount":         targetAccount,

--- a/internal/connectors/plugins/public/wise/client/profiles.go
+++ b/internal/connectors/plugins/public/wise/client/profiles.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Profile struct {
@@ -14,7 +14,7 @@ type Profile struct {
 }
 
 func (c *client) GetProfiles(ctx context.Context) ([]Profile, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_profiles")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_profiles")
 
 	var profiles []Profile
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint("v2/profiles"), http.NoBody)

--- a/internal/connectors/plugins/public/wise/client/quotes.go
+++ b/internal/connectors/plugins/public/wise/client/quotes.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/google/uuid"
 )
 
@@ -16,7 +16,7 @@ type Quote struct {
 }
 
 func (c *client) CreateQuote(ctx context.Context, profileID, currency string, amount json.Number) (Quote, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "create_quote")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "create_quote")
 
 	var quote Quote
 

--- a/internal/connectors/plugins/public/wise/client/recipient_accounts.go
+++ b/internal/connectors/plugins/public/wise/client/recipient_accounts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type RecipientAccountsResponse struct {
@@ -27,7 +27,7 @@ type RecipientAccount struct {
 }
 
 func (c *client) GetRecipientAccounts(ctx context.Context, profileID uint64, pageSize int, seekPositionForNext uint64) (*RecipientAccountsResponse, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_recipient_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_recipient_accounts")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint("v2/accounts"), http.NoBody)
@@ -54,7 +54,7 @@ func (c *client) GetRecipientAccounts(ctx context.Context, profileID uint64, pag
 }
 
 func (c *client) GetRecipientAccount(ctx context.Context, accountID uint64) (*RecipientAccount, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_recipient_accounts")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_recipient_accounts")
 
 	c.mux.Lock()
 	defer c.mux.Unlock()

--- a/internal/connectors/plugins/public/wise/client/transfers.go
+++ b/internal/connectors/plugins/public/wise/client/transfers.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+	"github.com/formancehq/payments/internal/connectors/metrics"
 )
 
 type Transfer struct {
@@ -62,7 +62,7 @@ func (t *Transfer) UnmarshalJSON(data []byte) error {
 }
 
 func (c *client) GetTransfers(ctx context.Context, profileID uint64, offset int, limit int) ([]Transfer, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "list_transfers")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transfers")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint("v1/transfers"), http.NoBody)
@@ -156,7 +156,7 @@ func (c *client) GetTransfers(ctx context.Context, profileID uint64, offset int,
 }
 
 func (c *client) GetTransfer(ctx context.Context, transferID string) (*Transfer, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "get_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "get_transfer")
 
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, c.endpoint("v1/transfers/"+transferID), http.NoBody)
@@ -174,7 +174,7 @@ func (c *client) GetTransfer(ctx context.Context, transferID string) (*Transfer,
 }
 
 func (c *client) CreateTransfer(ctx context.Context, quote Quote, targetAccount uint64, transactionID string) (*Transfer, error) {
-	ctx = context.WithValue(ctx, httpwrapper.MetricOperationContextKey, "initiate_transfer")
+	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_transfer")
 
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"targetAccount":         targetAccount,

--- a/internal/connectors/plugins/public/wise/plugin.go
+++ b/internal/connectors/plugins/public/wise/plugin.go
@@ -11,8 +11,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "wise"
+
 func init() {
-	registry.RegisterPlugin("wise", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }
@@ -42,7 +44,7 @@ func New(name string, rawConfig json.RawMessage) (*Plugin, error) {
 		return nil, err
 	}
 
-	client := client.New(config.APIKey)
+	client := client.New(ProviderName, config.APIKey)
 
 	p := &Plugin{
 		name:   name,

--- a/internal/connectors/plugins/registry/plugins.go
+++ b/internal/connectors/plugins/registry/plugins.go
@@ -22,8 +22,8 @@ var (
 	ErrPluginNotFound = errors.New("plugin not found")
 )
 
-func RegisterPlugin(name string, createFunc PluginCreateFunction, capabilities []models.Capability) {
-	pluginsRegistry[name] = PluginInformation{
+func RegisterPlugin(provider string, createFunc PluginCreateFunction, capabilities []models.Capability) {
+	pluginsRegistry[provider] = PluginInformation{
 		capabilities: capabilities,
 		createFunc:   createFunc,
 	}

--- a/internal/models/plugin.go
+++ b/internal/models/plugin.go
@@ -3,7 +3,10 @@ package models
 import (
 	"context"
 	"encoding/json"
+	"time"
 )
+
+const DefaultConnectorClientTimeout = 3 * time.Second
 
 type PluginConstructorFn func() Plugin
 

--- a/tools/connector-template/template/client/client.gotpl
+++ b/tools/connector-template/template/client/client.gotpl
@@ -25,13 +25,10 @@ type client struct {
 
 func New(/* TODO: fill config parameters */) *client {
 	config := &httpwrapper.Config{
-		CommonMetricsAttributes: httpwrapper.CommonMetricsAttributesFor("{{ .Connector }}"),
-		// TODO: you can use your own http transport for auth for example
-		//Transport: &apiTransport{
-		//	underlying: otelhttp.NewTransport(http.DefaultTransport),
-		//},
-		// TODO: you can also use your own http error checker to send the right
-		// error for your PSP
+		// TODO: you can set an underlying http transport in metrics.TransportOpts for authentication for example
+		Transport: metrics.NewTransport("{{ .Connector }}", metrics.TransportOpts{}),
+		// TODO: if the PSP requires special http status code handling, you can override the default handling by setting a
+		// custom HttpErrorCheckerFn like below
 		// HttpErrorCheckerFn: func(statusCode int) error {
 		// 	if statusCode == http.StatusNotFound {
 		// 		return nil

--- a/tools/connector-template/template/plugin.gotpl
+++ b/tools/connector-template/template/plugin.gotpl
@@ -10,8 +10,10 @@ import (
 	"github.com/formancehq/payments/internal/models"
 )
 
+const ProviderName = "{{ .Connector }}"
+
 func init() {
-	registry.RegisterPlugin("{{ .Connector }}", func(name string, rm json.RawMessage) (models.Plugin, error) {
+	registry.RegisterPlugin(ProviderName, func(name string, rm json.RawMessage) (models.Plugin, error) {
 		return New(name, rm)
 	}, capabilities)
 }


### PR DESCRIPTION
fixes: ENG-1579

metrics samples from connectors using SDKs now have correct http status code and endpoint tags, which makes them consistent with those using httpwrapper
```
Descriptor:
     -> Name: payments_connectors_psp_calls_latencies
     -> Description: payments connectors psp calls latencies
     -> Unit: ms
     -> DataType: Histogram
     -> AggregationTemporality: Cumulative
HistogramDataPoints #0
Data point attributes:
     -> connector: Str(stripe)
     -> endpoint: Str(/v1/balance_transactions)
     -> operation: Str(list_transactions)
     -> status: Int(200)
```