### PR TITLE
fix(api): fix missing currency for v2 balances endpoint

### DIFF
--- a/internal/api/v2/handler_accounts_balances.go
+++ b/internal/api/v2/handler_accounts_balances.go
@@ -21,6 +21,7 @@ type balancesResponse struct {
 	AccountID     string    `json:"accountId"`
 	CreatedAt     time.Time `json:"createdAt"`
 	LastUpdatedAt time.Time `json:"lastUpdatedAt"`
+	Currency      string    `json:"currency"`
 	Asset         string    `json:"asset"`
 	Balance       *big.Int  `json:"balance"`
 }
@@ -64,6 +65,7 @@ func accountsBalances(backend backend.Backend) http.HandlerFunc {
 			data[i] = &balancesResponse{
 				AccountID:     ret[i].AccountID.String(),
 				CreatedAt:     ret[i].CreatedAt,
+				Currency:      ret[i].Asset,
 				Asset:         ret[i].Asset,
 				Balance:       ret[i].Balance,
 				LastUpdatedAt: ret[i].LastUpdatedAt,


### PR DESCRIPTION
Even if it's deprecated in the openapi.yml, we still need to support it for the time being