### PR TITLE
fix(v2): related accounts should not be empty for v2

### DIFF
--- a/internal/api/v2/handler_bank_accounts_create.go
+++ b/internal/api/v2/handler_bank_accounts_create.go
@@ -35,7 +35,7 @@ type BankAccountResponse struct {
 	AccountNumber   string                                `json:"accountNumber,omitempty"`
 	SwiftBicCode    string                                `json:"swiftBicCode,omitempty"`
 	Metadata        map[string]string                     `json:"metadata,omitempty"`
-	RelatedAccounts []*bankAccountRelatedAccountsResponse `json:"relatedAccounts,omitempty"`
+	RelatedAccounts []*bankAccountRelatedAccountsResponse `json:"relatedAccounts"`
 }
 
 type BankAccountsCreateRequest struct {


### PR DESCRIPTION
To keep the retrocompatibility, related accounts should not be empty