### PR TITLE
fix(temporal): fix schedule already running error

### DIFF
--- a/internal/connectors/engine/activities/temporal_schedule_create.go
+++ b/internal/connectors/engine/activities/temporal_schedule_create.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.temporal.io/api/enums/v1"
@@ -46,6 +47,10 @@ func (a Activities) TemporalScheduleCreate(ctx context.Context, options Schedule
 		SearchAttributes:   options.SearchAttributes,
 	})
 	if err != nil {
+		if errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+			// No need to do anything if schedule is already running
+			return nil
+		}
 		return err
 	}
 

--- a/internal/connectors/engine/activities/temporal_schedule_create_test.go
+++ b/internal/connectors/engine/activities/temporal_schedule_create_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	enums "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -84,6 +85,19 @@ var _ = Describe("Temporal Schedule Creation", func() {
 		sc.EXPECT().Create(ctx, gomock.Any()).Return(nil, expectedErr)
 		err := act.TemporalScheduleCreate(ctx, createOpts)
 		Expect(err).NotTo(BeNil())
+	})
+
+	It("returns no error when schedule is already running", func(ctx SpecContext) {
+		t.EXPECT().ScheduleClient().Return(sc)
+
+		createOpts := activities.ScheduleCreateOptions{
+			ScheduleID: scheduleID,
+		}
+
+		expectedErr := fmt.Errorf("%w, some error", temporal.ErrScheduleAlreadyRunning)
+		sc.EXPECT().Create(ctx, gomock.Any()).Return(nil, expectedErr)
+		err := act.TemporalScheduleCreate(ctx, createOpts)
+		Expect(err).To(BeNil())
 	})
 
 	It("forwards expected create options to temporal", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/atlar/workflow.go
+++ b/internal/connectors/plugins/public/atlar/workflow.go
@@ -19,11 +19,11 @@ func workflow() models.ConnectorTasksTree {
 			},
 		},
 		{
-			TaskType:  models.TASK_FETCH_PAYMENTS,
-			Name:      "fetch_payments",
-			NextTasks: []models.ConnectorTaskTree{},
+			TaskType:     models.TASK_FETCH_PAYMENTS,
+			Name:         "fetch_payments",
+			Periodically: true,
+			NextTasks:    []models.ConnectorTaskTree{},
 		},
-
 		{
 			TaskType:     models.TASK_FETCH_EXTERNAL_ACCOUNTS,
 			Name:         "fetch_external_accounts",


### PR DESCRIPTION
Needed for the Atlar connector because we fetch everything at every polling (since Atlar does not provide a good pagination api)