### PR TITLE
fix(temporal): fix already started run workflow

### DIFF
--- a/internal/connectors/engine/workflow/install_connector.go
+++ b/internal/connectors/engine/workflow/install_connector.go
@@ -98,11 +98,8 @@ func (w Workflow) installConnector(
 		nil,
 		[]models.ConnectorTaskTree(installResponse.Workflow),
 	).GetChildWorkflowExecution().Get(ctx, nil); err != nil {
-		applicationError := &temporal.ApplicationError{}
-		if errors.As(err, &applicationError) {
-			if applicationError.Type() != "ChildWorkflowExecutionAlreadyStartedError" {
-				return err
-			}
+		if temporal.IsWorkflowExecutionAlreadyStartedError(err) {
+			return nil
 		} else {
 			return errors.Wrap(err, "running next workflow")
 		}

--- a/internal/connectors/engine/workflow/install_connector_test.go
+++ b/internal/connectors/engine/workflow/install_connector_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/stretchr/testify/mock"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/temporal"
 )
 
@@ -177,6 +178,34 @@ func (s *UnitTestSuite) Test_InstallConnector_Run_Error() {
 	s.env.OnActivity(activities.StorageWebhooksConfigsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
 		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test-error")),
+	)
+
+	s.env.ExecuteWorkflow(RunInstallConnector, InstallConnector{
+		ConnectorID: s.connectorID,
+		Config:      models.DefaultConfig(),
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+	err := s.env.GetWorkflowError()
+	// We only check that the workflow has started, we don't check if it has completed
+	// without error
+	s.NoError(err)
+}
+
+func (s *UnitTestSuite) Test_InstallConnector_Run_ErrorAlreadyStarted() {
+	s.env.OnActivity(activities.PluginInstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(&models.InstallResponse{
+		Workflow: []models.ConnectorTaskTree{},
+		WebhooksConfigs: []models.PSPWebhookConfig{
+			{
+				Name:    "test",
+				URLPath: "/test",
+			},
+		},
+	}, nil)
+	s.env.OnActivity(activities.StorageConnectorTasksTreeStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
+	s.env.OnActivity(activities.StorageWebhooksConfigsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
+	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
+		serviceerror.NewWorkflowExecutionAlreadyStarted("test", "test", "test"),
 	)
 
 	s.env.ExecuteWorkflow(RunInstallConnector, InstallConnector{


### PR DESCRIPTION
When pod is restarting, the install method is called again but failed since the child workflow run is already started, leading to the connector being dropped.