### PR TITLE
fix(balances): return empty list balances response instead of nil

### DIFF
--- a/internal/storage/balances.go
+++ b/internal/storage/balances.go
@@ -298,7 +298,7 @@ func fromBalanceModels(from models.Balance) balance {
 }
 
 func toBalancesModels(from []balance) []models.Balance {
-	var to []models.Balance
+	to := make([]models.Balance, 0, len(from))
 	for _, b := range from {
 		to = append(to, toBalanceModels(b))
 	}

--- a/internal/storage/balances_test.go
+++ b/internal/storage/balances_test.go
@@ -260,6 +260,25 @@ func TestBalancesUpsert(t *testing.T) {
 		require.Len(t, cursor.Data, 3)
 		require.Equal(t, expectedBalances, cursor.Data)
 	})
+
+	t.Run("no balances available", func(t *testing.T) {
+		accountID := models.AccountID{
+			Reference:   "12324343abc",
+			ConnectorID: defaultConnector.ID,
+		}
+
+		q := NewListBalancesQuery(
+			bunpaginate.NewPaginatedQueryOptions(BalanceQuery{
+				AccountID: pointer.For(accountID),
+			}).WithPageSize(15),
+		)
+
+		expectedBalances := []models.Balance{}
+		cursor, err := store.BalancesList(ctx, q)
+		require.NoError(t, err)
+		require.Len(t, cursor.Data, 0)
+		require.Equal(t, expectedBalances, cursor.Data)
+	})
 }
 
 func TestBalancesDeleteFromConnectorID(t *testing.T) {


### PR DESCRIPTION
balance endpoint now returns when there's no balance data for the account

```
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 27 Jan 2025 13:00:07 GMT
Content-Length: 53

{"cursor":{"pageSize":15,"hasMore":false,"data":[]}}
```