### PR TITLE
fix(storage): fix payment list sorting

### DIFF
--- a/internal/storage/payments.go
+++ b/internal/storage/payments.go
@@ -329,7 +329,7 @@ func (s *store) PaymentsList(ctx context.Context, q ListPaymentsQuery) (*bunpagi
 				select status
 				from payment_adjustments apd
 				where payment_id = payment.id
-				order by created_at desc
+				order by created_at desc, sort_id desc
 				limit 1
 			) apd on true`)
 


### PR DESCRIPTION
Mor modulr, when we create a transfer/payout, we will have the same date for pending/succeeded transaction, so the only thing differenciating the two is the sort_id we added. That way, we can have the last status in the main payment