### PR TITLE
fix(paymentinitiations): fix created at sent to the workflow

### DIFF
--- a/internal/models/payment_initiations.go
+++ b/internal/models/payment_initiations.go
@@ -170,9 +170,13 @@ func (pi *PaymentInitiation) UnmarshalJSON(data []byte) error {
 }
 
 func FromPaymentInitiationToPSPPaymentInitiation(from *PaymentInitiation, sourceAccount, destinationAccount *PSPAccount) PSPPaymentInitiation {
+	createdAt := from.CreatedAt
+	if !from.ScheduledAt.IsZero() {
+		createdAt = from.ScheduledAt // Scheduled at should be the creation time of the payment on the PSP
+	}
 	return PSPPaymentInitiation{
 		Reference:          from.Reference,
-		CreatedAt:          from.ScheduledAt, // Scheduled at should be the creation time of the payment on the PSP
+		CreatedAt:          createdAt,
 		Description:        from.Description,
 		SourceAccount:      sourceAccount,
 		DestinationAccount: destinationAccount,


### PR DESCRIPTION
If scheduleAt is empty, we have to take the createdAt