### PR TITLE
fix(stripe): fix issues when making payouts and transfers using root account

### DIFF
--- a/internal/connectors/plugins/public/stripe/client/payouts.go
+++ b/internal/connectors/plugins/public/stripe/client/payouts.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/stripe/stripe-go/v79"
-	"github.com/stripe/stripe-go/v79/payout"
 )
 
 type CreatePayoutRequest struct {
@@ -41,7 +40,7 @@ func (c *client) CreatePayout(ctx context.Context, createPayoutRequest *CreatePa
 		params.Description = stripe.String(createPayoutRequest.Description)
 	}
 
-	payoutResponse, err := payout.New(params)
+	payoutResponse, err := c.payoutClient.New(params)
 	if err != nil {
 		return nil, wrapSDKErr(err)
 	}

--- a/internal/models/accounts.go
+++ b/internal/models/accounts.go
@@ -150,6 +150,9 @@ func FromPSPAccounts(from []PSPAccount, accountType AccountType, connectorID Con
 }
 
 func ToPSPAccount(from *Account) *PSPAccount {
+	if from == nil {
+		return nil
+	}
 	return &PSPAccount{
 		Reference:    from.Reference,
 		CreatedAt:    from.CreatedAt,

--- a/internal/models/accounts_test.go
+++ b/internal/models/accounts_test.go
@@ -1,0 +1,12 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToPSPAccount(t *testing.T) {
+	assert.Nil(t, ToPSPAccount(nil))
+	assert.NotNil(t, ToPSPAccount(&Account{}))
+}


### PR DESCRIPTION
issue 1: payouts were made using an unauthenticated client
issue 2: when using an implied root account the conversion to PSPAccount panicked