### PR TITLE
feat(validation): Use validation library in API payments initiation endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/google/go-cmp v0.6.0
@@ -113,8 +115,6 @@ require (
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/internal/api/v2/handler_test.go
+++ b/internal/api/v2/handler_test.go
@@ -27,7 +27,7 @@ func assertExpectedResponse(res *http.Response, expectedStatusCode int, expected
 
 	data, err := ioutil.ReadAll(res.Body)
 	Expect(err).To(BeNil())
-	Expect(data).To(ContainSubstring(expectedBodyString))
+	Expect(string(data)).To(ContainSubstring(expectedBodyString))
 }
 
 func prepareJSONRequest(method string, a any) *http.Request {

--- a/internal/api/v2/handler_transfer_initiations_create.go
+++ b/internal/api/v2/handler_transfer_initiations_create.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"encoding/json"
-	"errors"
 	"math/big"
 	"net/http"
 	"time"
@@ -10,63 +9,30 @@ import (
 	"github.com/formancehq/go-libs/v2/api"
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type CreateTransferInitiationRequest struct {
-	Reference            string            `json:"reference"`
-	ScheduledAt          time.Time         `json:"scheduledAt"`
-	Description          string            `json:"description"`
-	SourceAccountID      string            `json:"sourceAccountID"`
-	DestinationAccountID string            `json:"destinationAccountID"`
-	ConnectorID          string            `json:"connectorID"`
-	Provider             string            `json:"provider"`
-	Type                 string            `json:"type"`
-	Amount               *big.Int          `json:"amount"`
-	Asset                string            `json:"asset"`
-	Validated            bool              `json:"validated"`
-	Metadata             map[string]string `json:"metadata"`
+	Reference            string            `json:"reference" validate:"required"`
+	ScheduledAt          time.Time         `json:"scheduledAt" validate:""`
+	Description          string            `json:"description" validate:""`
+	SourceAccountID      string            `json:"sourceAccountID" validate:"omitempty,accountID"`
+	DestinationAccountID string            `json:"destinationAccountID" validate:"required,accountID"`
+	ConnectorID          string            `json:"connectorID" validate:"required,connectorID"`
+	Provider             string            `json:"provider" validate:""`
+	Type                 string            `json:"type" validate:"required,paymentInitiationType"`
+	Amount               *big.Int          `json:"amount" validate:"required"`
+	Asset                string            `json:"asset" validate:"required,asset"`
+	Validated            bool              `json:"validated" validate:""`
+	Metadata             map[string]string `json:"metadata" validate:""`
 }
 
-func (r *CreateTransferInitiationRequest) Validate() error {
-	if r.Reference == "" {
-		return errors.New("reference is required")
-	}
-
-	if r.SourceAccountID != "" {
-		_, err := models.AccountIDFromString(r.SourceAccountID)
-		if err != nil {
-			return err
-		}
-	}
-
-	if r.DestinationAccountID != "" {
-		_, err := models.AccountIDFromString(r.DestinationAccountID)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err := models.PaymentInitiationTypeFromString(r.Type)
-	if err != nil {
-		return err
-	}
-
-	if r.Amount == nil {
-		return errors.New("amount is required")
-	}
-
-	if r.Asset == "" {
-		return errors.New("asset is required")
-	}
-
-	return nil
-}
-
-func transferInitiationsCreate(backend backend.Backend) http.HandlerFunc {
+func transferInitiationsCreate(backend backend.Backend, validate *validator.Validate) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := otel.Tracer().Start(r.Context(), "v2_transferInitiationsCreate")
 		defer span.End()
@@ -80,9 +46,9 @@ func transferInitiationsCreate(backend backend.Backend) http.HandlerFunc {
 
 		setSpanAttributesFromRequest(span, payload)
 
-		if err := payload.Validate(); err != nil {
+		if err := validate.Struct(payload); err != nil {
 			otel.RecordError(span, err)
-			api.BadRequest(w, ErrValidation, err)
+			validation.WrapError(w, ErrValidation, err)
 			return
 		}
 

--- a/internal/api/v2/handler_transfer_initiations_create_test.go
+++ b/internal/api/v2/handler_transfer_initiations_create_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
-	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
@@ -18,7 +17,7 @@ import (
 var _ = Describe("API v2 Payment Initiation Creation", func() {
 	var (
 		handlerFn http.HandlerFunc
-		validate  *validator.Validate
+		validate  *validation.Validator
 		connID    models.ConnectorID
 		source    models.AccountID
 		dest      models.AccountID

--- a/internal/api/v2/handler_transfer_initiations_create_test.go
+++ b/internal/api/v2/handler_transfer_initiations_create_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
@@ -16,6 +18,7 @@ import (
 var _ = Describe("API v2 Payment Initiation Creation", func() {
 	var (
 		handlerFn http.HandlerFunc
+		validate  *validator.Validate
 		connID    models.ConnectorID
 		source    models.AccountID
 		dest      models.AccountID
@@ -23,6 +26,8 @@ var _ = Describe("API v2 Payment Initiation Creation", func() {
 		destID    string
 	)
 	BeforeEach(func() {
+		validate = validation.NewValidator()
+
 		connID = models.ConnectorID{Reference: uuid.New(), Provider: "psp"}
 		source = models.AccountID{Reference: uuid.New().String(), ConnectorID: connID}
 		dest = models.AccountID{Reference: uuid.New().String(), ConnectorID: connID}
@@ -40,7 +45,7 @@ var _ = Describe("API v2 Payment Initiation Creation", func() {
 			w = httptest.NewRecorder()
 			ctrl := gomock.NewController(GinkgoT())
 			m = backend.NewMockBackend(ctrl)
-			handlerFn = transferInitiationsCreate(m)
+			handlerFn = transferInitiationsCreate(m, validate)
 		})
 
 		It("should return a bad request error when body is missing", func(ctx SpecContext) {
@@ -75,7 +80,7 @@ var _ = Describe("API v2 Payment Initiation Creation", func() {
 				DestinationAccountID: destID,
 				Type:                 "TRANSFER",
 				Amount:               big.NewInt(144),
-				Asset:                "EUR",
+				Asset:                "EUR/2",
 			}
 			handlerFn(w, prepareJSONRequest(http.MethodPost, &picr))
 			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
@@ -97,7 +102,7 @@ var _ = Describe("API v2 Payment Initiation Creation", func() {
 				DestinationAccountID: destID,
 				Type:                 "TRANSFER",
 				Amount:               big.NewInt(2144),
-				Asset:                "EUR",
+				Asset:                "EUR/2",
 			}
 			handlerFn(w, prepareJSONRequest(http.MethodPost, &picr))
 			assertExpectedResponse(w.Result(), http.StatusOK, "data")

--- a/internal/api/v2/handler_transfer_initiations_reverse_test.go
+++ b/internal/api/v2/handler_transfer_initiations_reverse_test.go
@@ -7,13 +7,14 @@ import (
 	"net/http/httptest"
 
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
 )
 
-var _ = Describe("API v2 Payment Initiation Reverse", func() {
+var _ = Describe("API v2 Transfer Initiation Reversal", func() {
 	var (
 		handlerFn http.HandlerFunc
 		paymentID models.PaymentInitiationID
@@ -23,7 +24,7 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 		paymentID = models.PaymentInitiationID{Reference: "ref", ConnectorID: connID}
 	})
 
-	Context("retry payment initiation", func() {
+	Context("reverse transfer initiation", func() {
 		var (
 			w *httptest.ResponseRecorder
 			m *backend.MockBackend
@@ -32,7 +33,7 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 			w = httptest.NewRecorder()
 			ctrl := gomock.NewController(GinkgoT())
 			m = backend.NewMockBackend(ctrl)
-			handlerFn = transferInitiationsReverse(m)
+			handlerFn = transferInitiationsReverse(m, validation.NewValidator())
 		})
 
 		It("should return a bad request error when transferInitiationID is invalid", func(ctx SpecContext) {
@@ -65,9 +66,9 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 				expectedErr,
 			)
 			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "transferInitiationID", paymentID.String(), &reverseTransferInitiationRequest{
-				Reference: "ref",
+				Reference: "ref1",
 				Amount:    big.NewInt(1313),
-				Asset:     "USD",
+				Asset:     "USD/2",
 			}))
 			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
 		})
@@ -78,9 +79,9 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 				nil,
 			)
 			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "transferInitiationID", paymentID.String(), &reverseTransferInitiationRequest{
-				Reference: "ref",
+				Reference: "ref1",
 				Amount:    big.NewInt(1313),
-				Asset:     "USD",
+				Asset:     "USD/2",
 			}))
 			assertExpectedResponse(w.Result(), http.StatusNoContent, "")
 		})

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -102,7 +102,7 @@ func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticat
 
 					r.Post("/status", transferInitiationsUpdateStatus(backend))
 					r.Post("/retry", transferInitiationsRetry(backend))
-					r.Post("/reverse", transferInitiationsReverse(backend))
+					r.Post("/reverse", transferInitiationsReverse(backend, validator))
 				})
 			})
 		})

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -7,11 +7,13 @@ import (
 	"github.com/formancehq/go-libs/v2/auth"
 	"github.com/formancehq/go-libs/v2/service"
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/go-chi/chi/v5"
 )
 
 func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticator, debug bool) *chi.Mux {
 	r := chi.NewRouter()
+	validator := validation.NewValidator()
 
 	r.Get("/_info", api.InfoHandler(info))
 
@@ -91,7 +93,7 @@ func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticat
 
 			// Transfer Initiations
 			r.Route("/transfer-initiations", func(r chi.Router) {
-				r.Post("/", transferInitiationsCreate(backend))
+				r.Post("/", transferInitiationsCreate(backend, validator))
 				r.Get("/", transferInitiationsList(backend))
 
 				r.Route("/{transferInitiationID}", func(r chi.Router) {

--- a/internal/api/v3/handler_payment_initiations_create.go
+++ b/internal/api/v3/handler_payment_initiations_create.go
@@ -53,7 +53,7 @@ func paymentInitiationsCreate(backend backend.Backend, validate *validator.Valid
 
 		if err := validate.Struct(payload); err != nil {
 			otel.RecordError(span, err)
-			api.BadRequest(w, ErrValidation, err)
+			WrapValidationError(w, ErrValidation, err)
 			return
 		}
 

--- a/internal/api/v3/handler_payment_initiations_create.go
+++ b/internal/api/v3/handler_payment_initiations_create.go
@@ -18,10 +18,10 @@ import (
 )
 
 type PaymentInitiationsCreateRequest struct {
-	Reference   string    `json:"reference" validate:"required,gt=3,lt=1000"`
+	Reference   string    `json:"reference" validate:"required,gte=3,lte=1000"`
 	ScheduledAt time.Time `json:"scheduledAt" validate:"omitempty,gt=now"`
 	ConnectorID string    `json:"connectorID" validate:"required,connectorID"`
-	Description string    `json:"description" validate:"omitempty,lt=10000"`
+	Description string    `json:"description" validate:"omitempty,lte=10000"`
 	Type        string    `json:"type" validate:"required,paymentInitiationType"`
 	Amount      *big.Int  `json:"amount" validate:"required"`
 	Asset       string    `json:"asset" validate:"required,asset"`

--- a/internal/api/v3/handler_payment_initiations_create.go
+++ b/internal/api/v3/handler_payment_initiations_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/go-libs/v2/api"
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/otel"
 	"github.com/go-playground/validator/v10"
@@ -53,7 +54,7 @@ func paymentInitiationsCreate(backend backend.Backend, validate *validator.Valid
 
 		if err := validate.Struct(payload); err != nil {
 			otel.RecordError(span, err)
-			WrapValidationError(w, ErrValidation, err)
+			validation.WrapError(w, ErrValidation, err)
 			return
 		}
 

--- a/internal/api/v3/handler_payment_initiations_create.go
+++ b/internal/api/v3/handler_payment_initiations_create.go
@@ -18,16 +18,16 @@ import (
 )
 
 type PaymentInitiationsCreateRequest struct {
-	Reference   string    `json:"reference" validate:"required"`
-	ScheduledAt time.Time `json:"scheduledAt" validate:""`
+	Reference   string    `json:"reference" validate:"required,gt=3,lt=1000"`
+	ScheduledAt time.Time `json:"scheduledAt" validate:"omitempty,gt=now"`
 	ConnectorID string    `json:"connectorID" validate:"required,connectorID"`
-	Description string    `json:"description" validate:""`
+	Description string    `json:"description" validate:"omitempty,lt=10000"`
 	Type        string    `json:"type" validate:"required,paymentInitiationType"`
 	Amount      *big.Int  `json:"amount" validate:"required"`
-	Asset       string    `json:"asset" validate:"required"`
+	Asset       string    `json:"asset" validate:"required,asset"`
 
-	SourceAccountID      *string `json:"sourceAccountID" validate:"required,accountID"`
-	DestinationAccountID *string `json:"destinationAccountID" validate:"omitempty,accountID"`
+	SourceAccountID      *string `json:"sourceAccountID" validate:"omitempty,accountID"`
+	DestinationAccountID *string `json:"destinationAccountID" validate:"required,accountID"`
 
 	Metadata map[string]string `json:"metadata" validate:""`
 }

--- a/internal/api/v3/handler_payment_initiations_create_test.go
+++ b/internal/api/v3/handler_payment_initiations_create_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
@@ -16,6 +18,7 @@ import (
 var _ = Describe("API v3 Payment Initiation Creation", func() {
 	var (
 		handlerFn http.HandlerFunc
+		validate  *validator.Validate
 		connID    models.ConnectorID
 		source    models.AccountID
 		dest      models.AccountID
@@ -23,6 +26,8 @@ var _ = Describe("API v3 Payment Initiation Creation", func() {
 		destID    string
 	)
 	BeforeEach(func() {
+		validate = validation.NewValidator()
+
 		connID = models.ConnectorID{Reference: uuid.New(), Provider: "psp"}
 		source = models.AccountID{Reference: uuid.New().String(), ConnectorID: connID}
 		dest = models.AccountID{Reference: uuid.New().String(), ConnectorID: connID}
@@ -40,7 +45,7 @@ var _ = Describe("API v3 Payment Initiation Creation", func() {
 			w = httptest.NewRecorder()
 			ctrl := gomock.NewController(GinkgoT())
 			m = backend.NewMockBackend(ctrl)
-			handlerFn = paymentInitiationsCreate(m)
+			handlerFn = paymentInitiationsCreate(m, validate)
 		})
 
 		It("should return a bad request error when body is missing", func(ctx SpecContext) {

--- a/internal/api/v3/handler_payment_initiations_create_test.go
+++ b/internal/api/v3/handler_payment_initiations_create_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
-	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
@@ -20,7 +19,7 @@ import (
 var _ = Describe("API v3 Payment Initiation Creation", func() {
 	var (
 		handlerFn http.HandlerFunc
-		validate  *validator.Validate
+		validate  *validation.Validator
 		connID    models.ConnectorID
 		source    models.AccountID
 		dest      models.AccountID

--- a/internal/api/v3/handler_payment_initiations_reverse.go
+++ b/internal/api/v3/handler_payment_initiations_reverse.go
@@ -17,8 +17,8 @@ import (
 )
 
 type PaymentInitiationsReverseRequest struct {
-	Reference   string            `json:"reference" validate:"required,gt=3,lt=1000"`
-	Description string            `json:"description" validate:"omitempty,lt=10000"`
+	Reference   string            `json:"reference" validate:"required,gte=3,lte=1000"`
+	Description string            `json:"description" validate:"omitempty,lte=10000"`
 	Amount      *big.Int          `json:"amount" validate:"required"`
 	Asset       string            `json:"asset" validate:"required,asset"`
 	Metadata    map[string]string `json:"metadata" validate:""`

--- a/internal/api/v3/handler_payment_initiations_reverse_test.go
+++ b/internal/api/v3/handler_payment_initiations_reverse_test.go
@@ -7,13 +7,14 @@ import (
 	"net/http/httptest"
 
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/mock/gomock"
 )
 
-var _ = Describe("API v2 Payment Initiation Reverse", func() {
+var _ = Describe("API v3 Payment Initiation Reversal", func() {
 	var (
 		handlerFn http.HandlerFunc
 		paymentID models.PaymentInitiationID
@@ -23,7 +24,7 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 		paymentID = models.PaymentInitiationID{Reference: "ref", ConnectorID: connID}
 	})
 
-	Context("retry payment initiation", func() {
+	Context("reverse payment initiation", func() {
 		var (
 			w *httptest.ResponseRecorder
 			m *backend.MockBackend
@@ -32,7 +33,7 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 			w = httptest.NewRecorder()
 			ctrl := gomock.NewController(GinkgoT())
 			m = backend.NewMockBackend(ctrl)
-			handlerFn = paymentInitiationsReverse(m)
+			handlerFn = paymentInitiationsReverse(m, validation.NewValidator())
 
 			_ = paymentID
 		})
@@ -67,9 +68,9 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 				expectedErr,
 			)
 			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "paymentInitiationID", paymentID.String(), &PaymentInitiationsReverseRequest{
-				Reference: "ref",
+				Reference: "ref1",
 				Amount:    big.NewInt(1313),
-				Asset:     "USD",
+				Asset:     "USD/2",
 			}))
 			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
 		})
@@ -80,9 +81,9 @@ var _ = Describe("API v2 Payment Initiation Reverse", func() {
 				nil,
 			)
 			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "paymentInitiationID", paymentID.String(), &PaymentInitiationsReverseRequest{
-				Reference: "ref",
+				Reference: "ref3",
 				Amount:    big.NewInt(1313),
-				Asset:     "USD",
+				Asset:     "eur/2",
 			}))
 			assertExpectedResponse(w.Result(), http.StatusAccepted, "")
 		})

--- a/internal/api/v3/router.go
+++ b/internal/api/v3/router.go
@@ -119,7 +119,7 @@ func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticat
 					r.Post("/retry", paymentInitiationsRetry(backend))
 					r.Post("/approve", paymentInitiationsApprove(backend))
 					r.Post("/reject", paymentInitiationsReject(backend))
-					r.Post("/reverse", paymentInitiationsReverse(backend))
+					r.Post("/reverse", paymentInitiationsReverse(backend, validator))
 
 					r.Get("/adjustments", paymentInitiationAdjustmentsList(backend))
 					r.Get("/payments", paymentInitiationPaymentsList(backend))

--- a/internal/api/v3/router.go
+++ b/internal/api/v3/router.go
@@ -7,11 +7,13 @@ import (
 	"github.com/formancehq/go-libs/v2/auth"
 	"github.com/formancehq/go-libs/v2/service"
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/go-chi/chi/v5"
 )
 
 func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticator, debug bool) *chi.Mux {
 	r := chi.NewRouter()
+	validator := validation.NewValidator()
 
 	r.Get("/_info", api.InfoHandler(info))
 
@@ -108,7 +110,7 @@ func newRouter(backend backend.Backend, info api.ServiceInfo, a auth.Authenticat
 
 			// Payment Initiations
 			r.Route("/payment-initiations", func(r chi.Router) {
-				r.Post("/", paymentInitiationsCreate(backend))
+				r.Post("/", paymentInitiationsCreate(backend, validator))
 				r.Get("/", paymentInitiationsList(backend))
 
 				r.Route("/{paymentInitiationID}", func(r chi.Router) {

--- a/internal/api/v3/utils.go
+++ b/internal/api/v3/utils.go
@@ -5,12 +5,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v2/api"
 	"github.com/formancehq/go-libs/v2/bun/bunpaginate"
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/go-libs/v2/query"
-	"github.com/formancehq/payments/internal/api/validation"
-	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -43,16 +40,6 @@ func getQueryBuilder(span trace.Span, r *http.Request) (query.Builder, error) {
 		span.SetAttributes(attribute.String("query", r.URL.Query().Get("query")))
 		return query.ParseJSON(r.URL.Query().Get("query"))
 	}
-}
-
-func WrapValidationError(w http.ResponseWriter, code string, rawErr error) {
-	if errs, ok := rawErr.(validator.ValidationErrors); ok && len(errs) > 0 {
-		err := fmt.Errorf("%s", errs[0].Translate(validation.Translator()))
-		api.BadRequest(w, code, err)
-		return
-	}
-	// fallback
-	api.BadRequest(w, code, rawErr)
 }
 
 func getPagination[T any](span trace.Span, r *http.Request, options T) (*bunpaginate.PaginatedQueryOptions[T], error) {

--- a/internal/api/v3/utils.go
+++ b/internal/api/v3/utils.go
@@ -5,9 +5,12 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/formancehq/go-libs/v2/api"
 	"github.com/formancehq/go-libs/v2/bun/bunpaginate"
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/go-libs/v2/query"
+	"github.com/formancehq/payments/internal/api/validation"
+	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -40,6 +43,16 @@ func getQueryBuilder(span trace.Span, r *http.Request) (query.Builder, error) {
 		span.SetAttributes(attribute.String("query", r.URL.Query().Get("query")))
 		return query.ParseJSON(r.URL.Query().Get("query"))
 	}
+}
+
+func WrapValidationError(w http.ResponseWriter, code string, rawErr error) {
+	if errs, ok := rawErr.(validator.ValidationErrors); ok && len(errs) > 0 {
+		err := fmt.Errorf("%s", errs[0].Translate(validation.Translator()))
+		api.BadRequest(w, code, err)
+		return
+	}
+	// fallback
+	api.BadRequest(w, code, rawErr)
 }
 
 func getPagination[T any](span trace.Span, r *http.Request, options T) (*bunpaginate.PaginatedQueryOptions[T], error) {

--- a/internal/api/validation/checkers.go
+++ b/internal/api/validation/checkers.go
@@ -1,0 +1,79 @@
+package validation
+
+import (
+	"github.com/formancehq/payments/internal/connectors/plugins/currency"
+	"github.com/formancehq/payments/internal/models"
+	ut "github.com/go-playground/universal-translator"
+	"github.com/go-playground/validator/v10"
+)
+
+func registerCustomChecker(
+	tagName string,
+	fn func(validator.FieldLevel) bool,
+	localeStr string,
+	validate *validator.Validate,
+	translator ut.Translator,
+) {
+	if localeStr == "" {
+		localeStr = "{0} is invalid"
+	}
+
+	validate.RegisterValidation(tagName, fn, false)
+	validate.RegisterTranslation(tagName, translator, func(u ut.Translator) error {
+		return u.Add(tagName, localeStr, true)
+	}, func(u ut.Translator, fe validator.FieldError) string {
+		t, _ := u.T(tagName, fe.Field())
+		return t
+	})
+}
+
+func IsConnectorID(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.ConnectorIDFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsAccountID(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.AccountIDFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsPaymentInitiationType(fl validator.FieldLevel) bool {
+	_, ok := fl.Field().Interface().(models.PaymentInitiationType)
+	if ok {
+		return true
+	}
+
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.PaymentInitiationTypeFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsAsset(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+
+	_, _, err = currency.GetCurrencyAndPrecisionFromAsset(currency.ISO4217Currencies, str)
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -1,0 +1,67 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/validator/v10"
+)
+
+func NewValidator() *validator.Validate {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+
+	validate.RegisterValidation("accountID", IsAccountID, false)
+	validate.RegisterValidation("connectorID", IsConnectorID, false)
+	validate.RegisterValidation("paymentInitiationType", IsPaymentInitiationType, false)
+	return validate
+}
+
+func fieldLevelToString(fl validator.FieldLevel) (str string, err error) {
+	switch v := fl.Field().Interface().(type) {
+	case *string:
+		str = *fl.Field().Interface().(*string)
+	case string:
+		str = fl.Field().Interface().(string)
+	default:
+		return str, fmt.Errorf("unsupported type %T", v)
+	}
+	return str, nil
+}
+
+func IsConnectorID(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.ConnectorIDFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsAccountID(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.AccountIDFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsPaymentInitiationType(fl validator.FieldLevel) bool {
+	_, ok := fl.Field().Interface().(models.PaymentInitiationType)
+	if ok {
+		return true
+	}
+
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+	if _, err := models.PaymentInitiationTypeFromString(str); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -2,7 +2,9 @@ package validation
 
 import (
 	"fmt"
+	"net/http"
 
+	"github.com/formancehq/go-libs/v2/api"
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/go-playground/locales"
@@ -29,6 +31,17 @@ func init() {
 // currently only one locale is expected
 func Translator() ut.Translator {
 	return translator
+}
+
+// TODO: could be added to go-libs later on so we don't have to think about it
+func WrapError(w http.ResponseWriter, code string, rawErr error) {
+	if errs, ok := rawErr.(validator.ValidationErrors); ok && len(errs) > 0 {
+		err := fmt.Errorf("%s", errs[0].Translate(Translator()))
+		api.BadRequest(w, code, err)
+		return
+	}
+	// fallback
+	api.BadRequest(w, code, rawErr)
 }
 
 func NewValidator() *validator.Validate {

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -2,11 +2,7 @@ package validation
 
 import (
 	"fmt"
-	"net/http"
 
-	"github.com/formancehq/go-libs/v2/api"
-	"github.com/formancehq/payments/internal/connectors/plugins/currency"
-	"github.com/formancehq/payments/internal/models"
 	"github.com/go-playground/locales"
 	"github.com/go-playground/locales/en"
 	"github.com/go-playground/validator/v10"
@@ -16,47 +12,53 @@ import (
 )
 
 var (
-	defaultLocaleStr = "en"
-	defaultLocale    = en.New()
+	defaultLocale    locales.Translator
 	supportedLocales []locales.Translator
-
-	translator ut.Translator
 )
 
 func init() {
+	defaultLocale = en.New()
 	supportedLocales = []locales.Translator{defaultLocale}
 }
 
-// Translator returns the locale for this deployment
-// currently only one locale is expected
-func Translator() ut.Translator {
-	return translator
+type Validator struct {
+	internal   *validator.Validate
+	translator ut.Translator
 }
 
-// TODO: could be added to go-libs later on so we don't have to think about it
-func WrapError(w http.ResponseWriter, code string, rawErr error) {
-	if errs, ok := rawErr.(validator.ValidationErrors); ok && len(errs) > 0 {
-		err := fmt.Errorf("%s", errs[0].Translate(Translator()))
-		api.BadRequest(w, code, err)
-		return
-	}
-	// fallback
-	api.BadRequest(w, code, rawErr)
-}
-
-func NewValidator() *validator.Validate {
+func NewValidator() *Validator {
 	uni := ut.New(defaultLocale, supportedLocales...)
 	// TODO: non-default locale could be configured for a stack if we have non-english clients who need it
-	translator, _ = uni.GetTranslator(defaultLocaleStr)
+	translator, _ := uni.GetTranslator(defaultLocale.Locale())
 
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	en_translations.RegisterDefaultTranslations(validate, translator)
 
-	validate.RegisterValidation("accountID", IsAccountID, false)
-	validate.RegisterValidation("connectorID", IsConnectorID, false)
-	validate.RegisterValidation("paymentInitiationType", IsPaymentInitiationType, false)
-	validate.RegisterValidation("asset", IsAsset, false)
-	return validate
+	registerCustomChecker("accountID", IsAccountID, "", validate, translator)
+	registerCustomChecker("connectorID", IsConnectorID, "", validate, translator)
+	registerCustomChecker("paymentInitiationType", IsPaymentInitiationType, "", validate, translator)
+	registerCustomChecker("asset", IsAsset, "", validate, translator)
+	return &Validator{
+		internal:   validate,
+		translator: translator,
+	}
+}
+
+func (v *Validator) Validate(payload any) (fieldErrors validator.ValidationErrors, err error) {
+	rawErr := v.internal.Struct(payload)
+	if rawErr == nil {
+		return fieldErrors, nil
+	}
+
+	fieldErrors, ok := rawErr.(validator.ValidationErrors)
+	if !ok {
+		return fieldErrors, rawErr
+	}
+
+	if len(fieldErrors) > 0 {
+		return fieldErrors, fmt.Errorf("%s", fieldErrors[0].Translate(v.translator))
+	}
+	return fieldErrors, rawErr
 }
 
 func fieldLevelToString(fl validator.FieldLevel) (str string, err error) {
@@ -69,55 +71,4 @@ func fieldLevelToString(fl validator.FieldLevel) (str string, err error) {
 		return str, fmt.Errorf("unsupported type %T", v)
 	}
 	return str, nil
-}
-
-func IsConnectorID(fl validator.FieldLevel) bool {
-	str, err := fieldLevelToString(fl)
-	if err != nil {
-		return false
-	}
-	if _, err := models.ConnectorIDFromString(str); err != nil {
-		return false
-	}
-	return true
-}
-
-func IsAccountID(fl validator.FieldLevel) bool {
-	str, err := fieldLevelToString(fl)
-	if err != nil {
-		return false
-	}
-	if _, err := models.AccountIDFromString(str); err != nil {
-		return false
-	}
-	return true
-}
-
-func IsPaymentInitiationType(fl validator.FieldLevel) bool {
-	_, ok := fl.Field().Interface().(models.PaymentInitiationType)
-	if ok {
-		return true
-	}
-
-	str, err := fieldLevelToString(fl)
-	if err != nil {
-		return false
-	}
-	if _, err := models.PaymentInitiationTypeFromString(str); err != nil {
-		return false
-	}
-	return true
-}
-
-func IsAsset(fl validator.FieldLevel) bool {
-	str, err := fieldLevelToString(fl)
-	if err != nil {
-		return false
-	}
-
-	_, _, err = currency.GetCurrencyAndPrecisionFromAsset(currency.ISO4217Currencies, str)
-	if err != nil {
-		return false
-	}
-	return true
 }

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 
+	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/go-playground/validator/v10"
 )
@@ -13,6 +14,7 @@ func NewValidator() *validator.Validate {
 	validate.RegisterValidation("accountID", IsAccountID, false)
 	validate.RegisterValidation("connectorID", IsConnectorID, false)
 	validate.RegisterValidation("paymentInitiationType", IsPaymentInitiationType, false)
+	validate.RegisterValidation("asset", IsAsset, false)
 	return validate
 }
 
@@ -61,6 +63,19 @@ func IsPaymentInitiationType(fl validator.FieldLevel) bool {
 		return false
 	}
 	if _, err := models.PaymentInitiationTypeFromString(str); err != nil {
+		return false
+	}
+	return true
+}
+
+func IsAsset(fl validator.FieldLevel) bool {
+	str, err := fieldLevelToString(fl)
+	if err != nil {
+		return false
+	}
+
+	_, _, err = currency.GetCurrencyAndPrecisionFromAsset(currency.ISO4217Currencies, str)
+	if err != nil {
 		return false
 	}
 	return true

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -5,11 +5,39 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/locales"
+	"github.com/go-playground/locales/en"
 	"github.com/go-playground/validator/v10"
+
+	ut "github.com/go-playground/universal-translator"
+	en_translations "github.com/go-playground/validator/v10/translations/en"
 )
 
+var (
+	defaultLocaleStr = "en"
+	defaultLocale    = en.New()
+	supportedLocales []locales.Translator
+
+	translator ut.Translator
+)
+
+func init() {
+	supportedLocales = []locales.Translator{defaultLocale}
+}
+
+// Translator returns the locale for this deployment
+// currently only one locale is expected
+func Translator() ut.Translator {
+	return translator
+}
+
 func NewValidator() *validator.Validate {
+	uni := ut.New(defaultLocale, supportedLocales...)
+	// TODO: non-default locale could be configured for a stack if we have non-english clients who need it
+	translator, _ = uni.GetTranslator(defaultLocaleStr)
+
 	validate := validator.New(validator.WithRequiredStructEnabled())
+	en_translations.RegisterDefaultTranslations(validate, translator)
 
 	validate.RegisterValidation("accountID", IsAccountID, false)
 	validate.RegisterValidation("connectorID", IsConnectorID, false)

--- a/internal/api/validation/validation_test.go
+++ b/internal/api/validation/validation_test.go
@@ -1,0 +1,126 @@
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/formancehq/go-libs/v2/pointer"
+	"github.com/formancehq/payments/internal/api/validation"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV3Handlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Suite")
+}
+
+var _ = Describe("Validator custom type checks", func() {
+	var (
+		validate *validator.Validate
+	)
+	BeforeEach(func() {
+		validate = validation.NewValidator()
+	})
+
+	Context("validation errors for various custom tags", func() {
+		type CustomStruct struct {
+			ConnectorID              string                       `validate:"omitempty,connectorID"`
+			ConnectorIDNullable      *string                      `validate:"omitempty,connectorID"`
+			AccountID                string                       `validate:"omitempty,accountID"`
+			AccountIDNullable        *string                      `validate:"omitempty,accountID"`
+			PaymentInitiationType    models.PaymentInitiationType `validate:"omitempty,paymentInitiationType"`
+			PaymentInitiationTypeStr string                       `validate:"omitempty,paymentInitiationType"`
+		}
+
+		DescribeTable("non conforming values",
+			func(tag, fieldName string, val any) {
+				err := validate.Struct(val)
+				Expect(err).ToNot(BeNil())
+				vErrs, ok := err.(validator.ValidationErrors)
+				Expect(ok).To(BeTrue())
+				Expect(vErrs).To(HaveLen(1))
+
+				fieldErr := vErrs[0]
+				Expect(fieldErr.ActualTag()).To(Equal(tag))
+				Expect(fieldErr.Field()).To(Equal(fieldName))
+			},
+			// connectorID
+			Entry("connectorID: invalid value of string on required field", "connectorID", "StringFieldName", struct {
+				StringFieldName string `validate:"required,connectorID"`
+			}{StringFieldName: "invalid"}),
+			Entry("connectorID: invalid value of string", "connectorID", "StringFieldName", struct {
+				StringFieldName string `validate:"omitempty,connectorID"`
+			}{StringFieldName: "invalid"}),
+			Entry("connectorID: invalid value on string pointer on required field", "connectorID", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"required,connectorID"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("connectorID: invalid value on string pointer", "connectorID", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"omitempty,connectorID"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("connectorID: unsupported type for this matcher", "connectorID", "FieldName", struct {
+				FieldName int `validate:"connectorID"`
+			}{FieldName: 44}),
+
+			// accountID
+			Entry("accountID: invalid value of string on required field", "accountID", "StringFieldName", struct {
+				StringFieldName string `validate:"required,accountID"`
+			}{StringFieldName: "invalid"}),
+			Entry("accountID: invalid value of string", "accountID", "StringFieldName", struct {
+				StringFieldName string `validate:"omitempty,accountID"`
+			}{StringFieldName: "invalid"}),
+			Entry("accountID: invalid value on string pointer on required field", "accountID", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"required,accountID"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("accountID: invalid value on string pointer", "accountID", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"omitempty,accountID"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("accountID: unsupported type for this matcher", "accountID", "FieldName", struct {
+				FieldName int `validate:"accountID"`
+			}{FieldName: 34}),
+
+			// paymentInitiationType
+			Entry("paymentInitiationType: invalid value of string on required field", "paymentInitiationType", "StringFieldName", struct {
+				StringFieldName string `validate:"required,paymentInitiationType"`
+			}{StringFieldName: "invalid"}),
+			Entry("paymentInitiationType: invalid value of string", "paymentInitiationType", "StringFieldName", struct {
+				StringFieldName string `validate:"omitempty,paymentInitiationType"`
+			}{StringFieldName: "invalid"}),
+			Entry("paymentInitiationType: invalid value on string pointer on required field", "paymentInitiationType", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"required,paymentInitiationType"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("paymentInitiationType: invalid value on string pointer", "paymentInitiationType", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"omitempty,paymentInitiationType"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("paymentInitiationType: unsupported type for this matcher", "paymentInitiationType", "FieldName", struct {
+				FieldName int `validate:"paymentInitiationType"`
+			}{FieldName: 34}),
+		)
+
+		It("connectorID supports expected values", func(ctx SpecContext) {
+			connID := models.ConnectorID{Reference: uuid.New()}
+			err := validate.Struct(CustomStruct{
+				ConnectorID:         connID.String(),
+				ConnectorIDNullable: pointer.For(connID.String()),
+			})
+			Expect(err).To(BeNil())
+		})
+		It("accountID supports expected values", func(ctx SpecContext) {
+			accID := models.AccountID{Reference: "ref"}
+			err := validate.Struct(CustomStruct{
+				AccountID:         accID.String(),
+				AccountIDNullable: pointer.For(accID.String()),
+			})
+			Expect(err).To(BeNil())
+		})
+		It("paymentInitiationType supports expected values", func(ctx SpecContext) {
+			err := validate.Struct(CustomStruct{
+				PaymentInitiationType:    models.PAYMENT_INITIATION_TYPE_PAYOUT,
+				PaymentInitiationTypeStr: models.PAYMENT_INITIATION_TYPE_TRANSFER.String(),
+			})
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/internal/api/validation/validation_test.go
+++ b/internal/api/validation/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/formancehq/payments/internal/models"
-	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +18,7 @@ func TestV3Handlers(t *testing.T) {
 
 var _ = Describe("Validator custom type checks", func() {
 	var (
-		validate *validator.Validate
+		validate *validation.Validator
 	)
 	BeforeEach(func() {
 		validate = validation.NewValidator()
@@ -39,10 +38,8 @@ var _ = Describe("Validator custom type checks", func() {
 
 		DescribeTable("non conforming values",
 			func(tag, fieldName string, val any) {
-				err := validate.Struct(val)
+				vErrs, err := validate.Validate(val)
 				Expect(err).ToNot(BeNil())
-				vErrs, ok := err.(validator.ValidationErrors)
-				Expect(ok).To(BeTrue())
 				Expect(vErrs).To(HaveLen(1))
 
 				fieldErr := vErrs[0]
@@ -120,7 +117,7 @@ var _ = Describe("Validator custom type checks", func() {
 
 		It("connectorID supports expected values", func(ctx SpecContext) {
 			connID := models.ConnectorID{Reference: uuid.New()}
-			err := validate.Struct(CustomStruct{
+			_, err := validate.Validate(CustomStruct{
 				ConnectorID:         connID.String(),
 				ConnectorIDNullable: pointer.For(connID.String()),
 			})
@@ -128,21 +125,21 @@ var _ = Describe("Validator custom type checks", func() {
 		})
 		It("accountID supports expected values", func(ctx SpecContext) {
 			accID := models.AccountID{Reference: "ref"}
-			err := validate.Struct(CustomStruct{
+			_, err := validate.Validate(CustomStruct{
 				AccountID:         accID.String(),
 				AccountIDNullable: pointer.For(accID.String()),
 			})
 			Expect(err).To(BeNil())
 		})
 		It("paymentInitiationType supports expected values", func(ctx SpecContext) {
-			err := validate.Struct(CustomStruct{
+			_, err := validate.Validate(CustomStruct{
 				PaymentInitiationType:    models.PAYMENT_INITIATION_TYPE_PAYOUT,
 				PaymentInitiationTypeStr: models.PAYMENT_INITIATION_TYPE_TRANSFER.String(),
 			})
 			Expect(err).To(BeNil())
 		})
 		It("asset supports expected values", func(ctx SpecContext) {
-			err := validate.Struct(CustomStruct{
+			_, err := validate.Validate(CustomStruct{
 				Asset:         "JPY/0",
 				AssetNullable: pointer.For("cad/2"),
 			})

--- a/internal/api/validation/validation_test.go
+++ b/internal/api/validation/validation_test.go
@@ -33,6 +33,8 @@ var _ = Describe("Validator custom type checks", func() {
 			AccountIDNullable        *string                      `validate:"omitempty,accountID"`
 			PaymentInitiationType    models.PaymentInitiationType `validate:"omitempty,paymentInitiationType"`
 			PaymentInitiationTypeStr string                       `validate:"omitempty,paymentInitiationType"`
+			Asset                    string                       `validate:"omitempty,asset"`
+			AssetNullable            *string                      `validate:"omitempty,asset"`
 		}
 
 		DescribeTable("non conforming values",
@@ -97,6 +99,23 @@ var _ = Describe("Validator custom type checks", func() {
 			Entry("paymentInitiationType: unsupported type for this matcher", "paymentInitiationType", "FieldName", struct {
 				FieldName int `validate:"paymentInitiationType"`
 			}{FieldName: 34}),
+
+			// asset
+			Entry("asset: invalid value of string on required field", "asset", "StringFieldName", struct {
+				StringFieldName string `validate:"required,asset"`
+			}{StringFieldName: "invalid"}),
+			Entry("asset: invalid value of string", "asset", "StringFieldName", struct {
+				StringFieldName string `validate:"omitempty,asset"`
+			}{StringFieldName: "invalid"}),
+			Entry("asset: invalid value on string pointer on required field", "asset", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"required,asset"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("asset: invalid value on string pointer", "asset", "PointerFieldName", struct {
+				PointerFieldName *string `validate:"omitempty,asset"`
+			}{PointerFieldName: pointer.For("invalid")}),
+			Entry("asset: unsupported type for this matcher", "asset", "FieldName", struct {
+				FieldName int `validate:"asset"`
+			}{FieldName: 34}),
 		)
 
 		It("connectorID supports expected values", func(ctx SpecContext) {
@@ -119,6 +138,13 @@ var _ = Describe("Validator custom type checks", func() {
 			err := validate.Struct(CustomStruct{
 				PaymentInitiationType:    models.PAYMENT_INITIATION_TYPE_PAYOUT,
 				PaymentInitiationTypeStr: models.PAYMENT_INITIATION_TYPE_TRANSFER.String(),
+			})
+			Expect(err).To(BeNil())
+		})
+		It("asset supports expected values", func(ctx SpecContext) {
+			err := validate.Struct(CustomStruct{
+				Asset:         "JPY/0",
+				AssetNullable: pointer.For("cad/2"),
 			})
 			Expect(err).To(BeNil())
 		})

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3416,6 +3416,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -3425,6 +3426,8 @@ components:
           $ref: '#/components/schemas/V3AccountTypeEnum'
         defaultAsset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
+          nullable: true
         metadata:
           $ref: '#/components/schemas/V3Metadata'
     V3CreateAccountResponse:
@@ -3449,6 +3452,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         provider:
           type: string
         reference:
@@ -3564,6 +3568,7 @@ components:
       properties:
         connectorID:
           type: string
+          format: byte
     V3ForwardBankAccountResponse:
       type: object
       required:
@@ -3854,6 +3859,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -3871,6 +3877,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         scheduleID:
           type: string
         createdAt:
@@ -3902,6 +3909,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -3915,12 +3923,15 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         scheme:
           type: string
         sourceAccountID:
           type: string
+          format: byte
         destinationAccountID:
           type: string
+          format: byte
         metadata:
           $ref: '#/components/schemas/V3Metadata'
         adjustments:
@@ -3946,6 +3957,7 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         metadata:
           $ref: '#/components/schemas/V3Metadata'
     V3CreatePaymentResponse:
@@ -4018,6 +4030,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         provider:
           type: string
         reference:
@@ -4041,9 +4054,11 @@ components:
           $ref: '#/components/schemas/V3PaymentStatusEnum'
         sourceAccountID:
           type: string
+          format: byte
           nullable: true
         destinationAccountID:
           type: string
+          format: byte
           nullable: true
         metadata:
           $ref: '#/components/schemas/V3Metadata'
@@ -4120,13 +4135,17 @@ components:
       properties:
         reference:
           type: string
+          minLength: 3
+          maxLength: 1000
         scheduledAt:
           type: string
           format: date-time
         connectorID:
           type: string
+          format: byte
         description:
           type: string
+          maxLength: 10000
         type:
           $ref: '#/components/schemas/V3PaymentInitiationTypeEnum'
         amount:
@@ -4134,10 +4153,14 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         sourceAccountID:
           type: string
+          format: byte
+          nullable: true
         destinationAccountID:
           type: string
+          format: byte
         metadata:
           $ref: '#/components/schemas/V3Metadata'
     V3InitiatePaymentResponse:
@@ -4194,13 +4217,17 @@ components:
       properties:
         reference:
           type: string
+          minLength: 3
+          maxLength: 1000
         description:
           type: string
+          maxLength: 10000
         amount:
           type: integer
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         metadata:
           $ref: '#/components/schemas/V3Metadata'
     V3ReversePaymentInitiationResponse:
@@ -4327,6 +4354,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         reference:
           type: string
         createdAt:
@@ -4348,8 +4376,10 @@ components:
           $ref: '#/components/schemas/V3PaymentInitiationStatusEnum'
         sourceAccountID:
           type: string
+          format: byte
         destinationAccountID:
           type: string
+          format: byte
         error:
           type: string
         metadata:
@@ -4527,6 +4557,7 @@ components:
           format: date-time
         connectorID:
           type: string
+          format: byte
         createdObjectID:
           type: string
         error:

--- a/openapi/v3/v3-schemas.yaml
+++ b/openapi/v3/v3-schemas.yaml
@@ -74,6 +74,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -83,6 +84,8 @@ components:
           $ref: "#/components/schemas/V3AccountTypeEnum"
         defaultAsset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
+          nullable: true
         metadata:
           $ref: '#/components/schemas/V3Metadata'
 
@@ -109,6 +112,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         provider:
           type: string
         reference:
@@ -231,6 +235,7 @@ components:
       properties:
         connectorID:
           type: string
+          format: byte
 
     V3ForwardBankAccountResponse:
       type: object
@@ -548,6 +553,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -566,6 +572,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         scheduleID:
           type: string
         createdAt:
@@ -599,6 +606,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         createdAt:
           type: string
           format: date-time
@@ -612,12 +620,15 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         scheme:
           type: string
         sourceAccountID:
           type: string
+          format: byte
         destinationAccountID:
           type: string
+          format: byte
         metadata:
           $ref: '#/components/schemas/V3Metadata'
         adjustments:
@@ -644,6 +655,7 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         metadata:
           $ref: '#/components/schemas/V3Metadata'
 
@@ -721,6 +733,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         provider:
           type: string
         reference:
@@ -744,9 +757,11 @@ components:
           $ref: "#/components/schemas/V3PaymentStatusEnum"
         sourceAccountID:
           type: string
+          format: byte
           nullable: true
         destinationAccountID:
           type: string
+          format: byte
           nullable: true
         metadata:
           $ref: '#/components/schemas/V3Metadata'
@@ -828,13 +843,17 @@ components:
       properties:
         reference:
           type: string
+          minLength: 3
+          maxLength: 1000
         scheduledAt:
           type: string
           format: date-time
         connectorID:
           type: string
+          format: byte
         description:
           type: string
+          maxLength: 10000
         type:
           $ref: "#/components/schemas/V3PaymentInitiationTypeEnum"
         amount:
@@ -842,10 +861,14 @@ components:
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         sourceAccountID:
           type: string
+          format: byte
+          nullable: true
         destinationAccountID:
           type: string
+          format: byte
         metadata:
           $ref: '#/components/schemas/V3Metadata'
 
@@ -916,13 +939,17 @@ components:
       properties:
         reference:
           type: string
+          minLength: 3
+          maxLength: 1000
         description:
           type: string
+          maxLength: 10000
         amount:
           type: integer
           format: bigint
         asset:
           type: string
+          pattern: ^[a-zA-Z]{3}\/[0-9]$
         metadata:
           $ref: '#/components/schemas/V3Metadata'
 
@@ -1057,6 +1084,7 @@ components:
           type: string
         connectorID:
           type: string
+          format: byte
         reference:
           type: string
         createdAt:
@@ -1078,8 +1106,10 @@ components:
           $ref: "#/components/schemas/V3PaymentInitiationStatusEnum"
         sourceAccountID:
           type: string
+          format: byte
         destinationAccountID:
           type: string
+          format: byte
         error:
           type: string
         metadata:
@@ -1273,6 +1303,7 @@ components:
           format: date-time
         connectorID:
           type: string
+          format: byte
         createdObjectID:
           type: string
         error:

--- a/test/e2e/api_payment_initiations_test.go
+++ b/test/e2e/api_payment_initiations_test.go
@@ -67,12 +67,11 @@ var _ = Context("Payments API Payment Initiation", func() {
 			debtorID, creditorID = setupDebtorAndCreditorAccounts(ctx, app.GetValue(), e, ver, connectorRes.Data, createdAt)
 			payReq = v3.PaymentInitiationsCreateRequest{
 				Reference:            uuid.New().String(),
-				ScheduledAt:          time.Now(),
 				ConnectorID:          connectorRes.Data,
 				Description:          "some description",
 				Type:                 models.PAYMENT_INITIATION_TYPE_TRANSFER.String(),
 				Amount:               big.NewInt(3200),
-				Asset:                "EUR",
+				Asset:                "EUR/2",
 				SourceAccountID:      &debtorID,
 				DestinationAccountID: &creditorID,
 				Metadata:             map[string]string{"key": "val"},
@@ -226,12 +225,11 @@ var _ = Context("Payments API Payment Initiation", func() {
 			debtorID, creditorID = setupDebtorAndCreditorAccounts(ctx, app.GetValue(), e, ver, connectorRes.Data, createdAt)
 			payReq = v3.PaymentInitiationsCreateRequest{
 				Reference:            uuid.New().String(),
-				ScheduledAt:          time.Now(),
 				ConnectorID:          connectorRes.Data,
 				Description:          "payout description",
 				Type:                 models.PAYMENT_INITIATION_TYPE_PAYOUT.String(),
 				Amount:               big.NewInt(2233),
-				Asset:                "EUR",
+				Asset:                "EUR/2",
 				SourceAccountID:      &debtorID,
 				DestinationAccountID: &creditorID,
 				Metadata:             map[string]string{"pay": "out"},


### PR DESCRIPTION
Fixes: ENG-1636

Some examples of error responses messages provided by library:
```
{"errorCode":"VALIDATION","errorMessage":"Reference is a required field"}
{"errorCode":"VALIDATION","errorMessage":"Reference must be greater than 3 characters in length"}
{"errorCode":"VALIDATION","errorMessage":"ScheduledAt must be greater than the current Date Time"}
```