### PR TITLE
feat(api): Allow payment initiation list endpoint to query by adjustment status

### DIFF
--- a/internal/storage/migrations/0-init-schema.sql
+++ b/internal/storage/migrations/0-init-schema.sql
@@ -439,8 +439,6 @@ create table if not exists payment_initiation_adjustments(
     primary key (id)
 );
 create index payment_initiation_adjustments_created_at_sort_id on payment_initiation_adjustments (created_at, sort_id);
-create index payment_initiation_adjustments_pi_id on payment_initiation_adjustments (payment_initiation_id);
-create index payment_initiation_adjustments_sort_id on payment_initiation_adjustments (sort_id);
 alter table payment_initiation_adjustments
     add constraint payment_initiation_adjustments_payment_initiation_id_fk foreign key (payment_initiation_id)
     references payment_initiations (id)

--- a/internal/storage/migrations/0-init-schema.sql
+++ b/internal/storage/migrations/0-init-schema.sql
@@ -439,6 +439,8 @@ create table if not exists payment_initiation_adjustments(
     primary key (id)
 );
 create index payment_initiation_adjustments_created_at_sort_id on payment_initiation_adjustments (created_at, sort_id);
+create index payment_initiation_adjustments_pi_id on payment_initiation_adjustments (payment_initiation_id);
+create index payment_initiation_adjustments_sort_id on payment_initiation_adjustments (sort_id);
 alter table payment_initiation_adjustments
     add constraint payment_initiation_adjustments_payment_initiation_id_fk foreign key (payment_initiation_id)
     references payment_initiations (id)

--- a/internal/storage/migrations/12-add-payment-initiation-adjustment-indexes.go
+++ b/internal/storage/migrations/12-add-payment-initiation-adjustment-indexes.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func AddPaymentInitiationAdjustmentsIndexes(ctx context.Context, db bun.IDB) error {
+	_, err := db.ExecContext(ctx, `
+		CREATE INDEX CONCURRENTLY IF NOT EXISTS payment_initiation_adjustments_pi_id ON payment_initiation_adjustments (payment_initiation_id);
+	`)
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, `
+		CREATE INDEX CONCURRENTLY IF NOT EXISTS payment_initiation_adjustments_sort_id ON payment_initiation_adjustments (sort_id);
+	`)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/storage/migrations/migrations.go
+++ b/internal/storage/migrations/migrations.go
@@ -167,6 +167,15 @@ func registerMigrations(logger logging.Logger, migrator *migrations.Migrator, en
 				})
 			},
 		},
+		migrations.Migration{
+			Name: "add payment_initiation_adjustments indexes",
+			Up: func(ctx context.Context, db bun.IDB) error {
+				logger.Info("running add payment_initiation_adjustments index migration...")
+				err := AddPaymentInitiationAdjustmentsIndexes(ctx, db)
+				logger.WithField("error", err).Info("finished add payment_initiation_adjustments index migration")
+				return err
+			},
+		},
 	)
 }
 

--- a/internal/storage/payment_initiations.go
+++ b/internal/storage/payment_initiations.go
@@ -33,9 +33,6 @@ type paymentInitiation struct {
 	SourceAccountID      *models.AccountID `bun:"source_account_id,type:character varying"`
 	DestinationAccountID *models.AccountID `bun:"destination_account_id,type:character varying,notnull"`
 
-	// Fields retrieved with a join
-	Adjustments []paymentInitiationAdjustment `bun:"rel:has-many,join:id=payment_initiation_id"`
-
 	// Optional fields with default
 	// c.f. https://bun.uptrace.dev/guide/models.html#default
 	Metadata map[string]string `bun:"metadata,type:jsonb,nullzero,notnull,default:'{}'"`
@@ -246,9 +243,6 @@ func (s *store) PaymentInitiationsList(ctx context.Context, q ListPaymentInitiat
 	cursor, err := paginateWithOffset[bunpaginate.PaginatedQueryOptions[PaymentInitiationQuery], paymentInitiation](s, ctx,
 		(*bunpaginate.OffsetPaginatedQuery[bunpaginate.PaginatedQueryOptions[PaymentInitiationQuery]])(&q),
 		func(query *bun.SelectQuery) *bun.SelectQuery {
-			query = query.
-				Relation("Adjustments")
-
 			if join != "" {
 				query = query.Join(join)
 			}


### PR DESCRIPTION
Fixes: PMNT-62

### Query performance prior to adding indexes:

Quite bad there are some sequential scans
```
Sort  (cost=40.88..40.88 rows=1 width=344)
   Sort Key: payment_initiation.created_at DESC, payment_initiation.sort_id DESC
   ->  Hash Right Join  (cost=26.71..40.87 rows=1 width=344)
         Hash Cond: ((old_adj.payment_initiation_id)::text = payment_initiation.id)
         Join Filter: (latest_adj.sort_id < old_adj.sort_id)
         Filter: (old_adj.id IS NULL)
         ->  Seq Scan on payment_initiation_adjustments old_adj  (cost=0.00..13.00 rows=300 width=72)
         ->  Hash  (cost=26.68..26.68 rows=2 width=352)
               ->  Hash Join  (cost=13.78..26.68 rows=2 width=352)
                     Hash Cond: (payment_initiation.id = (latest_adj.payment_initiation_id)::text)
                     ->  Seq Scan on payment_initiations payment_initiation  (cost=0.00..12.10 rows=210 width=344)
                     ->  Hash  (cost=13.75..13.75 rows=2 width=40)
                           ->  Seq Scan on payment_initiation_adjustments latest_adj  (cost=0.00..13.75 rows=2 width=40)
                                 Filter: (status = 'FAILED'::text)
```

### After indexes added:

The one remaining sequential scan is on a derived table which at most only contains as many adjustments as a single payment has, so should not pose much of a problem.
```
 Sort  (cost=10.61..10.62 rows=1 width=344)
   Sort Key: payment_initiation.created_at DESC, payment_initiation.sort_id DESC
   ->  Nested Loop Left Join  (cost=0.28..10.60 rows=1 width=344)
         Join Filter: (latest_adj.sort_id < old_adj.sort_id)
         Filter: (old_adj.id IS NULL)
         ->  Nested Loop  (cost=0.14..10.36 rows=1 width=352)
               ->  Seq Scan on payment_initiation_adjustments latest_adj  (cost=0.00..2.12 rows=1 width=40)
                     Filter: (status = 'FAILED'::text)
               ->  Index Scan using payment_initiations_pkey on payment_initiations payment_initiation  (cost=0.14..8.16 rows=1 width=344)
                     Index Cond: (id = (latest_adj.payment_initiation_id)::text)
         ->  Index Scan using payment_initiation_adjustments_pi_id on payment_initiation_adjustments old_adj  (cost=0.14..0.23 rows=1 width=72)
               Index Cond: ((payment_initiation_id)::text = payment_initiation.id)
(12 rows)
```