### PR TITLE
feat(*): improve connector errors

### DIFF
--- a/internal/api/services/errors.go
+++ b/internal/api/services/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/formancehq/payments/internal/connectors/engine"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +48,10 @@ func handleEngineErrors(err error) error {
 
 	switch {
 	case errors.Is(err, engine.ErrValidation):
-		return fmt.Errorf("%w: %w", err, ErrValidation)
+		return errorsutils.NewWrappedError(
+			err,
+			ErrValidation,
+		)
 	case errors.Is(err, engine.ErrNotFound):
 		return fmt.Errorf("%w: %w", err, ErrNotFound)
 	default:

--- a/internal/api/v2/errors.go
+++ b/internal/api/v2/errors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/payments/internal/api/common"
 	"github.com/formancehq/payments/internal/api/services"
 	"github.com/formancehq/payments/internal/storage"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 const (
@@ -27,7 +28,8 @@ func handleServiceErrors(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, storage.ErrValidation):
 		api.BadRequest(w, ErrValidation, err)
 	case errors.Is(err, services.ErrValidation):
-		api.BadRequest(w, ErrValidation, err)
+		cause := errorsutils.Cause(err)
+		api.BadRequest(w, ErrValidation, cause)
 	case errors.Is(err, services.ErrNotFound):
 		api.NotFound(w, err)
 	default:

--- a/internal/connectors/engine/activities/errors.go
+++ b/internal/connectors/engine/activities/errors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/storage"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 )
@@ -29,18 +30,23 @@ func (a Activities) temporalPluginPollingError(ctx context.Context, err error, p
 }
 
 func (a Activities) temporalPluginErrorCheck(ctx context.Context, err error, isPeriodic bool) error {
+	// Since typed errors are discard with temporal when returning from an activity,
+	// we need only to pass to temporal the cause of the error and not all the
+	// stack trace.
+	cause := errorsutils.Cause(err)
+
 	switch {
 	// Do not retry the following errors
 	case errors.Is(err, plugins.ErrNotImplemented):
-		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeUnimplemented, err)
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeUnimplemented, cause)
 	case errors.Is(err, plugins.ErrInvalidClientRequest):
-		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, err)
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 	case errors.Is(err, plugins.ErrCurrencyNotSupported):
-		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, err)
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 	case errors.Is(err, enginePlugins.ErrNotFound):
-		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, err)
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 	case errors.Is(err, models.ErrMissingConnectorMetadata):
-		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, err)
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 
 	// Potentially retry
 	case errors.Is(err, plugins.ErrUpstreamRatelimit):
@@ -52,7 +58,7 @@ func (a Activities) temporalPluginErrorCheck(ctx context.Context, err error, isP
 				"scheduled_time": info.ScheduledTime.String(),
 				"workflow_id":    info.WorkflowExecution.ID,
 			}).Debug("disabling retry for polled activity triggered by schedule due to rate-limit")
-			return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeRateLimited, err)
+			return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeRateLimited, cause)
 		}
 
 		return temporal.NewApplicationErrorWithOptions(err.Error(), ErrTypeRateLimited, temporal.ApplicationErrorOptions{
@@ -64,9 +70,9 @@ func (a Activities) temporalPluginErrorCheck(ctx context.Context, err error, isP
 	// Retry the following errors
 	case errors.Is(err, plugins.ErrNotYetInstalled):
 		// We want to retry in case of not installed
-		return temporal.NewApplicationErrorWithCause(err.Error(), ErrTypeDefault, err)
+		return temporal.NewApplicationErrorWithCause(err.Error(), ErrTypeDefault, cause)
 	default:
-		return temporal.NewApplicationErrorWithCause(err.Error(), ErrTypeDefault, err)
+		return temporal.NewApplicationErrorWithCause(err.Error(), ErrTypeDefault, cause)
 	}
 }
 

--- a/internal/connectors/engine/errors.go
+++ b/internal/connectors/engine/errors.go
@@ -1,8 +1,32 @@
 package engine
 
-import "github.com/pkg/errors"
+import (
+	"github.com/formancehq/payments/internal/connectors/engine/activities"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
+)
 
 var (
 	ErrValidation = errors.New("validation error")
 	ErrNotFound   = errors.New("not found")
 )
+
+// handleWorkflowError processes Temporal workflow errors and wraps validation errors
+// with ErrValidation to provide consistent error handling for API responses.
+func handleWorkflowError(err error) error {
+	var applicationErr *temporal.ApplicationError
+	if errors.As(err, &applicationErr) {
+		switch applicationErr.Type() {
+		case activities.ErrTypeInvalidArgument:
+			return errorsutils.NewWrappedError(
+				errorsutils.Cause(err),
+				ErrValidation,
+			)
+		default:
+			return err
+		}
+	}
+
+	return err
+}

--- a/internal/connectors/engine/workflow/create_transfer.go
+++ b/internal/connectors/engine/workflow/create_transfer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -190,6 +191,10 @@ func (w Workflow) createTransfer(
 		return nil
 
 	default:
+		// Temporal errors do not have a Cause method, so we need to unwrap them
+		// to get the underlying error and not store the whole stack trace inside
+		// the database.
+		cause := errorsutils.Cause(errPlugin)
 		err := w.addPIAdjustment(
 			ctx,
 			models.PaymentInitiationAdjustmentID{
@@ -199,7 +204,7 @@ func (w Workflow) createTransfer(
 			},
 			pi.Amount,
 			&pi.Asset,
-			errPlugin,
+			cause,
 			nil,
 		)
 		if err != nil {

--- a/internal/connectors/engine/workflow/update_tasks.go
+++ b/internal/connectors/engine/workflow/update_tasks.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -12,6 +13,7 @@ func (w Workflow) updateTasksError(
 	connectorID *models.ConnectorID,
 	err error,
 ) error {
+	cause := errorsutils.Cause(err)
 	return activities.StorageTasksStore(
 		infiniteRetryContext(ctx),
 		models.Task{
@@ -19,7 +21,7 @@ func (w Workflow) updateTasksError(
 			ConnectorID: connectorID,
 			Status:      models.TASK_STATUS_FAILED,
 			UpdatedAt:   workflow.Now(ctx).UTC(),
-			Error:       err,
+			Error:       cause,
 		})
 }
 

--- a/internal/connectors/plugins/currency/currency.go
+++ b/internal/connectors/plugins/currency/currency.go
@@ -205,7 +205,7 @@ func GetPrecision(currencies map[string]int, cur string) (int, error) {
 
 	def, ok := currencies[asset]
 	if !ok {
-		return 0, ErrMissingCurrencies
+		return 0, fmt.Errorf("%s: %w", asset, ErrMissingCurrencies)
 	}
 
 	return def, nil
@@ -214,7 +214,7 @@ func GetPrecision(currencies map[string]int, cur string) (int, error) {
 func GetCurrencyAndPrecisionFromAsset(currencies map[string]int, asset string) (string, int, error) {
 	parts := strings.Split(asset, "/")
 	if len(parts) != 2 {
-		return "", 0, errors.New("invalid asset")
+		return "", 0, fmt.Errorf("invalid asset: %s", asset)
 	}
 
 	currency := parts[0]

--- a/internal/connectors/plugins/public/adyen/client/client.go
+++ b/internal/connectors/plugins/public/adyen/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -71,11 +72,11 @@ func New(
 // so that activities can classify this error for temporal
 func (c *client) wrapSDKError(err error, statusCode int) error {
 	if statusCode == http.StatusTooManyRequests {
-		return fmt.Errorf("rate-limited by adyen %w: %w", httpwrapper.ErrStatusCodeTooManyRequests, err)
+		return errorsutils.NewWrappedError(err, httpwrapper.ErrStatusCodeTooManyRequests)
 	}
 
 	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
-		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeClientError, err)
+		return errorsutils.NewWrappedError(err, httpwrapper.ErrStatusCodeClientError)
 	}
 
 	// Adyen SDK doesn't appear to catch anything above 500

--- a/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("required metadata field com.atlar.spec/owner/name is missing"))
+			Expect(err).To(MatchError("required metadata field com.atlar.spec/owner/name is missing: invalid request"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -74,7 +74,7 @@ var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("required metadata field com.atlar.spec/owner/type is missing"))
+			Expect(err).To(MatchError("required metadata field com.atlar.spec/owner/type is missing: invalid request"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("metadata field com.atlar.spec/owner/type needs to be one of [ INDIVIDUAL COMPANY ]"))
+			Expect(err).To(MatchError("metadata field com.atlar.spec/owner/type needs to be one of [ INDIVIDUAL COMPANY ]: invalid request"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/atlar/client/client.go
+++ b/internal/connectors/plugins/public/atlar/client/client.go
@@ -3,13 +3,13 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	atlar_client "github.com/get-momo/atlar-v1-go-client/client"
 	"github.com/get-momo/atlar-v1-go-client/client/accounts"
 	"github.com/get-momo/atlar-v1-go-client/client/counterparties"
@@ -101,13 +101,13 @@ func wrapSDKErr(err error, atlarErr any) error {
 	}
 
 	if code == http.StatusTooManyRequests {
-		return fmt.Errorf("atlar error: %w: %w", err, httpwrapper.ErrStatusCodeTooManyRequests)
+		return errorsutils.NewWrappedError(err, httpwrapper.ErrStatusCodeTooManyRequests)
 	}
 
 	if code >= http.StatusBadRequest && code < http.StatusInternalServerError {
-		return fmt.Errorf("atlar error: %w: %w", err, httpwrapper.ErrStatusCodeClientError)
+		return errorsutils.NewWrappedError(err, httpwrapper.ErrStatusCodeClientError)
 	} else if code >= http.StatusInternalServerError {
-		return fmt.Errorf("atlar error: %w: %w", err, httpwrapper.ErrStatusCodeServerError)
+		return errorsutils.NewWrappedError(err, httpwrapper.ErrStatusCodeServerError)
 	}
 
 	return err

--- a/internal/connectors/plugins/public/atlar/client/counter_parties.go
+++ b/internal/connectors/plugins/public/atlar/client/counter_parties.go
@@ -7,6 +7,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/get-momo/atlar-v1-go-client/client/counterparties"
 	atlar_models "github.com/get-momo/atlar-v1-go-client/models"
 )
@@ -66,7 +67,10 @@ func (c *client) PostV1CounterParties(ctx context.Context, newExternalBankAccoun
 
 	if len(postCounterpartiesResponse.Payload.ExternalAccounts) != 1 {
 		// should never occur, but when in case it happens it's nice to have an error to search for
-		return nil, fmt.Errorf("counterparty was not created with exactly one account: %w", httpwrapper.ErrStatusCodeUnexpected)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("counterparty was not created with exactly one account"),
+			httpwrapper.ErrStatusCodeUnexpected,
+		)
 	}
 
 	return postCounterpartiesResponse, nil

--- a/internal/connectors/plugins/public/atlar/payouts.go
+++ b/internal/connectors/plugins/public/atlar/payouts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	atlar_models "github.com/get-momo/atlar-v1-go-client/models"
 )
 
@@ -18,7 +19,10 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	currency, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return "", fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return "", errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	paymentSchemeType := "SCT" // SEPA Credit Transfer

--- a/internal/connectors/plugins/public/atlar/payouts_test.go
+++ b/internal/connectors/plugins/public/atlar/payouts_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Atlar Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("Atlar Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -103,7 +103,7 @@ var _ = Describe("Atlar Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/atlar/utils.go
+++ b/internal/connectors/plugins/public/atlar/utils.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func ParseAtlarTimestamp(value string) (time.Time, error) {
@@ -15,11 +16,17 @@ func ParseAtlarTimestamp(value string) (time.Time, error) {
 
 func validateTransferPayoutRequest(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/public/bankingcircle/client/accounts.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/accounts.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Balance struct {
@@ -71,7 +72,10 @@ func (c *client) GetAccounts(ctx context.Context, page int, pageSize int, fromOp
 	res := response{Result: make([]Account, 0)}
 	statusCode, err := c.httpClient.Do(ctx, req, &res, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get accounts, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get accounts: status code %d", statusCode),
+			err,
+		)
 	}
 	return res.Result, nil
 }
@@ -91,7 +95,10 @@ func (c *client) GetAccount(ctx context.Context, accountID string) (*Account, er
 	var account Account
 	statusCode, err := c.httpClient.Do(ctx, req, &account, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get account: status code %d", statusCode),
+			err,
+		)
 	}
 	return &account, nil
 }

--- a/internal/connectors/plugins/public/bankingcircle/client/auth.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/auth.go
@@ -3,12 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (c *client) login(ctx context.Context) error {
@@ -37,9 +37,15 @@ func (c *client) login(ctx context.Context) error {
 	statusCode, err := c.httpClient.Do(ctx, req, &res, &errors)
 	if err != nil {
 		if len(errors) > 0 {
-			log.Printf("bankingcircle auth failed with code %s: %s", errors[0].ErrorCode, errors[0].ErrorText)
+			return errorsutils.NewWrappedError(
+				fmt.Errorf("failed to login, status code %d: %s", statusCode, errors[0].ErrorText),
+				err,
+			)
 		}
-		return fmt.Errorf("failed to login, status code %d: %w", statusCode, err)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to login, status code %d", statusCode),
+			err,
+		)
 	}
 
 	c.accessToken = res.AccessToken

--- a/internal/connectors/plugins/public/bankingcircle/client/client.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
@@ -43,7 +44,10 @@ func New(
 ) (Client, error) {
 	cert, err := tls.X509KeyPair([]byte(uCertificate), []byte(uCertificateKey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to load user certificate: %w: %w", err, models.ErrInvalidConfig)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to load user certificate: %w", err),
+			models.ErrInvalidConfig,
+		)
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()

--- a/internal/connectors/plugins/public/bankingcircle/client/payments.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/payments.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type DebtorInformation struct {
@@ -119,7 +120,10 @@ func (c *client) GetPayments(ctx context.Context, page int, pageSize int) ([]Pay
 	res := response{Result: make([]Payment, 0)}
 	statusCode, err := c.httpClient.Do(ctx, req, &res, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get payments, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payments: status code %d", statusCode),
+			err,
+		)
 	}
 	return res.Result, nil
 }
@@ -140,7 +144,10 @@ func (c *client) GetPayment(ctx context.Context, paymentID string) (*Payment, er
 	var res Payment
 	statusCode, err := c.httpClient.Do(ctx, req, &res, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get payment, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payment: status code %d", statusCode),
+			err,
+		)
 	}
 	return &res, nil
 }
@@ -164,7 +171,10 @@ func (c *client) GetPaymentStatus(ctx context.Context, paymentID string) (*Statu
 	var res StatusResponse
 	statusCode, err := c.httpClient.Do(ctx, req, &res, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get payment status, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payment status: status code %d", statusCode),
+			err,
+		)
 	}
 	return &res, nil
 }

--- a/internal/connectors/plugins/public/bankingcircle/client/transfer_payouts.go
+++ b/internal/connectors/plugins/public/bankingcircle/client/transfer_payouts.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type PaymentAccount struct {
@@ -56,7 +57,10 @@ func (c *client) InitiateTransferOrPayouts(ctx context.Context, transferRequest 
 	var res PaymentResponse
 	statusCode, err := c.httpClient.Do(ctx, req, &res, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make payout, status code %d: %w", statusCode, err)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to make payment, status code %d", statusCode),
+			err,
+		)
 	}
 	return &res, nil
 }

--- a/internal/connectors/plugins/public/bankingcircle/payouts_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/payouts_test.go
@@ -99,7 +99,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -136,7 +136,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account number or IBAN is required: invalid request"))
+			Expect(err).To(MatchError("destination account number or IBAN is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -148,7 +148,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account name is required: invalid request"))
+			Expect(err).To(MatchError("destination account name is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -162,7 +162,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get source account: test error: invalid request"))
+			Expect(err).To(MatchError("failed to get source account acc1: test error: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -178,7 +178,7 @@ var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("no account identifiers provided for source account: invalid request"))
+			Expect(err).To(MatchError("no account identifiers provided for source account acc1: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/bankingcircle/transfers.go
+++ b/internal/connectors/plugins/public/bankingcircle/transfers.go
@@ -8,15 +8,22 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/bankingcircle/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validateTransferRequest(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil
@@ -29,30 +36,48 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int amount %v: %v", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	var sourceAccount *client.Account
 	sourceAccount, err = p.client.GetAccount(ctx, pi.SourceAccount.Reference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get source account: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get source account %s: %v", pi.SourceAccount.Reference, err),
+			models.ErrInvalidRequest,
+		)
 	}
 	if len(sourceAccount.AccountIdentifiers) == 0 {
-		return nil, fmt.Errorf("no account identifiers provided for source account: %w", models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("no account identifiers provided for source account %s", pi.SourceAccount.Reference),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	var destinationAccount *client.Account
 	destinationAccount, err = p.client.GetAccount(ctx, pi.DestinationAccount.Reference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get destination account: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get destination account %s: %v", pi.DestinationAccount.Reference, err),
+			models.ErrInvalidRequest,
+		)
 	}
 	if len(destinationAccount.AccountIdentifiers) == 0 {
-		return nil, fmt.Errorf("no account identifiers provided for destination account: %w", models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("no account identifiers provided for destination account %s", pi.DestinationAccount.Reference),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiateTransferOrPayouts(

--- a/internal/connectors/plugins/public/bankingcircle/transfers_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/transfers_test.go
@@ -69,7 +69,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -109,7 +109,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get source account: test error: invalid request"))
+			Expect(err).To(MatchError("failed to get source account acc1: test error: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("no account identifiers provided for source account: invalid request"))
+			Expect(err).To(MatchError("no account identifiers provided for source account acc1: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -144,7 +144,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get destination account: test error: invalid request"))
+			Expect(err).To(MatchError("failed to get destination account acc2: test error: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("no account identifiers provided for destination account: invalid request"))
+			Expect(err).To(MatchError("no account identifiers provided for destination account acc2: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/currencycloud/client/accounts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/accounts.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Account struct {
@@ -49,7 +50,10 @@ func (c *client) GetAccounts(ctx context.Context, page int, pageSize int) ([]*Ac
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get accounts: %w, %w", err, errRes.Error())
+		return nil, 0, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get accounts: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Accounts, res.Pagination.NextPage, nil
 }

--- a/internal/connectors/plugins/public/currencycloud/client/auth.go
+++ b/internal/connectors/plugins/public/currencycloud/client/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (c *client) authenticate(ctx context.Context) error {
@@ -36,7 +37,10 @@ func (c *client) authenticate(ctx context.Context) error {
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return fmt.Errorf("failed to get authenticate: %w, %w", err, errRes.Error())
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get authenticate: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	c.authToken = res.AuthToken

--- a/internal/connectors/plugins/public/currencycloud/client/balances.go
+++ b/internal/connectors/plugins/public/currencycloud/client/balances.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Balance struct {
@@ -53,7 +54,10 @@ func (c *client) GetBalances(ctx context.Context, page int, pageSize int) ([]*Ba
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get balances %w, %w", err, errRes.Error())
+		return nil, 0, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get balances: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Balances, res.Pagination.NextPage, nil
 }

--- a/internal/connectors/plugins/public/currencycloud/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/currencycloud/client/beneficiaries.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Beneficiary struct {
@@ -52,7 +53,10 @@ func (c *client) GetBeneficiaries(ctx context.Context, page int, pageSize int) (
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get beneficiaries %w, %w", err, errRes.Error())
+		return nil, 0, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get beneficiaries: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Beneficiaries, res.Pagination.NextPage, nil
 }

--- a/internal/connectors/plugins/public/currencycloud/client/contacts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/contacts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Contact struct {
@@ -39,11 +40,17 @@ func (c *client) GetContactID(ctx context.Context, accountID string) (*Contact, 
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get contacts %w, %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get contacts: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	if len(res.Contacts) == 0 {
-		return nil, fmt.Errorf("no contact found for account %s: %w", accountID, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("no contact found for account %s", accountID),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return res.Contacts[0], nil

--- a/internal/connectors/plugins/public/currencycloud/client/payouts.go
+++ b/internal/connectors/plugins/public/currencycloud/client/payouts.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type PayoutRequest struct {
@@ -74,7 +75,10 @@ func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutReques
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &payoutResponse, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create payout: %w, %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create payout: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	return &payoutResponse, nil

--- a/internal/connectors/plugins/public/currencycloud/client/transactions.go
+++ b/internal/connectors/plugins/public/currencycloud/client/transactions.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 //nolint:tagliatelle // allow different styled tags in client
@@ -67,7 +68,10 @@ func (c *client) GetTransactions(ctx context.Context, page int, pageSize int, up
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get transactions: %w, %w", err, errRes.Error())
+		return nil, 0, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transactions: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Transactions, res.Pagination.NextPage, nil
 }

--- a/internal/connectors/plugins/public/currencycloud/client/transfers.go
+++ b/internal/connectors/plugins/public/currencycloud/client/transfers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type TransferRequest struct {
@@ -73,7 +74,10 @@ func (c *client) InitiateTransfer(ctx context.Context, transferRequest *Transfer
 	var errRes currencyCloudError
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transfer: %w, %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create transfer: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	return &res, nil

--- a/internal/connectors/plugins/public/currencycloud/payouts.go
+++ b/internal/connectors/plugins/public/currencycloud/payouts.go
@@ -8,15 +8,22 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/currencycloud/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validatePayoutRequest(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil
@@ -29,12 +36,18 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %v", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int amount %v: %v", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiatePayout(ctx, &client.PayoutRequest{

--- a/internal/connectors/plugins/public/currencycloud/payouts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/payouts_test.go
@@ -69,7 +69,7 @@ var _ = Describe("CurrencyCloud Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("CurrencyCloud Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("CurrencyCloud Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/currencycloud/transfers.go
+++ b/internal/connectors/plugins/public/currencycloud/transfers.go
@@ -8,15 +8,22 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/currencycloud/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validateTransferRequest(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil
@@ -29,12 +36,18 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %v", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int amount %v: %v", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiateTransfer(

--- a/internal/connectors/plugins/public/currencycloud/transfers_test.go
+++ b/internal/connectors/plugins/public/currencycloud/transfers_test.go
@@ -69,7 +69,7 @@ var _ = Describe("CurrencyCloud Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("CurrencyCloud Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("CurrencyCloud Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/generic/balances.go
+++ b/internal/connectors/plugins/public/generic/balances.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBalancesRequest) (models.FetchNextBalancesResponse, error) {
 	var from models.PSPAccount
 	if req.FromPayload == nil {
-		return models.FetchNextBalancesResponse{}, fmt.Errorf("from payload is required: %w", models.ErrInvalidRequest)
+		return models.FetchNextBalancesResponse{}, errorsutils.NewWrappedError(
+			fmt.Errorf("from payload is required"),
+			models.ErrInvalidRequest,
+		)
 	}
 	if err := json.Unmarshal(req.FromPayload, &from); err != nil {
 		return models.FetchNextBalancesResponse{}, err

--- a/internal/connectors/plugins/public/mangopay/bank_account_creation.go
+++ b/internal/connectors/plugins/public/mangopay/bank_account_creation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/mangopay/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (models.CreateBankAccountResponse, error) {
@@ -49,7 +50,10 @@ func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (
 		var err error
 		mangopayBankAccount, err = p.client.CreateIBANBankAccount(ctx, userID, req)
 		if err != nil {
-			return models.CreateBankAccountResponse{}, fmt.Errorf("%w: %w", models.ErrFailedAccountCreation, err)
+			return models.CreateBankAccountResponse{}, errorsutils.NewWrappedError(
+				fmt.Errorf("failed to create IBAN bank account: %w", err),
+				models.ErrFailedAccountCreation,
+			)
 		}
 	} else {
 		if ba.Country == nil {
@@ -73,7 +77,10 @@ func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (
 			var err error
 			mangopayBankAccount, err = p.client.CreateUSBankAccount(ctx, userID, req)
 			if err != nil {
-				return models.CreateBankAccountResponse{}, fmt.Errorf("%w: %w", models.ErrFailedAccountCreation, err)
+				return models.CreateBankAccountResponse{}, errorsutils.NewWrappedError(
+					fmt.Errorf("failed to create US bank account: %w", err),
+					models.ErrFailedAccountCreation,
+				)
 			}
 
 		case "CA":
@@ -93,7 +100,10 @@ func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (
 			var err error
 			mangopayBankAccount, err = p.client.CreateCABankAccount(ctx, userID, req)
 			if err != nil {
-				return models.CreateBankAccountResponse{}, fmt.Errorf("%w: %w", models.ErrFailedAccountCreation, err)
+				return models.CreateBankAccountResponse{}, errorsutils.NewWrappedError(
+					fmt.Errorf("failed to create CA bank account: %w", err),
+					models.ErrFailedAccountCreation,
+				)
 			}
 
 		case "GB":
@@ -112,7 +122,10 @@ func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (
 			var err error
 			mangopayBankAccount, err = p.client.CreateGBBankAccount(ctx, userID, req)
 			if err != nil {
-				return models.CreateBankAccountResponse{}, fmt.Errorf("%w: %w", models.ErrFailedAccountCreation, err)
+				return models.CreateBankAccountResponse{}, errorsutils.NewWrappedError(
+					fmt.Errorf("failed to create GB bank account: %w", err),
+					models.ErrFailedAccountCreation,
+				)
 			}
 
 		default:
@@ -137,7 +150,10 @@ func (p *Plugin) createBankAccount(ctx context.Context, ba models.BankAccount) (
 			var err error
 			mangopayBankAccount, err = p.client.CreateOtherBankAccount(ctx, userID, req)
 			if err != nil {
-				return models.CreateBankAccountResponse{}, fmt.Errorf("%w: %w", models.ErrFailedAccountCreation, err)
+				return models.CreateBankAccountResponse{}, errorsutils.NewWrappedError(
+					fmt.Errorf("failed to create other bank account: %w", err),
+					models.ErrFailedAccountCreation,
+				)
 			}
 		}
 	}

--- a/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to create account: test error"))
+			Expect(err).To(MatchError("failed to create IBAN bank account: test error: failed to create account"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -179,7 +179,7 @@ var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to create account: test error"))
+			Expect(err).To(MatchError("failed to create US bank account: test error: failed to create account"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -261,7 +261,7 @@ var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to create account: test error"))
+			Expect(err).To(MatchError("failed to create CA bank account: test error: failed to create account"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -342,7 +342,7 @@ var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to create account: test error"))
+			Expect(err).To(MatchError("failed to create GB bank account: test error: failed to create account"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 
@@ -422,7 +422,7 @@ var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to create account: test error"))
+			Expect(err).To(MatchError("failed to create other bank account: test error: failed to create account"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/mangopay/client/payin.go
+++ b/internal/connectors/plugins/public/mangopay/client/payin.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type PayinResponse struct {
@@ -41,7 +41,10 @@ func (c *client) GetPayin(ctx context.Context, payinID string) (*PayinResponse, 
 	var payinResponse PayinResponse
 	statusCode, err := c.httpClient.Do(ctx, req, &payinResponse, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get payin: %w", err), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payin: status code %d", statusCode),
+			err,
+		)
 	}
 	return &payinResponse, nil
 }

--- a/internal/connectors/plugins/public/mangopay/client/refund.go
+++ b/internal/connectors/plugins/public/mangopay/client/refund.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Refund struct {
@@ -42,7 +42,10 @@ func (c *client) GetRefund(ctx context.Context, refundID string) (*Refund, error
 	var refund Refund
 	statusCode, err := c.httpClient.Do(ctx, req, &refund, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get refund: %w", err), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get refund: status code %d", statusCode),
+			err,
+		)
 	}
 	return &refund, nil
 }

--- a/internal/connectors/plugins/public/mangopay/client/transactions.go
+++ b/internal/connectors/plugins/public/mangopay/client/transactions.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Payment struct {
@@ -51,7 +51,10 @@ func (c *client) GetTransactions(ctx context.Context, walletsID string, page, pa
 	var payments []Payment
 	statusCode, err := c.httpClient.Do(ctx, req, &payments, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get transactions: %w", err), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transactions: status code %d", statusCode),
+			err,
+		)
 	}
 	return payments, nil
 }

--- a/internal/connectors/plugins/public/mangopay/client/users.go
+++ b/internal/connectors/plugins/public/mangopay/client/users.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type User struct {
@@ -33,7 +33,10 @@ func (c *client) GetUsers(ctx context.Context, page int, pageSize int) ([]User, 
 	var users []User
 	statusCode, err := c.httpClient.Do(ctx, req, &users, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get user response: %w", err), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get users: status code %d", statusCode),
+			err,
+		)
 	}
 	return users, nil
 }

--- a/internal/connectors/plugins/public/mangopay/client/wallets.go
+++ b/internal/connectors/plugins/public/mangopay/client/wallets.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Wallet struct {
@@ -39,10 +39,12 @@ func (c *client) GetWallets(ctx context.Context, userID string, page, pageSize i
 	req.URL.RawQuery = q.Encode()
 
 	var wallets []Wallet
-	var errRes mangopayError
-	statusCode, err := c.httpClient.Do(ctx, req, &wallets, &errRes)
+	statusCode, err := c.httpClient.Do(ctx, req, &wallets, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get wallets: %w %w", err, errRes.Error()), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get wallets: status code %d", statusCode),
+			err,
+		)
 	}
 	return wallets, nil
 }
@@ -57,10 +59,12 @@ func (c *client) GetWallet(ctx context.Context, walletID string) (*Wallet, error
 	}
 
 	var wallet Wallet
-	var errRes mangopayError
-	statusCode, err := c.httpClient.Do(ctx, req, &wallet, &errRes)
+	statusCode, err := c.httpClient.Do(ctx, req, &wallet, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to get wallet: %w %w", err, errRes.Error()), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get wallet: status code %d", statusCode),
+			err,
+		)
 	}
 	return &wallet, nil
 }

--- a/internal/connectors/plugins/public/mangopay/client/webhooks.go
+++ b/internal/connectors/plugins/public/mangopay/client/webhooks.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/formancehq/go-libs/v2/errorsutils"
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type EventType string
@@ -97,10 +97,12 @@ func (c *client) ListAllHooks(ctx context.Context) ([]*Hook, error) {
 	req.URL.RawQuery = q.Encode()
 
 	var hooks []*Hook
-	var errRes mangopayError
-	statusCode, err := c.httpClient.Do(ctx, req, &hooks, &errRes)
+	statusCode, err := c.httpClient.Do(ctx, req, &hooks, nil)
 	if err != nil {
-		return nil, errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to list hooks: %w %w", err, errRes.Error()), statusCode)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to list hooks: status code %d", statusCode),
+			err,
+		)
 	}
 	return hooks, nil
 }
@@ -129,9 +131,12 @@ func (c *client) CreateHook(ctx context.Context, eventType EventType, URL string
 	req.Header.Set("Content-Type", "application/json")
 
 	var errRes mangopayError
-	statusCode, err := c.httpClient.Do(ctx, req, nil, &errRes)
+	_, err = c.httpClient.Do(ctx, req, nil, &errRes)
 	if err != nil {
-		return errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to create hook: %w %w", err, errRes.Error()), statusCode)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create hook: %v", errRes.Error()),
+			err,
+		)
 	}
 	return nil
 }
@@ -160,9 +165,12 @@ func (c *client) UpdateHook(ctx context.Context, hookID string, URL string) erro
 	req.Header.Set("Content-Type", "application/json")
 
 	var errRes mangopayError
-	statusCode, err := c.httpClient.Do(ctx, req, nil, &errRes)
+	_, err = c.httpClient.Do(ctx, req, nil, &errRes)
 	if err != nil {
-		return errorsutils.NewErrorWithExitCode(fmt.Errorf("failed to update hook: %w %w", err, errRes.Error()), statusCode)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to update hook: %v", errRes.Error()),
+			err,
+		)
 	}
 	return nil
 }

--- a/internal/connectors/plugins/public/mangopay/payouts.go
+++ b/internal/connectors/plugins/public/mangopay/payouts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/mangopay/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/google/uuid"
 )
 
@@ -21,24 +22,39 @@ var (
 func (p *Plugin) validatePayoutRequest(pi models.PSPPaymentInitiation) error {
 	_, err := uuid.Parse(pi.Reference)
 	if err != nil {
-		return fmt.Errorf("reference is required as an uuid: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("reference %s is required to be an uuid in payout request", pi.Reference),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("missing source account: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("missing destination account: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	_, ok := pi.SourceAccount.Metadata[userIDMetadataKey]
 	if !ok {
-		return fmt.Errorf("source account metadata with user id is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account metadata with user id is required in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if len(pi.Description) > 12 || !bankWireRefPatternRegexp.MatchString(pi.Description) {
-		return fmt.Errorf("description must be alphanumeric and less than 12 characters: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("description must be alphanumeric and less than 12 characters in payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil
@@ -53,7 +69,10 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	curr, _, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %w: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiatePayout(ctx, &client.PayoutRequest{

--- a/internal/connectors/plugins/public/mangopay/payouts_test.go
+++ b/internal/connectors/plugins/public/mangopay/payouts_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("reference is required as an uuid: invalid request"))
+			Expect(err).To(MatchError("reference test is required to be an uuid in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -86,7 +86,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("missing source account: invalid request"))
+			Expect(err).To(MatchError("source account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("missing destination account: invalid request"))
+			Expect(err).To(MatchError("destination account is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with user id is required: invalid request"))
+			Expect(err).To(MatchError("source account metadata with user id is required in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("description must be alphanumeric and less than 12 characters: invalid request"))
+			Expect(err).To(MatchError("description must be alphanumeric and less than 12 characters in payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -138,7 +138,7 @@ var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/mangopay/transfers.go
+++ b/internal/connectors/plugins/public/mangopay/transfers.go
@@ -10,26 +10,39 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/mangopay/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/google/uuid"
 )
 
 func (p *Plugin) validateTransferRequest(pi models.PSPPaymentInitiation) error {
 	_, err := uuid.Parse(pi.Reference)
 	if err != nil {
-		return fmt.Errorf("reference is required as an uuid: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("reference %s is required to be an uuid in transfer request", pi.Reference),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	_, ok := pi.SourceAccount.Metadata[userIDMetadataKey]
 	if !ok {
-		return fmt.Errorf("source account metadata with user id is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account metadata with user id is required in transfer request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil
@@ -44,7 +57,10 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, _, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %v", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiateWalletTransfer(

--- a/internal/connectors/plugins/public/mangopay/transfers_test.go
+++ b/internal/connectors/plugins/public/mangopay/transfers_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("reference is required as an uuid: invalid request"))
+			Expect(err).To(MatchError("reference test is required to be an uuid in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -86,7 +86,7 @@ var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with user id is required: invalid request"))
+			Expect(err).To(MatchError("source account metadata with user id is required in transfer request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -125,7 +125,7 @@ var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/mangopay/webhooks.go
+++ b/internal/connectors/plugins/public/mangopay/webhooks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/mangopay/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type webhookTranslateRequest struct {
@@ -101,7 +102,10 @@ func (p *Plugin) initWebhookConfig() {
 
 func (p *Plugin) createWebhooks(ctx context.Context, req models.CreateWebhooksRequest) error {
 	if req.WebhookBaseUrl == "" {
-		return fmt.Errorf("STACK_PUBLIC_URL is not set: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("webhook base URL is required"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	activeHooks, err := p.getActiveHooks(ctx)

--- a/internal/connectors/plugins/public/mangopay/webhooks_test.go
+++ b/internal/connectors/plugins/public/mangopay/webhooks_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Mangopay Plugin Create Webhooks", func() {
 
 			resp, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("STACK_PUBLIC_URL is not set: invalid request"))
+			Expect(err).To(MatchError("webhook base URL is required: invalid request"))
 			Expect(resp).To(Equal(models.CreateWebhooksResponse{}))
 		})
 
@@ -371,7 +371,7 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 
 			resp, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("invalid Date query parameter: invalid request"))
+			Expect(err).To(MatchError("invalid Date query parameter: strconv.ParseInt: parsing \"test\": invalid syntax: invalid request"))
 			Expect(resp).To(Equal(models.TranslateWebhookResponse{}))
 		})
 
@@ -389,7 +389,7 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 
 			resp, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("unsupported webhook event type: invalid request"))
+			Expect(err).To(MatchError("unsupported webhook event type: TEST: invalid request"))
 			Expect(resp).To(Equal(models.TranslateWebhookResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/modulr/client/accounts.go
+++ b/internal/connectors/plugins/public/modulr/client/accounts.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 //nolint:tagliatelle // allow for clients
@@ -46,10 +47,13 @@ func (c *client) GetAccounts(ctx context.Context, page, pageSize int, fromCreate
 	req.URL.RawQuery = q.Encode()
 
 	var res responseWrapper[[]Account]
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get accounts: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get accounts: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Content, nil
 }
@@ -63,10 +67,13 @@ func (c *client) GetAccount(ctx context.Context, accountID string) (*Account, er
 	}
 
 	var res Account
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get account: %v", errRes.Error()),
+			err,
+		)
 	}
 	return &res, nil
 }

--- a/internal/connectors/plugins/public/modulr/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/modulr/client/beneficiaries.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Beneficiary struct {
@@ -33,10 +34,13 @@ func (c *client) GetBeneficiaries(ctx context.Context, page, pageSize int, modif
 	req.URL.RawQuery = q.Encode()
 
 	var res responseWrapper[[]Beneficiary]
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get beneficiaries: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get beneficiaries: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Content, nil
 }

--- a/internal/connectors/plugins/public/modulr/client/error.go
+++ b/internal/connectors/plugins/public/modulr/client/error.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 )
+
+type modulrErrors []modulrError
 
 type modulrError struct {
 	StatusCode    int    `json:"-"`
@@ -13,7 +16,13 @@ type modulrError struct {
 	SourceService string `json:"sourceService"`
 }
 
-func (me *modulrError) Error() error {
+func (mes modulrErrors) Error() error {
+	if len(mes) == 0 {
+		return errors.New("unexpected error")
+	}
+
+	me := mes[0]
+
 	var err error
 	if me.Message == "" {
 		err = fmt.Errorf("unexpected status code: %d", me.StatusCode)

--- a/internal/connectors/plugins/public/modulr/client/payments.go
+++ b/internal/connectors/plugins/public/modulr/client/payments.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type PaymentType string
@@ -57,10 +58,13 @@ func (c *client) GetPayments(ctx context.Context, paymentType PaymentType, page,
 	req.URL.RawQuery = q.Encode()
 
 	var res responseWrapper[[]Payment]
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get payments: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payments: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Content, nil
 }

--- a/internal/connectors/plugins/public/modulr/client/payout.go
+++ b/internal/connectors/plugins/public/modulr/client/payout.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type PayoutRequest struct {
@@ -46,10 +47,13 @@ func (c *client) InitiatePayout(ctx context.Context, payoutRequest *PayoutReques
 	req.Header.Set("x-mod-nonce", payoutRequest.IdempotencyKey)
 
 	var res PayoutResponse
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create payout: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create payout: %v", errRes.Error()),
+			err,
+		)
 	}
 	return &res, nil
 }
@@ -63,10 +67,13 @@ func (c *client) GetPayout(ctx context.Context, payoutID string) (PayoutResponse
 	}
 
 	var res PayoutResponse
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return PayoutResponse{}, fmt.Errorf("failed to get payout: %w %w", err, errRes.Error())
+		return PayoutResponse{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payout: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res, nil
 }

--- a/internal/connectors/plugins/public/modulr/client/transactions.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 //nolint:tagliatelle // allow different styled tags in client
@@ -42,10 +43,13 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 	req.URL.RawQuery = q.Encode()
 
 	var res responseWrapper[[]Transaction]
-	var errRes modulrError
+	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transactions: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transactions: %v", errRes.Error()),
+			err,
+		)
 	}
 	return res.Content, nil
 }

--- a/internal/connectors/plugins/public/modulr/payouts.go
+++ b/internal/connectors/plugins/public/modulr/payouts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/modulr/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiation) (*models.PSPPayment, error) {
@@ -18,12 +19,18 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %v", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int: %v: %w", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	description := pi.Description

--- a/internal/connectors/plugins/public/modulr/payouts_test.go
+++ b/internal/connectors/plugins/public/modulr/payouts_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Modulr Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("Modulr Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("Modulr Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/modulr/transfers.go
+++ b/internal/connectors/plugins/public/modulr/transfers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/modulr/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiation) (*models.PSPPayment, error) {
@@ -18,12 +19,18 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int amount %v: %w", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	description := pi.Description

--- a/internal/connectors/plugins/public/modulr/transfers_test.go
+++ b/internal/connectors/plugins/public/modulr/transfers_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Modulr Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("Modulr Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("Modulr Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/modulr/utils.go
+++ b/internal/connectors/plugins/public/modulr/utils.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 var (
@@ -13,15 +14,24 @@ var (
 
 func (p *Plugin) validateTransferPayoutRequests(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if len(pi.Description) > 18 || !referencePatternRegexp.MatchString(pi.Description) {
-		return fmt.Errorf("description is invalid: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("description must be less than 18 characters and match the following regexp [a-zA-Z0-9 ]*: %s", pi.Description),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/public/moneycorp/client/accounts.go
+++ b/internal/connectors/plugins/public/moneycorp/client/accounts.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type accountsResponse struct {
@@ -39,10 +40,13 @@ func (c *client) GetAccounts(ctx context.Context, page int, pageSize int) ([]*Ac
 	req.URL.RawQuery = q.Encode()
 
 	accounts := accountsResponse{Accounts: make([]*Account, 0)}
-	var errRes moneycorpError
+	var errRes moneycorpErrors
 	_, err = c.httpClient.Do(ctx, req, &accounts, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get accounts: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get accounts: %v", errRes.Error()),
+			err,
+		)
 	}
 	return accounts.Accounts, nil
 }

--- a/internal/connectors/plugins/public/moneycorp/client/error.go
+++ b/internal/connectors/plugins/public/moneycorp/client/error.go
@@ -8,19 +8,23 @@ type moneycorpErrors struct {
 	Errors []*moneycorpError `json:"errors"`
 }
 
+func (mes *moneycorpErrors) Error() error {
+	return toError(0, *mes).Error()
+}
+
 type moneycorpError struct {
-	StatusCode int    `json:"-"`
-	Code       string `json:"code"`
-	Title      string `json:"title"`
-	Detail     string `json:"detail"`
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
 }
 
 func (me *moneycorpError) Error() error {
 	var err error
 	if me.Detail == "" {
-		err = fmt.Errorf("unexpected status code: %d", me.StatusCode)
+		err = fmt.Errorf("unexpected status code: %d", me.Status)
 	} else {
-		err = fmt.Errorf("%d: %s", me.StatusCode, me.Detail)
+		err = fmt.Errorf("%d: %s", me.Status, me.Detail)
 	}
 
 	return err
@@ -29,14 +33,14 @@ func (me *moneycorpError) Error() error {
 func toError(statusCode int, ces moneycorpErrors) *moneycorpError {
 	if len(ces.Errors) == 0 {
 		return &moneycorpError{
-			StatusCode: statusCode,
+			Status: statusCode,
 		}
 	}
 
 	return &moneycorpError{
-		StatusCode: statusCode,
-		Code:       ces.Errors[0].Code,
-		Title:      ces.Errors[0].Title,
-		Detail:     ces.Errors[0].Detail,
+		Status: ces.Errors[0].Status,
+		Code:   ces.Errors[0].Code,
+		Title:  ces.Errors[0].Title,
+		Detail: ces.Errors[0].Detail,
 	}
 }

--- a/internal/connectors/plugins/public/moneycorp/client/recipients.go
+++ b/internal/connectors/plugins/public/moneycorp/client/recipients.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type recipientsResponse struct {
@@ -42,10 +43,13 @@ func (c *client) GetRecipients(ctx context.Context, accountID string, page int, 
 	req.URL.RawQuery = q.Encode()
 
 	recipients := recipientsResponse{Recipients: make([]*Recipient, 0)}
-	var errRes moneycorpError
+	var errRes moneycorpErrors
 	_, err = c.httpClient.Do(ctx, req, &recipients, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get recipients: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get recipients: %v", errRes.Error()),
+			err,
+		)
 	}
 	return recipients.Recipients, nil
 }

--- a/internal/connectors/plugins/public/moneycorp/client/transactions.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transactions.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type transactionsResponse struct {
@@ -96,10 +97,13 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 	req.URL.RawQuery = q.Encode()
 
 	transactions := transactionsResponse{Transactions: make([]*Transaction, 0)}
-	var errRes moneycorpError
+	var errRes moneycorpErrors
 	_, err = c.httpClient.Do(ctx, req, &transactions, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transactions: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transactions: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	return transactions.Transactions, nil

--- a/internal/connectors/plugins/public/moneycorp/client/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transfers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type transferRequest struct {
@@ -71,10 +72,13 @@ func (c *client) InitiateTransfer(ctx context.Context, tr *TransferRequest) (*Tr
 	req.Header.Set("Idempotency-Key", tr.IdempotencyKey)
 
 	var transferResponse transferResponse
-	var errRes moneycorpError
+	var errRes moneycorpErrors
 	_, err = c.httpClient.Do(ctx, req, &transferResponse, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initiate transfer: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to initiate transfer: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	return transferResponse.Transfer, nil
@@ -91,10 +95,13 @@ func (c *client) GetTransfer(ctx context.Context, accountID string, transferID s
 	req.Header.Set("Content-Type", "application/json")
 
 	var transferResponse transferResponse
-	var errRes moneycorpError
+	var errRes moneycorpErrors
 	_, err = c.httpClient.Do(ctx, req, &transferResponse, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transfer: %w %w", err, errRes.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transfer: %v", errRes.Error()),
+			err,
+		)
 	}
 
 	return transferResponse.Transfer, nil

--- a/internal/connectors/plugins/public/moneycorp/payouts.go
+++ b/internal/connectors/plugins/public/moneycorp/payouts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiation) (*models.PSPPayment, error) {
@@ -19,12 +20,18 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int %v, %w", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiatePayout(

--- a/internal/connectors/plugins/public/moneycorp/payouts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payouts_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Moneycorp *Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("Moneycorp *Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("Moneycorp *Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/moneycorp/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiation) (*models.PSPPayment, error) {
@@ -19,12 +20,18 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, precision, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	amount, err := currency.GetStringAmountFromBigIntWithPrecision(pi.Amount, precision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get string amount from big int: %v: %w", err, models.ErrInvalidRequest)
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get string amount from big int amount %v: %w", pi.Amount, err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	resp, err := p.client.InitiateTransfer(

--- a/internal/connectors/plugins/public/moneycorp/transfers_test.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Moneycorp *Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("Moneycorp *Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("Moneycorp *Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/moneycorp/utils.go
+++ b/internal/connectors/plugins/public/moneycorp/utils.go
@@ -4,15 +4,22 @@ import (
 	"fmt"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validateTransferPayoutRequests(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/public/stripe/client/client.go
+++ b/internal/connectors/plugins/public/stripe/client/client.go
@@ -2,11 +2,11 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/metrics"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/stripe/stripe-go/v79"
 	"github.com/stripe/stripe-go/v79/account"
 	"github.com/stripe/stripe-go/v79/balance"
@@ -72,12 +72,18 @@ func wrapSDKErr(err error) error {
 	}
 
 	if stripeErr.Code == stripe.ErrorCodeRateLimit {
-		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeTooManyRequests, err)
+		return errorsutils.NewWrappedError(
+			err,
+			httpwrapper.ErrStatusCodeTooManyRequests,
+		)
 	}
 
 	switch stripeErr.Type {
 	case stripe.ErrorTypeInvalidRequest, stripe.ErrorTypeIdempotency:
-		return fmt.Errorf("%w: %w", httpwrapper.ErrStatusCodeClientError, err)
+		return errorsutils.NewWrappedError(
+			err,
+			httpwrapper.ErrStatusCodeClientError,
+		)
 	}
 	return err
 }

--- a/internal/connectors/plugins/public/stripe/create_payouts.go
+++ b/internal/connectors/plugins/public/stripe/create_payouts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/stripe/stripe-go/v79"
 )
 
@@ -21,7 +22,10 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 
 	curr, _, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	var source *string = nil

--- a/internal/connectors/plugins/public/stripe/create_payouts_test.go
+++ b/internal/connectors/plugins/public/stripe/create_payouts_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Stripe Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("Stripe Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HHH: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/stripe/create_transfers.go
+++ b/internal/connectors/plugins/public/stripe/create_transfers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/stripe/stripe-go/v79"
 )
 
@@ -21,7 +22,10 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 
 	curr, _, err := currency.GetCurrencyAndPrecisionFromAsset(supportedCurrenciesWithDecimal, pi.Asset)
 	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("failed to get currency and precision from asset: %v: %w", err, models.ErrInvalidRequest)
+		return models.PSPPayment{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get currency and precision from asset: %w", err),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	var source *string = nil

--- a/internal/connectors/plugins/public/stripe/create_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/create_transfers_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Stripe Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("Stripe Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HHH: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/stripe/reverse_transfers.go
+++ b/internal/connectors/plugins/public/stripe/reverse_transfers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/stripe/stripe-go/v79"
 )
 
@@ -21,7 +22,10 @@ const (
 func validateReverseTransferRequest(pir models.PSPPaymentInitiationReversal) error {
 	_, ok := pir.Metadata[transferIDMetadataKey]
 	if !ok {
-		return fmt.Errorf("transfer id is required in metadata: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("transfer id is required in metadata of transfer reversal request"),
+			models.ErrInvalidRequest,
+		)
 	}
 	return nil
 }

--- a/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Stripe Plugin Transfers Reversal", func() {
 			}
 			resp, err := plg.ReverseTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("transfer id is required in metadata: invalid request"))
+			Expect(err).To(MatchError("transfer id is required in metadata of transfer reversal request: invalid request"))
 			Expect(resp).To(Equal(models.ReverseTransferResponse{}))
 		})
 		It("should return an error - reverse transfer error", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/stripe/utils.go
+++ b/internal/connectors/plugins/public/stripe/utils.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validatePayoutTransferRequest(pi models.PSPPaymentInitiation) error {
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/public/wise/client/balances.go
+++ b/internal/connectors/plugins/public/wise/client/balances.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type BalanceAmount struct {
@@ -51,7 +52,10 @@ func (c *client) GetBalances(ctx context.Context, profileID uint64) ([]Balance, 
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &balances, &errRes)
 	if err != nil {
-		return balances, fmt.Errorf("failed to get balances: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get balances: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return balances, nil
 }
@@ -69,7 +73,10 @@ func (c *client) GetBalance(ctx context.Context, profileID uint64, balanceID uin
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &balance, &errRes)
 	if err != nil {
-		return &balance, fmt.Errorf("failed to get balance: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get balance: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &balance, nil
 }

--- a/internal/connectors/plugins/public/wise/client/payouts.go
+++ b/internal/connectors/plugins/public/wise/client/payouts.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Payout struct {
@@ -74,7 +75,10 @@ func (c *client) GetPayout(ctx context.Context, payoutID string) (*Payout, error
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &payout, &errRes)
 	if err != nil {
-		return &payout, fmt.Errorf("failed to get payout: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get payout: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &payout, nil
 }
@@ -101,7 +105,10 @@ func (c *client) CreatePayout(ctx context.Context, quote Quote, targetAccount ui
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &payout, &errRes)
 	if err != nil {
-		return &payout, fmt.Errorf("failed to make payout: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to initiate payout: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &payout, nil
 }

--- a/internal/connectors/plugins/public/wise/client/profiles.go
+++ b/internal/connectors/plugins/public/wise/client/profiles.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Profile struct {
@@ -25,7 +26,10 @@ func (c *client) GetProfiles(ctx context.Context) ([]Profile, error) {
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &profiles, &errRes)
 	if err != nil {
-		return profiles, fmt.Errorf("failed to make profiles: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get profiles: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return profiles, nil
 }

--- a/internal/connectors/plugins/public/wise/client/quotes.go
+++ b/internal/connectors/plugins/public/wise/client/quotes.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/google/uuid"
 )
 
@@ -43,7 +44,10 @@ func (c *client) CreateQuote(ctx context.Context, profileID, currency string, am
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &quote, &errRes)
 	if err != nil {
-		return quote, fmt.Errorf("failed to get response from quote: %w %w", err, errRes.Error(statusCode).Error())
+		return Quote{}, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create quote: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return quote, nil
 }

--- a/internal/connectors/plugins/public/wise/client/recipient_accounts.go
+++ b/internal/connectors/plugins/public/wise/client/recipient_accounts.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type RecipientAccountsResponse struct {
@@ -48,7 +49,10 @@ func (c *client) GetRecipientAccounts(ctx context.Context, profileID uint64, pag
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &accounts, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get recipient accounts: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get recipient accounts: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &accounts, nil
 }
@@ -78,7 +82,10 @@ func (c *client) GetRecipientAccount(ctx context.Context, accountID uint64) (*Re
 			// our recipients.
 			return &RecipientAccount{}, nil
 		}
-		return nil, fmt.Errorf("failed to get recipient account: %w %w", err, e.Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get recipient account: %v", e.Error()),
+			err,
+		)
 	}
 
 	c.recipientAccountsCache.Add(accountID, &res)

--- a/internal/connectors/plugins/public/wise/client/transfers.go
+++ b/internal/connectors/plugins/public/wise/client/transfers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/metrics"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type Transfer struct {
@@ -80,7 +81,10 @@ func (c *client) GetTransfers(ctx context.Context, profileID uint64, offset int,
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &transfers, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transfers: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transfers: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 
 	for i, transfer := range transfers {
@@ -168,7 +172,10 @@ func (c *client) GetTransfer(ctx context.Context, transferID string) (*Transfer,
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &transfer, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transfer: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to get transfer: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &transfer, nil
 }
@@ -195,7 +202,10 @@ func (c *client) CreateTransfer(ctx context.Context, quote Quote, targetAccount 
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &transfer, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transfer: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create transfer: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &transfer, nil
 }

--- a/internal/connectors/plugins/public/wise/client/webhooks.go
+++ b/internal/connectors/plugins/public/wise/client/webhooks.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 type WebhookDelivery struct {
@@ -64,7 +66,10 @@ func (c *client) CreateWebhook(ctx context.Context, profileID uint64, name, trig
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create subscription: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to create subscription: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return &res, nil
 }
@@ -80,7 +85,10 @@ func (c *client) ListWebhooksSubscription(ctx context.Context, profileID uint64)
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get subscription: %w %w", err, errRes.Error(statusCode).Error())
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("failed to list subscriptions: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return res, nil
 }
@@ -95,7 +103,10 @@ func (c *client) DeleteWebhooks(ctx context.Context, profileID uint64, subscript
 	var errRes wiseErrors
 	statusCode, err := c.httpClient.Do(ctx, req, nil, &errRes)
 	if err != nil {
-		return fmt.Errorf("failed to delete webhooks: %w %w", err, errRes.Error(statusCode).Error())
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to delete subscription: %v", errRes.Error(statusCode)),
+			err,
+		)
 	}
 	return nil
 }

--- a/internal/connectors/plugins/public/wise/config.go
+++ b/internal/connectors/plugins/public/wise/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 )
@@ -22,19 +23,28 @@ type Config struct {
 func (c *Config) validate() error {
 	p, _ := pem.Decode([]byte(c.WebhookPublicKey))
 	if p == nil {
-		return fmt.Errorf("invalid webhook public key in config: %w", models.ErrInvalidConfig)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("invalid webhook public key in config"),
+			models.ErrInvalidConfig,
+		)
 	}
 
 	publicKey, err := x509.ParsePKIXPublicKey(p.Bytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse webhook public key in config %w: %w", err, models.ErrInvalidConfig)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("failed to parse webhook public key in config %w", err),
+			models.ErrInvalidConfig,
+		)
 	}
 
 	switch pub := publicKey.(type) {
 	case *rsa.PublicKey:
 		c.webhookPublicKey = pub
 	default:
-		return fmt.Errorf("invalid webhook public key in config: %w", models.ErrInvalidConfig)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("invalid webhook public key in config"),
+			models.ErrInvalidConfig,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/public/wise/payouts_test.go
+++ b/internal/connectors/plugins/public/wise/payouts_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -102,7 +102,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with profile id is required: invalid request"))
+			Expect(err).To(MatchError("source account metadata with profile id is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with profile id is required as an integer: invalid request"))
+			Expect(err).To(MatchError("source account metadata with profile id is required as an integer in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -128,7 +128,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account metadata with profile id is required: invalid request"))
+			Expect(err).To(MatchError("destination account metadata with profile id is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -141,7 +141,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account metadata with profile id is required as an integer: invalid request"))
+			Expect(err).To(MatchError("destination account metadata with profile id is required as an integer in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 
@@ -154,7 +154,7 @@ var _ = Describe("Wise Plugin Payouts Creation", func() {
 
 			resp, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreatePayoutResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/wise/transfers_test.go
+++ b/internal/connectors/plugins/public/wise/transfers_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account is required: invalid request"))
+			Expect(err).To(MatchError("source account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account is required: invalid request"))
+			Expect(err).To(MatchError("destination account is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -102,7 +102,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with profile id is required: invalid request"))
+			Expect(err).To(MatchError("source account metadata with profile id is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("source account metadata with profile id is required as an integer: invalid request"))
+			Expect(err).To(MatchError("source account metadata with profile id is required as an integer in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -128,7 +128,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account metadata with profile id is required: invalid request"))
+			Expect(err).To(MatchError("destination account metadata with profile id is required in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -141,7 +141,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("destination account metadata with profile id is required as an integer: invalid request"))
+			Expect(err).To(MatchError("destination account metadata with profile id is required as an integer in transfer/payout request: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 
@@ -154,7 +154,7 @@ var _ = Describe("Wise Plugin Transfers Creation", func() {
 
 			resp, err := plg.CreateTransfer(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("failed to get currency and precision from asset: missing currencies: invalid request"))
+			Expect(err).To(MatchError("failed to get currency and precision from asset: HUF: missing currencies: invalid request"))
 			Expect(resp).To(Equal(models.CreateTransferResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/wise/utils.go
+++ b/internal/connectors/plugins/public/wise/utils.go
@@ -5,35 +5,54 @@ import (
 	"strconv"
 
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func (p *Plugin) validateTransferPayoutRequest(pi models.PSPPaymentInitiation) error {
 	if pi.SourceAccount == nil {
-		return fmt.Errorf("source account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	if pi.DestinationAccount == nil {
-		return fmt.Errorf("destination account is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	id, ok := pi.SourceAccount.Metadata["profile_id"]
 	if !ok {
-		return fmt.Errorf("source account metadata with profile id is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account metadata with profile id is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	_, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		return fmt.Errorf("source account metadata with profile id is required as an integer: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("source account metadata with profile id is required as an integer in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	id, ok = pi.DestinationAccount.Metadata["profile_id"]
 	if !ok {
-		return fmt.Errorf("destination account metadata with profile id is required: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account metadata with profile id is required in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	_, err = strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		return fmt.Errorf("destination account metadata with profile id is required as an integer: %w", models.ErrInvalidRequest)
+		return errorsutils.NewWrappedError(
+			fmt.Errorf("destination account metadata with profile id is required as an integer in transfer/payout request"),
+			models.ErrInvalidRequest,
+		)
 	}
 
 	return nil

--- a/internal/connectors/plugins/registry/errors.go
+++ b/internal/connectors/plugins/registry/errors.go
@@ -2,11 +2,11 @@ package registry
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
+	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
 
 func translateError(err error) error {
@@ -19,9 +19,15 @@ func translateError(err error) error {
 		errors.Is(err, plugins.ErrCurrencyNotSupported),
 		errors.Is(err, httpwrapper.ErrStatusCodeClientError),
 		errors.Is(err, models.ErrInvalidConfig):
-		return fmt.Errorf("%w: %w", err, plugins.ErrInvalidClientRequest)
+		return errorsutils.NewWrappedError(
+			err,
+			plugins.ErrInvalidClientRequest,
+		)
 	case errors.Is(err, httpwrapper.ErrStatusCodeTooManyRequests):
-		return fmt.Errorf("%w: %w", err, plugins.ErrUpstreamRatelimit)
+		return errorsutils.NewWrappedError(
+			err,
+			plugins.ErrUpstreamRatelimit,
+		)
 	default:
 		return err
 	}

--- a/internal/connectors/plugins/registry/plugins.go
+++ b/internal/connectors/plugins/registry/plugins.go
@@ -40,11 +40,11 @@ func RegisterPlugin(
 	pluginsRegistry[provider] = PluginInformation{
 		capabilities: capabilities,
 		createFunc:   createFunc,
-		config:       setupConfig(provider, conf),
+		config:       setupConfig(conf),
 	}
 }
 
-func setupConfig(provider string, conf any) Config {
+func setupConfig(conf any) Config {
 	config := make(Config)
 	for paramName, param := range defaultParameters {
 		if _, ok := config[paramName]; !ok {

--- a/internal/utils/errors/errors.go
+++ b/internal/utils/errors/errors.go
@@ -1,0 +1,49 @@
+package errors
+
+import "fmt"
+
+type wrappedError struct {
+	err error
+}
+
+// NewWrappedError creates a new error that wraps the cause error with the new error.
+// It should be use when you want to have the end cause of an error and not all
+// the stack trace, for example when you want to store the transfer/payout creation
+// error.
+func NewWrappedError(cause error, newError error) error {
+	return &wrappedError{
+		err: fmt.Errorf("%w: %w", cause, newError),
+	}
+}
+
+func (e *wrappedError) Error() string {
+	return e.err.Error()
+}
+
+// This method is needed for all errors to be recognized by the errors.Is function
+func (e *wrappedError) Unwrap() []error {
+	return e.err.(interface{ Unwrap() []error }).Unwrap()
+}
+
+// Cause unwraps the error to the root cause
+func Cause(err error) error {
+	for {
+		switch v := err.(type) {
+		case interface{ Unwrap() error }:
+			next := v.Unwrap()
+			if next == nil {
+				return err
+			}
+			err = next
+		case interface{ Unwrap() []error }:
+			nexts := v.Unwrap()
+			if len(nexts) == 0 {
+				return err
+			}
+			// we assume that the cause error is always the first one
+			err = nexts[0]
+		default:
+			return err
+		}
+	}
+}

--- a/internal/utils/errors/errors_test.go
+++ b/internal/utils/errors/errors_test.go
@@ -1,0 +1,71 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+
+	var (
+		causeError = errors.New("cause error")
+		testError  = errors.New("test error")
+	)
+	type testCase struct {
+		name        string
+		err         error
+		wantedCause error
+		wantedError error
+	}
+
+	testCases := []testCase{
+		{
+			name:        "simple",
+			err:         NewWrappedError(causeError, errors.New("test")),
+			wantedCause: causeError,
+			wantedError: causeError,
+		},
+		{
+			name:        "double wrapped",
+			err:         NewWrappedError(NewWrappedError(causeError, errors.New("test")), errors.New("test")),
+			wantedCause: causeError,
+			wantedError: causeError,
+		},
+		{
+			name:        "double wrapped but other logical error should still work 1",
+			err:         NewWrappedError(NewWrappedError(causeError, testError), errors.New("test")),
+			wantedCause: causeError,
+			wantedError: testError,
+		},
+
+		{
+			name:        "double wrapped but other logical error should still work 1",
+			err:         NewWrappedError(NewWrappedError(causeError, errors.New("test")), testError),
+			wantedCause: causeError,
+			wantedError: testError,
+		},
+		{
+			name:        "standard error in wrapped error",
+			err:         NewWrappedError(fmt.Errorf("%w", testError), errors.New("test")),
+			wantedError: testError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.wantedError != nil {
+				require.ErrorIs(t, tc.err, tc.wantedError)
+			}
+
+			if tc.wantedCause != nil {
+				require.Equal(t, Cause(tc.err).Error(), tc.wantedCause.Error())
+			}
+		})
+	}
+}

--- a/test/e2e/api_connectors_test.go
+++ b/test/e2e/api_connectors_test.go
@@ -93,6 +93,7 @@ var _ = Context("Payments API Connectors", func() {
 				err := ConnectorInstall(ctx, app.GetValue(), ver, connectorConf, nil)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("400"))
+				fmt.Println("TOTO", err.Error(), expectedErr)
 				Expect(err.Error()).To(ContainSubstring(expectedErr))
 			},
 			Entry("empty directory with v2", 2, "", "validation for 'Directory' failed on the 'required' tag"),


### PR DESCRIPTION
# Description
## What this PR do
- Send a BadRequest instead of an internal when a transfer/payout creation or bank account creation fails because of the request, with the cause error and not the whole stack trace
- Do not store the whole stack trace into the database when we have an transfer/payout creation error, instead just store the cause
- Improve connectors errors

### Before
FCTL
![image](https://github.com/user-attachments/assets/a1a1de96-51b2-4384-b9d5-71b5417174b1)

ADJUSTMENTS
![image](https://github.com/user-attachments/assets/ab0f06c2-082b-48ee-b410-3ebdb716c58d)

V3 TASKS
Same as adjustments above

### After
FCTL
![image](https://github.com/user-attachments/assets/eaca8def-78b1-49c5-b25d-0158765fdc98)

ADJUSTMENTS
![image](https://github.com/user-attachments/assets/60e79869-f559-43a3-8dcf-27ef6dc19354)

V3 TASKS
![image](https://github.com/user-attachments/assets/8fb37565-96ef-4902-9e4a-7a32056e738c)


Fixes PMNT-76
Fixes PMNT-77