### PR TITLE
fix(models): fix bank account ik and internal error not logging

### DIFF
--- a/internal/api/common/errors.go
+++ b/internal/api/common/errors.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/go-libs/v3/logging"
 )
 
 func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
-	api.InternalServerError(w, r, errors.New("Internal error. Consult logs/traces to have more details."))
+	logging.FromContext(r.Context()).Error(err)
+	api.WriteErrorResponse(w, http.StatusInternalServerError, api.ErrorInternal, errors.New("Internal error. Consult logs/traces to have more details."))
 }

--- a/internal/models/bank_accounts.go
+++ b/internal/models/bank_accounts.go
@@ -38,8 +38,21 @@ type BankAccount struct {
 	RelatedAccounts []BankAccountRelatedAccount `json:"relatedAccounts"`
 }
 
+type bankAccountIK struct {
+	ID            uuid.UUID  `json:"id"`
+	LastAccountID *AccountID `json:"lastAccountID,omitempty"`
+}
+
 func (b *BankAccount) IdempotencyKey() string {
-	return IdempotencyKey(b.ID)
+	ik := bankAccountIK{
+		ID: b.ID,
+	}
+
+	if len(b.RelatedAccounts) > 0 {
+		ik.LastAccountID = &b.RelatedAccounts[len(b.RelatedAccounts)-1].AccountID
+	}
+
+	return IdempotencyKey(ik)
 }
 
 func (a *BankAccount) Obfuscate() error {


### PR DESCRIPTION
This PR fixes:

- The bank account IdempotencyKey that was not unique by related bank account created
- Internal server error was not logging the right error

Fixes PMNT-93
Fixes PMNT-94