### PR TITLE
fix(connectors): fix webhook idempotency key and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.4.6
 	github.com/adyen/adyen-go-api-library/v7 v7.3.1
 	github.com/bombsimon/logrusr/v3 v3.1.0
+	github.com/formancehq/go-libs v1.7.2
 	github.com/formancehq/go-libs/v3 v3.0.0-20250407134146-8be8ce3ddc42
 	github.com/formancehq/payments/genericclient v0.0.0-00010101000000-000000000000
 	github.com/formancehq/payments/pkg/client v0.0.0-00010101000000-000000000000
@@ -104,7 +105,6 @@ require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/formancehq/go-libs v1.7.2 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/render v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.4.6
 	github.com/adyen/adyen-go-api-library/v7 v7.3.1
 	github.com/bombsimon/logrusr/v3 v3.1.0
-	github.com/formancehq/go-libs v1.7.2
 	github.com/formancehq/go-libs/v3 v3.0.0-20250407134146-8be8ce3ddc42
 	github.com/formancehq/payments/genericclient v0.0.0-00010101000000-000000000000
 	github.com/formancehq/payments/pkg/client v0.0.0-00010101000000-000000000000
@@ -105,6 +104,7 @@ require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/formancehq/go-libs v1.7.2 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/render v1.0.3 // indirect

--- a/internal/connectors/engine/activities/activity.go
+++ b/internal/connectors/engine/activities/activity.go
@@ -88,6 +88,10 @@ func (a Activities) DefinitionSet() temporalworker.DefinitionSet {
 			Func: a.PluginCreateWebhooks,
 		}).
 		Append(temporalworker.Definition{
+			Name: "PluginVerifyWebhook",
+			Func: a.PluginVerifyWebhook,
+		}).
+		Append(temporalworker.Definition{
 			Name: "PluginTranslateWebhook",
 			Func: a.PluginTranslateWebhook,
 		}).

--- a/internal/connectors/engine/activities/errors.go
+++ b/internal/connectors/engine/activities/errors.go
@@ -47,6 +47,8 @@ func (a Activities) temporalPluginErrorCheck(ctx context.Context, err error, isP
 		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 	case errors.Is(err, models.ErrMissingConnectorMetadata):
 		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
+	case errors.Is(err, models.ErrWebhookVerification):
+		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 	case errors.As(err, &models.NonRetryableError):
 		return temporal.NewNonRetryableApplicationError(err.Error(), ErrTypeInvalidArgument, cause)
 

--- a/internal/connectors/engine/activities/plugin_verify_webhook.go
+++ b/internal/connectors/engine/activities/plugin_verify_webhook.go
@@ -1,0 +1,39 @@
+package activities
+
+import (
+	context "context"
+
+	"github.com/formancehq/payments/internal/models"
+	"go.temporal.io/sdk/workflow"
+)
+
+type VerifyWebhookRequest struct {
+	ConnectorID models.ConnectorID
+	Req         models.VerifyWebhookRequest
+}
+
+func (a Activities) PluginVerifyWebhook(ctx context.Context, request VerifyWebhookRequest) (*models.VerifyWebhookResponse, error) {
+	plugin, err := a.plugins.Get(request.ConnectorID)
+	if err != nil {
+		return nil, a.temporalPluginError(ctx, err)
+	}
+
+	resp, err := plugin.VerifyWebhook(ctx, request.Req)
+	if err != nil {
+		return nil, a.temporalPluginError(ctx, err)
+	}
+	return &resp, nil
+}
+
+var PluginVerifyWebhookActivity = Activities{}.PluginVerifyWebhook
+
+func PluginVerifyWebhook(ctx workflow.Context, connectorID models.ConnectorID, request models.VerifyWebhookRequest) (*models.VerifyWebhookResponse, error) {
+	ret := models.VerifyWebhookResponse{}
+	if err := executeActivity(ctx, PluginVerifyWebhookActivity, &ret, VerifyWebhookRequest{
+		ConnectorID: connectorID,
+		Req:         request,
+	}); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}

--- a/internal/connectors/engine/activities/plugin_verify_webhook_test.go
+++ b/internal/connectors/engine/activities/plugin_verify_webhook_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/formancehq/go-libs/pointer"
 	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
 	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"

--- a/internal/connectors/engine/activities/plugin_verify_webhook_test.go
+++ b/internal/connectors/engine/activities/plugin_verify_webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/formancehq/go-libs/pointer"
 	"github.com/formancehq/go-libs/v3/logging"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/plugins"
@@ -28,7 +29,7 @@ var _ = Describe("Plugin Verify Webhooks", func() {
 
 	BeforeEach(func() {
 		evts = &events.Events{}
-		sampleResponse = models.VerifyWebhookResponse{WebhookIdempotencyKey: "test"}
+		sampleResponse = models.VerifyWebhookResponse{WebhookIdempotencyKey: pointer.For("test")}
 	})
 
 	Context("plugin verify webhook", func() {

--- a/internal/connectors/engine/activities/plugin_verify_webhook_test.go
+++ b/internal/connectors/engine/activities/plugin_verify_webhook_test.go
@@ -1,0 +1,85 @@
+package activities_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/payments/internal/connectors/engine/activities"
+	"github.com/formancehq/payments/internal/connectors/engine/plugins"
+	pluginsError "github.com/formancehq/payments/internal/connectors/plugins"
+	"github.com/formancehq/payments/internal/events"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/internal/storage"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.temporal.io/sdk/temporal"
+	gomock "go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Plugin Verify Webhooks", func() {
+	var (
+		act            activities.Activities
+		p              *plugins.MockPlugins
+		s              *storage.MockStorage
+		evts           *events.Events
+		sampleResponse models.VerifyWebhookResponse
+	)
+
+	BeforeEach(func() {
+		evts = &events.Events{}
+		sampleResponse = models.VerifyWebhookResponse{WebhookIdempotencyKey: "test"}
+	})
+
+	Context("plugin verify webhook", func() {
+		var (
+			plugin *models.MockPlugin
+			req    activities.VerifyWebhookRequest
+			logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+			delay  = 50 * time.Millisecond
+		)
+
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			p = plugins.NewMockPlugins(ctrl)
+			s = storage.NewMockStorage(ctrl)
+			plugin = models.NewMockPlugin(ctrl)
+			act = activities.New(logger, nil, s, evts, p, delay)
+			req = activities.VerifyWebhookRequest{
+				ConnectorID: models.ConnectorID{
+					Provider: "some_provider",
+				},
+			}
+		})
+
+		It("calls underlying plugin", func(ctx SpecContext) {
+			p.EXPECT().Get(req.ConnectorID).Return(plugin, nil)
+			plugin.EXPECT().VerifyWebhook(ctx, req.Req).Return(sampleResponse, nil)
+			res, err := act.PluginVerifyWebhook(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(res.WebhookIdempotencyKey).To(Equal(sampleResponse.WebhookIdempotencyKey))
+		})
+
+		It("returns a retryable temporal error", func(ctx SpecContext) {
+			p.EXPECT().Get(req.ConnectorID).Return(plugin, nil)
+			plugin.EXPECT().VerifyWebhook(ctx, req.Req).Return(sampleResponse, fmt.Errorf("some string"))
+			_, err := act.PluginVerifyWebhook(ctx, req)
+			Expect(err).ToNot(BeNil())
+			temporalErr, ok := err.(*temporal.ApplicationError)
+			Expect(ok).To(BeTrue())
+			Expect(temporalErr.NonRetryable()).To(BeFalse())
+			Expect(temporalErr.Type()).To(Equal(activities.ErrTypeDefault))
+		})
+
+		It("returns a non-retryable temporal error", func(ctx SpecContext) {
+			p.EXPECT().Get(req.ConnectorID).Return(plugin, nil)
+			plugin.EXPECT().VerifyWebhook(ctx, req.Req).Return(sampleResponse, fmt.Errorf("invalid: %w", pluginsError.ErrNotImplemented))
+			_, err := act.PluginVerifyWebhook(ctx, req)
+			Expect(err).ToNot(BeNil())
+			temporalErr, ok := err.(*temporal.ApplicationError)
+			Expect(ok).To(BeTrue())
+			Expect(temporalErr.NonRetryable()).To(BeTrue())
+			Expect(temporalErr.Type()).To(Equal(activities.ErrTypeUnimplemented))
+		})
+	})
+})

--- a/internal/connectors/engine/workflow/handle_webhooks.go
+++ b/internal/connectors/engine/workflow/handle_webhooks.go
@@ -45,6 +45,24 @@ func (w Workflow) runHandleWebhooks(
 		return temporal.NewNonRetryableApplicationError("webhook config not found", "NOT_FOUND", errors.New("webhook config not found"))
 	}
 
+	verifyResponse, err := activities.PluginVerifyWebhook(
+		infiniteRetryContext(ctx),
+		handleWebhooks.ConnectorID,
+		models.VerifyWebhookRequest{
+			Webhook: models.PSPWebhook{
+				BasicAuth:   handleWebhooks.Webhook.BasicAuth,
+				QueryValues: handleWebhooks.Webhook.QueryValues,
+				Headers:     handleWebhooks.Webhook.Headers,
+				Body:        handleWebhooks.Webhook.Body,
+			},
+			Config: config,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("verifying webhook: %w", err)
+	}
+
+	handleWebhooks.Webhook.IdempotencyKey = verifyResponse.WebhookIdempotencyKey
 	err = activities.StorageWebhooksStore(infiniteRetryContext(ctx), handleWebhooks.Webhook)
 	if err != nil {
 		return fmt.Errorf("storing webhook: %w", err)
@@ -73,7 +91,7 @@ func (w Workflow) runHandleWebhooks(
 			workflow.WithChildOptions(
 				ctx,
 				workflow.ChildWorkflowOptions{
-					WorkflowID:            fmt.Sprintf("store-webhook-%s-%s-%s", w.stack, handleWebhooks.ConnectorID.String(), response.IdempotencyKey),
+					WorkflowID:            fmt.Sprintf("store-webhook-%s-%s-%s", w.stack, handleWebhooks.ConnectorID.String(), handleWebhooks.Webhook.ID),
 					TaskQueue:             w.getDefaultTaskQueue(),
 					ParentClosePolicy:     enums.PARENT_CLOSE_POLICY_ABANDON,
 					WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,

--- a/internal/connectors/engine/workflow/handle_webhooks_test.go
+++ b/internal/connectors/engine/workflow/handle_webhooks_test.go
@@ -27,7 +27,6 @@ func (s *UnitTestSuite) Test_HandleWebhooks_Success() {
 		return &models.TranslateWebhookResponse{
 			Responses: []models.WebhookResponse{
 				{
-					IdempotencyKey:  "test",
 					Account:         &s.pspAccount,
 					ExternalAccount: &s.pspAccount,
 					Payment:         &s.pspPayment,
@@ -250,7 +249,6 @@ func (s *UnitTestSuite) Test_HandleWebhooks_RunStoreWebhookTranslation_Error() {
 		return &models.TranslateWebhookResponse{
 			Responses: []models.WebhookResponse{
 				{
-					IdempotencyKey:  "test",
 					Account:         &s.pspAccount,
 					ExternalAccount: &s.pspAccount,
 					Payment:         &s.pspPayment,

--- a/internal/connectors/engine/workflow/handle_webhooks_test.go
+++ b/internal/connectors/engine/workflow/handle_webhooks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/formancehq/go-libs/v3/pointer"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/stretchr/testify/mock"
@@ -22,7 +23,15 @@ func (s *UnitTestSuite) Test_HandleWebhooks_Success() {
 		},
 		nil,
 	)
-	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.VerifyWebhookRequest) (*models.VerifyWebhookResponse, error) {
+		return &models.VerifyWebhookResponse{
+			WebhookIdempotencyKey: pointer.For("test"),
+		}, nil
+	})
+	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, webhook models.Webhook) error {
+		s.Equal(pointer.For("test"), webhook.IdempotencyKey)
+		return nil
+	})
 	s.env.OnActivity(activities.PluginTranslateWebhookActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.TranslateWebhookRequest) (*models.TranslateWebhookResponse, error) {
 		return &models.TranslateWebhookResponse{
 			Responses: []models.WebhookResponse{
@@ -77,7 +86,15 @@ func (s *UnitTestSuite) Test_HandleWebhooks_NoResponses_Success() {
 		},
 		nil,
 	)
-	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.VerifyWebhookRequest) (*models.VerifyWebhookResponse, error) {
+		return &models.VerifyWebhookResponse{
+			WebhookIdempotencyKey: pointer.For("test"),
+		}, nil
+	})
+	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, webhook models.Webhook) error {
+		s.Equal(pointer.For("test"), webhook.IdempotencyKey)
+		return nil
+	})
 	s.env.OnActivity(activities.PluginTranslateWebhookActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.TranslateWebhookRequest) (*models.TranslateWebhookResponse, error) {
 		return &models.TranslateWebhookResponse{
 			Responses: []models.WebhookResponse{},
@@ -160,6 +177,43 @@ func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksConfigsGet_Error() {
 	s.Error(err)
 }
 
+func (s *UnitTestSuite) Test_HandleWebhooks_PluginVerifyWebhook_Error() {
+	s.env.OnActivity(activities.StorageWebhooksConfigsGetActivity, mock.Anything, s.connectorID).Once().Return(
+		[]models.WebhookConfig{
+			{
+				Name:        "test",
+				ConnectorID: s.connectorID,
+				URLPath:     "/test",
+			},
+		},
+		nil,
+	)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(
+		nil,
+		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+	)
+
+	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
+		ConnectorID: s.connectorID,
+		URLPath:     "/test",
+		Webhook: models.Webhook{
+			ID:          "test",
+			ConnectorID: s.connectorID,
+			QueryValues: map[string][]string{
+				"test": {"test"},
+			},
+			Headers: map[string][]string{
+				"test": {"test"},
+			},
+			Body: []byte(`{}`),
+		},
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+	err := s.env.GetWorkflowError()
+	s.Error(err)
+}
+
 func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksStore_Error() {
 	s.env.OnActivity(activities.StorageWebhooksConfigsGetActivity, mock.Anything, s.connectorID).Once().Return(
 		[]models.WebhookConfig{
@@ -171,6 +225,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksStore_Error() {
 		},
 		nil,
 	)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(&models.VerifyWebhookResponse{}, nil)
 	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(
 		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
 	)
@@ -207,6 +262,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_PluginTranslateWebhook_Error() {
 		},
 		nil,
 	)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(&models.VerifyWebhookResponse{}, nil)
 	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.PluginTranslateWebhookActivity, mock.Anything, mock.Anything).Once().Return(nil,
 		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
@@ -244,6 +300,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_RunStoreWebhookTranslation_Error() {
 		},
 		nil,
 	)
+	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(&models.VerifyWebhookResponse{}, nil)
 	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.PluginTranslateWebhookActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.TranslateWebhookRequest) (*models.TranslateWebhookResponse, error) {
 		return &models.TranslateWebhookResponse{

--- a/internal/connectors/plugins/base_plugin.go
+++ b/internal/connectors/plugins/base_plugin.go
@@ -76,6 +76,10 @@ func (dp *basePlugin) CreateWebhooks(ctx context.Context, req models.CreateWebho
 	return models.CreateWebhooksResponse{}, ErrNotImplemented
 }
 
+func (dp *basePlugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	return models.VerifyWebhookResponse{}, ErrNotImplemented
+}
+
 func (dp *basePlugin) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	return models.TranslateWebhookResponse{}, ErrNotImplemented
 }

--- a/internal/connectors/plugins/public/adyen/accounts_test.go
+++ b/internal/connectors/plugins/public/adyen/accounts_test.go
@@ -15,15 +15,20 @@ import (
 
 var _ = Describe("Adyen Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/adyen/accounts_test.go
+++ b/internal/connectors/plugins/public/adyen/accounts_test.go
@@ -15,23 +15,23 @@ import (
 
 var _ = Describe("Adyen Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []management.Merchant
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 
 			for i := 10; i < 60; i++ {
 				sampleAccounts = append(sampleAccounts, management.Merchant{

--- a/internal/connectors/plugins/public/adyen/plugin.go
+++ b/internal/connectors/plugins/public/adyen/plugin.go
@@ -114,6 +114,14 @@ func (p *Plugin) CreateWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	}, nil
 }
 
+func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	if p.client == nil {
+		return models.VerifyWebhookResponse{}, plugins.ErrNotYetInstalled
+	}
+
+	return p.verifyWebhook(ctx, req)
+}
+
 func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	if p.client == nil {
 		return models.TranslateWebhookResponse{}, plugins.ErrNotYetInstalled

--- a/internal/connectors/plugins/public/adyen/plugin_test.go
+++ b/internal/connectors/plugins/public/adyen/plugin_test.go
@@ -21,6 +21,7 @@ func TestPlugin(t *testing.T) {
 var _ = Describe("Adyen Plugin", func() {
 	var (
 		plg    *Plugin
+		ctrl   *gomock.Controller
 		m      *client.MockClient
 		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 	)
@@ -29,8 +30,12 @@ var _ = Describe("Adyen Plugin", func() {
 		plg = &Plugin{
 			Plugin: plugins.NewBasePlugin(),
 		}
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("install", func() {

--- a/internal/connectors/plugins/public/adyen/webhooks.go
+++ b/internal/connectors/plugins/public/adyen/webhooks.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
@@ -54,9 +53,9 @@ func (p *Plugin) createWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	return configs, err
 }
 
-func (p *Plugin) verifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+func (p *Plugin) verifyWebhook(_ context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
 	if !p.client.VerifyWebhookBasicAuth(req.Webhook.BasicAuth) {
-		return models.VerifyWebhookResponse{}, errors.New("invalid basic auth")
+		return models.VerifyWebhookResponse{}, fmt.Errorf("invalid basic auth: %w", models.ErrWebhookVerification)
 	}
 
 	webhooks, err := p.client.TranslateWebhook(string(req.Webhook.Body))
@@ -66,7 +65,7 @@ func (p *Plugin) verifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 
 	for _, item := range *webhooks.NotificationItems {
 		if !p.client.VerifyWebhookHMAC(item) {
-			return models.VerifyWebhookResponse{}, errors.New("invalid HMAC")
+			return models.VerifyWebhookResponse{}, fmt.Errorf("invalid HMAC: %w", models.ErrWebhookVerification)
 		}
 	}
 

--- a/internal/connectors/plugins/public/adyen/webhooks.go
+++ b/internal/connectors/plugins/public/adyen/webhooks.go
@@ -71,7 +71,7 @@ func (p *Plugin) verifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 
 	ik := sha256.Sum256(req.Webhook.Body)
 	return models.VerifyWebhookResponse{
-		WebhookIdempotencyKey: string(ik[:]),
+		WebhookIdempotencyKey: pointer.For(string(ik[:])),
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/adyen/webhooks.go
+++ b/internal/connectors/plugins/public/adyen/webhooks.go
@@ -3,6 +3,7 @@ package adyen
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -69,9 +70,10 @@ func (p *Plugin) verifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 		}
 	}
 
-	ik := sha256.Sum256(req.Webhook.Body)
+	sha := sha256.Sum256(req.Webhook.Body)
+	ik := base64.StdEncoding.EncodeToString(sha[:])
 	return models.VerifyWebhookResponse{
-		WebhookIdempotencyKey: pointer.For(string(ik[:])),
+		WebhookIdempotencyKey: pointer.For(ik),
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/adyen/webhooks_test.go
+++ b/internal/connectors/plugins/public/adyen/webhooks_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			_, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("invalid basic auth"))
+			Expect(err).To(MatchError("invalid basic auth: webhook verification error"))
 		})
 
 		It("should not process - invalid hmac", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/adyen/webhooks_test.go
+++ b/internal/connectors/plugins/public/adyen/webhooks_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -165,7 +164,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			resp, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.WebhookIdempotencyKey).To(Equal(fmt.Sprintf("%s", string(ik[:]))))
+			Expect(resp.WebhookIdempotencyKey).To(Equal(string(ik[:])))
 		})
 	})
 

--- a/internal/connectors/plugins/public/adyen/webhooks_test.go
+++ b/internal/connectors/plugins/public/adyen/webhooks_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			resp, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(resp.WebhookIdempotencyKey).To(BeEmpty())
+			Expect(resp.WebhookIdempotencyKey).To(BeNil())
 		})
 
 		It("should be ok", func(ctx SpecContext) {
@@ -164,7 +164,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			resp, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.WebhookIdempotencyKey).To(Equal(string(ik[:])))
+			Expect(resp.WebhookIdempotencyKey).To(Equal(pointer.For(string(ik[:]))))
 		})
 	})
 

--- a/internal/connectors/plugins/public/atlar/accounts_test.go
+++ b/internal/connectors/plugins/public/atlar/accounts_test.go
@@ -19,15 +19,20 @@ import (
 
 var _ = Describe("Atlar Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
 
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/atlar/accounts_test.go
+++ b/internal/connectors/plugins/public/atlar/accounts_test.go
@@ -19,24 +19,24 @@ import (
 
 var _ = Describe("Atlar Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
+
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []*atlar_models.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]*atlar_models.Account, 0)

--- a/internal/connectors/plugins/public/atlar/balances_test.go
+++ b/internal/connectors/plugins/public/atlar/balances_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Atlar Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/atlar/balances_test.go
+++ b/internal/connectors/plugins/public/atlar/balances_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Atlar Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m             *client.MockClient
 			sampleAccount atlar_models.Account
 			now           time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccount = atlar_models.Account{

--- a/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create bank account", func() {
 		var (
-			m                 *client.MockClient
 			sampleBankAccount models.BankAccount
 			now               time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBankAccount = models.BankAccount{

--- a/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create bank account", func() {

--- a/internal/connectors/plugins/public/atlar/external_accounts_test.go
+++ b/internal/connectors/plugins/public/atlar/external_accounts_test.go
@@ -19,14 +19,19 @@ import (
 
 var _ = Describe("Atlar Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/atlar/external_accounts_test.go
+++ b/internal/connectors/plugins/public/atlar/external_accounts_test.go
@@ -19,24 +19,23 @@ import (
 
 var _ = Describe("Atlar Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []*atlar_models.ExternalAccount
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]*atlar_models.ExternalAccount, 0)

--- a/internal/connectors/plugins/public/atlar/payments_test.go
+++ b/internal/connectors/plugins/public/atlar/payments_test.go
@@ -20,25 +20,24 @@ import (
 
 var _ = Describe("Atlar Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next payments", func() {
 		var (
-			m              *client.MockClient
 			samplePayments []*atlar_models.Transaction
 			sampleAccount  atlar_models.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccount = atlar_models.Account{

--- a/internal/connectors/plugins/public/atlar/payments_test.go
+++ b/internal/connectors/plugins/public/atlar/payments_test.go
@@ -20,14 +20,19 @@ import (
 
 var _ = Describe("Atlar Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/atlar/payouts_test.go
+++ b/internal/connectors/plugins/public/atlar/payouts_test.go
@@ -21,24 +21,23 @@ import (
 
 var _ = Describe("Atlar Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{
@@ -167,7 +166,6 @@ var _ = Describe("Atlar Plugin Payouts Creation", func() {
 
 	Context("poll payout status", func() {
 		var (
-			m                      *client.MockClient
 			payoutID               string
 			creditTransferResponse credit_transfers.GetV1CreditTransfersGetByExternalIDExternalIDOK
 			now                    time.Time
@@ -175,9 +173,6 @@ var _ = Describe("Atlar Plugin Payouts Creation", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 			payoutID = "test"
 

--- a/internal/connectors/plugins/public/atlar/payouts_test.go
+++ b/internal/connectors/plugins/public/atlar/payouts_test.go
@@ -21,14 +21,19 @@ import (
 
 var _ = Describe("Atlar Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/bankingcircle/accounts_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("BankingCircle Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []client.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]client.Account, 0)

--- a/internal/connectors/plugins/public/bankingcircle/accounts_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/bankingcircle/balances_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/balances_test.go
@@ -12,25 +12,23 @@ import (
 
 var _ = Describe("BankingCircle Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m              *client.MockClient
 			sampleBalances []client.Balance
 			sampleAccount  *client.Account
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-
 			sampleBalances = []client.Balance{
 				{
 					Currency:         "EUR",

--- a/internal/connectors/plugins/public/bankingcircle/balances_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/balances_test.go
@@ -12,14 +12,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/bankingcircle/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/bank_account_creation_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Bank Account Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/bankingcircle/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/bank_account_creation_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("BankingCircle Plugin Bank Account Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m                 *client.MockClient
 			sampleBankAccount models.BankAccount
 			now               time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBankAccount = models.BankAccount{

--- a/internal/connectors/plugins/public/bankingcircle/payments_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/payments_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("BankingCircle Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			samplePayments []client.Payment
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePayments = make([]client.Payment, 0)

--- a/internal/connectors/plugins/public/bankingcircle/payments_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/payments_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/bankingcircle/payouts_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/payouts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/bankingcircle/payouts_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/payouts_test.go
@@ -16,25 +16,24 @@ import (
 
 var _ = Describe("BankingCircle Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                                         *client.MockClient
 			samplePSPPaymentInitiation                models.PSPPaymentInitiation
 			samplePSPPaymentInitiationMissingMetadata models.PSPPaymentInitiation
 			now                                       time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/bankingcircle/transfers_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/transfers_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/bankingcircle/transfers_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/transfers_test.go
@@ -16,24 +16,24 @@ import (
 
 var _ = Describe("BankingCircle Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
+
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/column/accounts_test.go
+++ b/internal/connectors/plugins/public/column/accounts_test.go
@@ -15,25 +15,25 @@ import (
 
 var _ = Describe("Column Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			mockHTTPClient *client.MockHTTPClient
 			sampleAccounts []*client.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
 			now = time.Now().UTC()
 			sampleAccounts = make([]*client.Account, 0)
 			for i := range 50 {
@@ -44,20 +44,6 @@ var _ = Describe("Column Plugin Accounts", func() {
 					CreatedAt:    now.Add(-time.Duration(50-i) * time.Minute).UTC().Format(time.RFC3339),
 				})
 			}
-		})
-
-		It("should return an error - invalid created_at", func() {
-			accounts := []*client.Account{{
-				ID:           "acc_123",
-				Description:  "Test Account",
-				CurrencyCode: "USD",
-				CreatedAt:    "invalid-timestamp",
-				Type:         "wire",
-			}}
-			resp, err := plg.fillAccounts(accounts, make([]models.PSPAccount, 0), 10)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError(`parsing time "invalid-timestamp" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid-timestamp" as "2006"`))
-			Expect(resp).To(BeNil())
 		})
 
 		It("should return an error - get accounts error", func(ctx SpecContext) {
@@ -77,6 +63,37 @@ var _ = Describe("Column Plugin Accounts", func() {
 			resp, err := plg.FetchNextAccounts(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError("failed to get accounts: test error : "))
+			Expect(resp).To(Equal(models.FetchNextAccountsResponse{}))
+		})
+
+		It("should return an error - invalid created_at", func(ctx SpecContext) {
+			accounts := []*client.Account{{
+				ID:           "acc_123",
+				Description:  "Test Account",
+				CurrencyCode: "USD",
+				CreatedAt:    "invalid-timestamp",
+				Type:         "wire",
+			}}
+
+			req := models.FetchNextAccountsRequest{
+				State:    []byte(`{}`),
+				PageSize: 60,
+			}
+			mockHTTPClient.EXPECT().Do(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).Return(
+				200,
+				nil,
+			).SetArg(2, client.AccountResponseWrapper[[]*client.Account]{
+				BankAccounts: accounts,
+			})
+
+			resp, err := plg.FetchNextAccounts(ctx, req)
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(MatchError(`parsing time "invalid-timestamp" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid-timestamp" as "2006"`))
 			Expect(resp).To(Equal(models.FetchNextAccountsResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/column/accounts_test.go
+++ b/internal/connectors/plugins/public/column/accounts_test.go
@@ -15,16 +15,21 @@ import (
 
 var _ = Describe("Column Plugin Accounts", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/column/balances_test.go
+++ b/internal/connectors/plugins/public/column/balances_test.go
@@ -13,16 +13,21 @@ import (
 
 var _ = Describe("Column Plugin Balances", func() {
 	var (
-		m   *client.MockHTTPClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockHTTPClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(m)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/column/balances_test.go
+++ b/internal/connectors/plugins/public/column/balances_test.go
@@ -13,24 +13,24 @@ import (
 
 var _ = Describe("Column Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockHTTPClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(m)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m             *client.MockHTTPClient
 			sampleBalance *client.Balance
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(m)
 			sampleBalance = &client.Balance{
 				AvailableAmount: "1000",
 				HoldingAmount:   "1000",

--- a/internal/connectors/plugins/public/column/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/column/bank_account_creation_test.go
@@ -13,16 +13,21 @@ import (
 
 var _ = Describe("Column Plugin Bank Accounts", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("Create counterparty Bank Accounts", func() {

--- a/internal/connectors/plugins/public/column/client/error.go
+++ b/internal/connectors/plugins/public/column/client/error.go
@@ -6,12 +6,12 @@ import (
 )
 
 var (
-	ErrWebhookUrlMissing              = errors.New("webhook url is not set")
-	ErrWebhookHeaderXSignatureMissing = errors.New("missing X-Signature-Sha256 header")
-	ErrWebhookConfigInvalid           = errors.New("webhook config is invalid")
-	ErrWebhookTypeUnknown             = errors.New("webhook type is not supported")
-	ErrWebhookConfigSecretMissing     = errors.New("webhook config secret missing")
-	ErrWebhookRequestFailed           = errors.New("failed to create webhooks request")
+	ErrWebhookUrlMissing          = errors.New("webhook url is not set")
+	ErrColumSignatureMissing      = errors.New("missing Column-Signature header")
+	ErrWebhookConfigInvalid       = errors.New("webhook config is invalid")
+	ErrWebhookTypeUnknown         = errors.New("webhook type is not supported")
+	ErrWebhookConfigSecretMissing = errors.New("webhook config secret missing")
+	ErrWebhookRequestFailed       = errors.New("failed to create webhooks request")
 )
 
 type columnError struct {

--- a/internal/connectors/plugins/public/column/external_accounts_test.go
+++ b/internal/connectors/plugins/public/column/external_accounts_test.go
@@ -15,16 +15,21 @@ import (
 
 var _ = Describe("Column Plugin External Accounts", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/column/external_accounts_test.go
+++ b/internal/connectors/plugins/public/column/external_accounts_test.go
@@ -15,25 +15,25 @@ import (
 
 var _ = Describe("Column Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			mockHTTPClient       *client.MockHTTPClient
 			sampleCounterparties []*client.Counterparties
 			now                  time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
 			now = time.Now().UTC()
 			sampleCounterparties = make([]*client.Counterparties, 0)
 			for i := range 50 {

--- a/internal/connectors/plugins/public/column/payments_test.go
+++ b/internal/connectors/plugins/public/column/payments_test.go
@@ -16,16 +16,21 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/column/payments_test.go
+++ b/internal/connectors/plugins/public/column/payments_test.go
@@ -16,25 +16,25 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next payments", func() {
 		var (
-			mockHTTPClient     *client.MockHTTPClient
 			sampleTransactions []*client.Transaction
 			now                time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
 			now = time.Now().UTC()
 			sampleTransactions = make([]*client.Transaction, 0)
 			statuses := []string{

--- a/internal/connectors/plugins/public/column/payouts_test.go
+++ b/internal/connectors/plugins/public/column/payouts_test.go
@@ -13,129 +13,118 @@ import (
 
 var _ = Describe("Column Plugin Payouts", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("Perform Payout Requests", func() {
-		var (
-			mockHTTPClient *client.MockHTTPClient
-		)
-
-		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
-		})
-
 		It("should return an error when amount is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{}
-			err := plg.validatePayoutRequests(req)
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{},
+			}
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingAmount.Error()))
 		})
 
 		It("should return an error when sourceAccount is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount: big.NewInt(100),
+				},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingSourceAccount.Error()))
 		})
 
 		It("should return an error when sourceAccount reference is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount:        big.NewInt(100),
-				SourceAccount: &models.PSPAccount{},
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount:        big.NewInt(100),
+					SourceAccount: &models.PSPAccount{},
+				},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrSourceAccountReferenceRequired.Error()))
 		})
 
 		It("should return an error when destinationAccount is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
-				SourceAccount: &models.PSPAccount{
-					Reference: "test-ref",
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount: big.NewInt(100),
+					SourceAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
 				},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingDestinationAccount.Error()))
 		})
 
 		It("should return an error when destinationAccount reference is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
-				SourceAccount: &models.PSPAccount{
-					Reference: "test-ref",
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount: big.NewInt(100),
+					SourceAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
+					DestinationAccount: &models.PSPAccount{},
 				},
-				DestinationAccount: &models.PSPAccount{},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingDestinationAccountReference.Error()))
 		})
 
 		It("should return an error when metadata is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
-				SourceAccount: &models.PSPAccount{
-					Reference: "test-ref",
-				},
-				DestinationAccount: &models.PSPAccount{
-					Reference: "test-ref",
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount: big.NewInt(100),
+					SourceAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
+					DestinationAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
 				},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingMetadata.Error()))
 		})
 
 		It("should return an error when payout type is missing", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
-				SourceAccount: &models.PSPAccount{
-					Reference: "test-ref",
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Amount: big.NewInt(100),
+					SourceAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
+					DestinationAccount: &models.PSPAccount{
+						Reference: "test-ref",
+					},
+					Metadata: map[string]string{},
 				},
-				DestinationAccount: &models.PSPAccount{
-					Reference: "test-ref",
-				},
-				Metadata: map[string]string{},
 			}
-			err := plg.validatePayoutRequests(req)
+			_, err := plg.CreatePayout(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError("validation error occurred for field metadata: required field metadata must be provided"))
 		})
 
 		It("should return an error when payout type is invalid", func(ctx SpecContext) {
-			req := models.PSPPaymentInitiation{
-				Amount: big.NewInt(100),
-				SourceAccount: &models.PSPAccount{
-					Reference: "test-ref",
-				},
-				DestinationAccount: &models.PSPAccount{
-					Reference: "test-ref",
-				},
-				Metadata: map[string]string{
-					client.ColumnPayoutTypeMetadataKey: "invalid-type",
-				},
-			}
-			err := plg.validatePayoutRequests(req)
-			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring(ErrInvalidMetadataPayoutType.Error()))
-		})
-
-		Context("Wire/Realtime/International-Wire Payout Validation", func() {
-
-			It("should return an error when asset is missing", func(ctx SpecContext) {
-				req := models.PSPPaymentInitiation{
+			req := models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
 					Amount: big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
@@ -144,10 +133,33 @@ var _ = Describe("Column Plugin Payouts", func() {
 						Reference: "test-ref",
 					},
 					Metadata: map[string]string{
-						client.ColumnPayoutTypeMetadataKey: "wire",
+						client.ColumnPayoutTypeMetadataKey: "invalid-type",
+					},
+				},
+			}
+			_, err := plg.CreatePayout(ctx, req)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(ErrInvalidMetadataPayoutType.Error()))
+		})
+
+		Context("Wire/Realtime/International-Wire Payout Validation", func() {
+
+			It("should return an error when asset is missing", func(ctx SpecContext) {
+				req := models.CreatePayoutRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						SourceAccount: &models.PSPAccount{
+							Reference: "test-ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "test-ref",
+						},
+						Metadata: map[string]string{
+							client.ColumnPayoutTypeMetadataKey: "wire",
+						},
 					},
 				}
-				err := plg.validatePayoutRequests(req)
+				_, err := plg.CreatePayout(ctx, req)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(ErrMissingAsset.Error()))
 			})
@@ -197,11 +209,13 @@ var _ = Describe("Column Plugin Payouts", func() {
 		})
 
 		Context("HTTP Request Creation Errors", func() {
+			var (
+				plg models.Plugin
+			)
 			BeforeEach(func() {
-				ctrl := gomock.NewController(GinkgoT())
-				mockHTTPClient = client.NewMockHTTPClient(ctrl)
-				plg.client = client.New("test", "aseplye", "https://test.com")
-				plg.client.SetHttpClient(mockHTTPClient)
+				c := client.New("test", "aseplye", "https://test.com")
+				c.SetHttpClient(mockHTTPClient)
+				plg = &Plugin{client: c}
 			})
 
 			It("should return an error when creating ACH payout request fails", func(ctx SpecContext) {
@@ -340,9 +354,14 @@ var _ = Describe("Column Plugin Payouts", func() {
 			})
 
 			Context("Invalid URL Errors", func() {
+				var (
+					plg models.Plugin
+				)
+
 				BeforeEach(func() {
-					plg.client = client.New("test", "aseplye", "http://invalid:port")
-					plg.client.SetHttpClient(mockHTTPClient)
+					c := client.New("test", "aseplye", "http://invalid:port")
+					c.SetHttpClient(mockHTTPClient)
+					plg = &Plugin{client: c}
 				})
 
 				It("should return an error when ACH payout URL is invalid", func(ctx SpecContext) {
@@ -645,6 +664,10 @@ var _ = Describe("Column Plugin Payouts", func() {
 	})
 
 	Context("mapTransactionStatus", func() {
+		var (
+			p Plugin
+		)
+
 		It("should map status values correctly", func() {
 			testCases := []struct {
 				status         string
@@ -687,7 +710,7 @@ var _ = Describe("Column Plugin Payouts", func() {
 			}
 
 			for _, tc := range testCases {
-				result := plg.mapTransactionStatus(tc.status)
+				result := p.mapTransactionStatus(tc.status)
 				Expect(result).To(Equal(tc.expectedStatus), "Status %s should map to %s", tc.status, tc.expectedStatus)
 			}
 		})

--- a/internal/connectors/plugins/public/column/payouts_test.go
+++ b/internal/connectors/plugins/public/column/payouts_test.go
@@ -13,16 +13,21 @@ import (
 
 var _ = Describe("Column Plugin Payouts", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("Perform Payout Requests", func() {

--- a/internal/connectors/plugins/public/column/plugin.go
+++ b/internal/connectors/plugins/public/column/plugin.go
@@ -193,6 +193,13 @@ func (p *Plugin) CreateWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	return p.createWebhooks(ctx, req)
 }
 
+func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	if p.client == nil {
+		return models.VerifyWebhookResponse{}, plugins.ErrNotYetInstalled
+	}
+	return p.verifyWebhook(ctx, req)
+}
+
 func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	if p.client == nil {
 		return models.TranslateWebhookResponse{}, plugins.ErrNotYetInstalled

--- a/internal/connectors/plugins/public/column/plugin_test.go
+++ b/internal/connectors/plugins/public/column/plugin_test.go
@@ -21,7 +21,7 @@ func TestPlugin(t *testing.T) {
 
 var _ = Describe("Column Plugin", func() {
 	var (
-		plg    *Plugin
+		plg    models.Plugin
 		logger = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
 		connID = models.ConnectorID{}
 		ts     *httptest.Server
@@ -204,14 +204,15 @@ var _ = Describe("Column Plugin", func() {
 	})
 
 	Context("When client is installed", func() {
-		var plg *Plugin
+		var plg models.Plugin
 
 		BeforeEach(func(ctx SpecContext) {
 			config := json.RawMessage(fmt.Sprintf(`{"apiKey":"test","endpoint": "%s"}`, ts.URL))
 			var err error
-			plg, err = New(connID, ProviderName, logger, config)
+			p, err := New(connID, ProviderName, logger, config)
 			Expect(err).To(BeNil())
-			Expect(plg.client).NotTo(BeNil())
+			Expect(p.client).NotTo(BeNil())
+			plg = p
 		})
 
 		It("should fail when fetching next others", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/column/reverse_payout_test.go
+++ b/internal/connectors/plugins/public/column/reverse_payout_test.go
@@ -14,16 +14,21 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {
@@ -112,14 +117,19 @@ var _ = Describe("Column Plugin Payments", func() {
 
 		Context("HTTP Request Creation Errors", func() {
 			var (
-				plg models.Plugin
+				ctrl *gomock.Controller
+				plg  models.Plugin
 			)
 			BeforeEach(func() {
-				ctrl := gomock.NewController(GinkgoT())
+				ctrl = gomock.NewController(GinkgoT())
 				mockHTTPClient = client.NewMockHTTPClient(ctrl)
 				c := client.New("test", "aseplye", "http://invalid:port")
 				c.SetHttpClient(mockHTTPClient)
 				plg = &Plugin{client: c}
+			})
+
+			AfterEach(func() {
+				ctrl.Finish()
 			})
 
 			It("should return an error when reverse payout request URL is invalid", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/column/reverse_payout_test.go
+++ b/internal/connectors/plugins/public/column/reverse_payout_test.go
@@ -14,81 +14,68 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next payments", func() {
-		var (
-			mockHTTPClient *client.MockHTTPClient
-		)
-
-		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
-		})
-
 		Context("validateReversePayout", func() {
-			It("should validate a valid reverse payout request", func() {
-				pr := models.PSPPaymentInitiationReversal{
-					Metadata: map[string]string{
-						client.ColumnReasonMetadataKey: "incorrect_amount",
-					},
-					RelatedPaymentInitiation: models.PSPPaymentInitiation{
-						Reference: "test-reference",
+			It("should return error when metadata is nil", func(ctx SpecContext) {
+				req := models.ReversePayoutRequest{
+					PaymentInitiationReversal: models.PSPPaymentInitiationReversal{
+						Metadata: nil,
 					},
 				}
 
-				err := plg.validateReversePayout(pr)
-				Expect(err).To(BeNil())
-			})
-
-			It("should return error when metadata is nil", func() {
-				pr := models.PSPPaymentInitiationReversal{
-					Metadata: nil,
-				}
-
-				err := plg.validateReversePayout(pr)
+				_, err := plg.ReversePayout(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field metadata: required field metadata must be provided"))
 			})
 
-			It("should return error when relatedPaymentInitiation.reference is missing", func() {
-				pr := models.PSPPaymentInitiationReversal{
-					Metadata: map[string]string{
-						client.ColumnReasonMetadataKey: "incorrect_amount",
+			It("should return error when relatedPaymentInitiation.reference is missing", func(ctx SpecContext) {
+				req := models.ReversePayoutRequest{
+					PaymentInitiationReversal: models.PSPPaymentInitiationReversal{
+						Metadata: map[string]string{
+							client.ColumnReasonMetadataKey: "incorrect_amount",
+						},
+						RelatedPaymentInitiation: models.PSPPaymentInitiation{},
 					},
-					RelatedPaymentInitiation: models.PSPPaymentInitiation{},
 				}
-
-				err := plg.validateReversePayout(pr)
+				_, err := plg.ReversePayout(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field relatedPaymentInitiation.reference: required field relatedPaymentInitiation.reference must be provided"))
 			})
 
-			It("should return error when reason is missing", func() {
-				pr := models.PSPPaymentInitiationReversal{
-					Metadata: map[string]string{},
-					RelatedPaymentInitiation: models.PSPPaymentInitiation{
-						Reference: "test-reference",
+			It("should return error when reason is missing", func(ctx SpecContext) {
+				req := models.ReversePayoutRequest{
+					PaymentInitiationReversal: models.PSPPaymentInitiationReversal{
+						Metadata: map[string]string{},
+						RelatedPaymentInitiation: models.PSPPaymentInitiation{
+							Reference: "test-reference",
+						},
 					},
 				}
 
-				err := plg.validateReversePayout(pr)
+				_, err := plg.ReversePayout(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/reason: required metadata field com.column.spec/reason must be provided"))
 			})
 
-			It("should return error when reason is invalid", func() {
-				pr := models.PSPPaymentInitiationReversal{
-					Metadata: map[string]string{
-						client.ColumnReasonMetadataKey: "invalid-reason",
+			It("should return error when reason is invalid", func(ctx SpecContext) {
+				req := models.ReversePayoutRequest{
+					PaymentInitiationReversal: models.PSPPaymentInitiationReversal{
+						Metadata: map[string]string{
+							client.ColumnReasonMetadataKey: "invalid-reason",
+						},
 					},
 				}
 
-				err := plg.validateReversePayout(pr)
+				_, err := plg.ReversePayout(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/reason: required metadata field com.column.spec/reason must be a valid reason"))
 			})
 		})
@@ -124,11 +111,15 @@ var _ = Describe("Column Plugin Payments", func() {
 		})
 
 		Context("HTTP Request Creation Errors", func() {
+			var (
+				plg models.Plugin
+			)
 			BeforeEach(func() {
 				ctrl := gomock.NewController(GinkgoT())
 				mockHTTPClient = client.NewMockHTTPClient(ctrl)
-				plg.client = client.New("test", "aseplye", "http://invalid:port")
-				plg.client.SetHttpClient(mockHTTPClient)
+				c := client.New("test", "aseplye", "http://invalid:port")
+				c.SetHttpClient(mockHTTPClient)
+				plg = &Plugin{client: c}
 			})
 
 			It("should return an error when reverse payout request URL is invalid", func(ctx SpecContext) {
@@ -151,13 +142,6 @@ var _ = Describe("Column Plugin Payments", func() {
 		})
 
 		Context("CreatedAt Timestamp Parsing", func() {
-			BeforeEach(func() {
-				ctrl := gomock.NewController(GinkgoT())
-				mockHTTPClient = client.NewMockHTTPClient(ctrl)
-				plg.client = client.New("test", "aseplye", "https://test.com")
-				plg.client.SetHttpClient(mockHTTPClient)
-			})
-
 			It("should successfully parse a valid timestamp", func(ctx SpecContext) {
 				req := models.ReversePayoutRequest{
 					PaymentInitiationReversal: models.PSPPaymentInitiationReversal{

--- a/internal/connectors/plugins/public/column/transfers_test.go
+++ b/internal/connectors/plugins/public/column/transfers_test.go
@@ -15,335 +15,340 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
-		plg *Plugin
+		mockHTTPClient *client.MockHTTPClient
+		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		mockHTTPClient = client.NewMockHTTPClient(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(mockHTTPClient)
+		plg = &Plugin{client: c}
 	})
 
 	Context("fetching next payments", func() {
-		var (
-			mockHTTPClient *client.MockHTTPClient
-		)
-
-		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			mockHTTPClient = client.NewMockHTTPClient(ctrl)
-			plg.client = client.New("test", "aseplye", "https://test.com")
-			plg.client.SetHttpClient(mockHTTPClient)
-		})
-
 		Context("validateTransferRequest", func() {
-			It("should validate a valid transfer request", func() {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAllowOverdraftMetadataKey:          "true",
-						client.ColumnHoldMetadataKey:                    "false",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
-					},
-				}
-
-				err := plg.validateTransferRequest(pi)
-				Expect(err).To(BeNil())
-			})
-
 			It("should return error when amount is missing", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Asset: "USD/2",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Asset: "USD/2",
+					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingAmount.Error()))
 			})
 
 			It("should return error when source account reference is missing", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount:   big.NewInt(100),
-					Asset:    "USD",
-					Metadata: map[string]string{},
-					SourceAccount: &models.PSPAccount{
-						Name:     pointer.For("Test Source"),
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount:   big.NewInt(100),
+						Asset:    "USD",
 						Metadata: map[string]string{},
+						SourceAccount: &models.PSPAccount{
+							Name:     pointer.For("Test Source"),
+							Metadata: map[string]string{},
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrSourceAccountReferenceRequired.Error()))
 			})
 
 			It("should return error when address line 1 is provided but city is missing", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressLine1MetadataKey:            "123 Main St",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressLine1MetadataKey:            "123 Main St",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_city: required metadata field com.column.spec/address_city must be provided"))
 			})
 
 			It("should return error when asset is missing", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingAsset.Error()))
 			})
 
 			It("should return error when metadata is nil", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD/2",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD/2",
+					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingMetadata.Error()))
 			})
 
 			It("should return error when source account is nil", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount:   big.NewInt(100),
-					Asset:    "USD",
-					Metadata: map[string]string{},
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount:   big.NewInt(100),
+						Asset:    "USD",
+						Metadata: map[string]string{},
+					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingSourceAccount.Error()))
 			})
 
 			It("should return error when source account name is nil", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount:        big.NewInt(100),
-					Asset:         "USD",
-					Metadata:      map[string]string{},
-					SourceAccount: &models.PSPAccount{},
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount:        big.NewInt(100),
+						Asset:         "USD",
+						Metadata:      map[string]string{},
+						SourceAccount: &models.PSPAccount{},
+					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingSourceAccountName.Error()))
 			})
 
 			It("should return error when destination account is nil", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD/2",
-					Metadata: map[string]string{
-						client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD/2",
+						Metadata: map[string]string{
+							client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingDestinationAccount.Error()))
 			})
 
 			It("should return error when destination account reference is missing", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{},
 					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingDestinationAccountReference.Error()))
 			})
 
 			It("should return error when allow overdraft is invalid", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAllowOverdraftMetadataKey:          "invalid",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAllowOverdraftMetadataKey:          "invalid",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingMetadataAllowOverDrafts.Error()))
 			})
 
 			It("should return error when hold is invalid", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnHoldMetadataKey:                    "invalid",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnHoldMetadataKey:                    "invalid",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err.Error()).To(ContainSubstring(ErrMissingMetadataHold.Error()))
 			})
 
 			It("should return error when country code is missing with address line 1", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressLine1MetadataKey:            "123 Main St",
-						client.ColumnAddressCityMetadataKey:             "New York",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressLine1MetadataKey:            "123 Main St",
+							client.ColumnAddressCityMetadataKey:             "New York",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_country_code: required metadata field com.column.spec/address_country_code must be provided"))
 			})
 
 			It("should return error when city is provided without address line 1", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressCityMetadataKey:             "New York",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressCityMetadataKey:             "New York",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_city: metadata field com.column.spec/address_city is not required when addressLine1 is not provided"))
 			})
 
 			It("should return error when state is provided without address line 1", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressStateMetadataKey:            "NY",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressStateMetadataKey:            "NY",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_state: metadata field com.column.spec/address_state is not required when addressLine1 is not provided"))
 			})
 
 			It("should return error when postal code is provided without address line 1", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressPostalCodeMetadataKey:       "10001",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressPostalCodeMetadataKey:       "10001",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_postal_code: metadata field com.column.spec/address_postal_code is not required when addressLine1 is not provided"))
 			})
 
 			It("should return error when country code is provided without address line 1", func(ctx SpecContext) {
-				pi := models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
-					Asset:  "USD",
-					Metadata: map[string]string{
-						client.ColumnAddressCountryCodeMetadataKey:      "US",
-						client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
-						client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
-					},
-					SourceAccount: &models.PSPAccount{
-						Name:      pointer.For("Test Source"),
-						Reference: "src_ref",
-					},
-					DestinationAccount: &models.PSPAccount{
-						Reference: "dst_ref",
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Amount: big.NewInt(100),
+						Asset:  "USD",
+						Metadata: map[string]string{
+							client.ColumnAddressCountryCodeMetadataKey:      "US",
+							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
+							client.ColumnReceiverAccountNumberIdMetadataKey: "dst_acc_num",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
 					},
 				}
 
-				err := plg.validateTransferRequest(pi)
+				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(MatchError("validation error occurred for field com.column.spec/address_country_code: metadata field com.column.spec/address_country_code is not required when addressLine1 is not provided"))
 			})
 
 		})
 
 		Context("HTTP Request Creation Errors", func() {
+			var (
+				plg models.Plugin
+			)
 			BeforeEach(func() {
-				ctrl := gomock.NewController(GinkgoT())
-				mockHTTPClient = client.NewMockHTTPClient(ctrl)
-				plg.client = client.New("test", "aseplye", "http://invalid:port")
-				plg.client.SetHttpClient(mockHTTPClient)
+				c := client.New("test", "aseplye", "http://invalid:port")
+				c.SetHttpClient(mockHTTPClient)
+				plg = &Plugin{client: c}
 			})
 
 			It("should return an error when transfer request URL is invalid", func(ctx SpecContext) {
@@ -375,13 +380,6 @@ var _ = Describe("Column Plugin Payments", func() {
 		})
 
 		Context("Column API Errors", func() {
-			BeforeEach(func() {
-				ctrl := gomock.NewController(GinkgoT())
-				mockHTTPClient = client.NewMockHTTPClient(ctrl)
-				plg.client = client.New("test", "aseplye", "https://test.com")
-				plg.client.SetHttpClient(mockHTTPClient)
-			})
-
 			It("should return an error when HTTP client Do fails", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/column/transfers_test.go
+++ b/internal/connectors/plugins/public/column/transfers_test.go
@@ -15,16 +15,21 @@ import (
 
 var _ = Describe("Column Plugin Payments", func() {
 	var (
+		ctrl           *gomock.Controller
 		mockHTTPClient *client.MockHTTPClient
 		plg            models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockHTTPClient = client.NewMockHTTPClient(ctrl)
 		c := client.New("test", "aseplye", "https://test.com")
 		c.SetHttpClient(mockHTTPClient)
 		plg = &Plugin{client: c}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/column/webhook.go
+++ b/internal/connectors/plugins/public/column/webhook.go
@@ -297,12 +297,37 @@ func (p *Plugin) createWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	}, nil
 }
 
-func (p *Plugin) translateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
+func (p *Plugin) verifyWebhook(_ context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
 	signatures, ok := req.Webhook.Headers[HeadersSignature]
 	if !ok || len(signatures) == 0 {
-		return models.TranslateWebhookResponse{}, client.ErrWebhookHeaderXSignatureMissing
+		return models.VerifyWebhookResponse{}, client.ErrWebhookHeaderXSignatureMissing
 	}
 
+	config := req.Config
+	if config == nil || config.Metadata == nil {
+		return models.VerifyWebhookResponse{}, client.ErrWebhookConfigInvalid
+	}
+
+	secret, ok := config.Metadata["secret"]
+	if !ok {
+		return models.VerifyWebhookResponse{}, client.ErrWebhookConfigSecretMissing
+	}
+
+	if err := p.verifier.verifyWebhookSignature(req.Webhook.Body, signatures[0], secret); err != nil {
+		return models.VerifyWebhookResponse{}, err
+	}
+
+	var webhook client.WebhookEvent[json.RawMessage]
+	if err := json.Unmarshal(req.Webhook.Body, &webhook); err != nil {
+		return models.VerifyWebhookResponse{}, fmt.Errorf("failed to unmarshal webhook: %w", err)
+	}
+
+	return models.VerifyWebhookResponse{
+		WebhookIdempotencyKey: webhook.ID,
+	}, nil
+}
+
+func (p *Plugin) translateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	config := req.Config
 	if config == nil || config.Metadata == nil {
 		return models.TranslateWebhookResponse{}, client.ErrWebhookConfigInvalid
@@ -318,15 +343,6 @@ func (p *Plugin) translateWebhook(ctx context.Context, req models.TranslateWebho
 		return models.TranslateWebhookResponse{}, client.ErrWebhookTypeUnknown
 	}
 
-	secret, ok := config.Metadata["secret"]
-	if !ok {
-		return models.TranslateWebhookResponse{}, client.ErrWebhookConfigSecretMissing
-	}
-
-	if err := p.verifier.verifyWebhookSignature(req.Webhook.Body, signatures[0], secret); err != nil {
-		return models.TranslateWebhookResponse{}, err
-	}
-
 	var webhook client.WebhookEvent[json.RawMessage]
 	if err := json.Unmarshal(req.Webhook.Body, &webhook); err != nil {
 		return models.TranslateWebhookResponse{}, fmt.Errorf("failed to unmarshal webhook: %w", err)
@@ -337,7 +353,6 @@ func (p *Plugin) translateWebhook(ctx context.Context, req models.TranslateWebho
 		return models.TranslateWebhookResponse{}, err
 	}
 
-	res.IdempotencyKey = webhook.ID
 	return models.TranslateWebhookResponse{
 		Responses: []models.WebhookResponse{res},
 	}, nil

--- a/internal/connectors/plugins/public/column/webhook.go
+++ b/internal/connectors/plugins/public/column/webhook.go
@@ -323,7 +323,7 @@ func (p *Plugin) verifyWebhook(_ context.Context, req models.VerifyWebhookReques
 	}
 
 	return models.VerifyWebhookResponse{
-		WebhookIdempotencyKey: webhook.ID,
+		WebhookIdempotencyKey: &webhook.ID,
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/column/webhook.go
+++ b/internal/connectors/plugins/public/column/webhook.go
@@ -300,21 +300,21 @@ func (p *Plugin) createWebhooks(ctx context.Context, req models.CreateWebhooksRe
 func (p *Plugin) verifyWebhook(_ context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
 	signatures, ok := req.Webhook.Headers[HeadersSignature]
 	if !ok || len(signatures) == 0 {
-		return models.VerifyWebhookResponse{}, client.ErrColumSignatureMissing
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", client.ErrColumSignatureMissing, models.ErrWebhookVerification)
 	}
 
 	config := req.Config
 	if config == nil || config.Metadata == nil {
-		return models.VerifyWebhookResponse{}, client.ErrWebhookConfigInvalid
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", client.ErrWebhookConfigInvalid, models.ErrWebhookVerification)
 	}
 
 	secret, ok := config.Metadata["secret"]
 	if !ok {
-		return models.VerifyWebhookResponse{}, client.ErrWebhookConfigSecretMissing
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", client.ErrWebhookConfigSecretMissing, models.ErrWebhookVerification)
 	}
 
 	if err := p.verifier.verifyWebhookSignature(req.Webhook.Body, signatures[0], secret); err != nil {
-		return models.VerifyWebhookResponse{}, err
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", err, models.ErrWebhookVerification)
 	}
 
 	var webhook client.WebhookEvent[json.RawMessage]

--- a/internal/connectors/plugins/public/column/webhook.go
+++ b/internal/connectors/plugins/public/column/webhook.go
@@ -300,7 +300,7 @@ func (p *Plugin) createWebhooks(ctx context.Context, req models.CreateWebhooksRe
 func (p *Plugin) verifyWebhook(_ context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
 	signatures, ok := req.Webhook.Headers[HeadersSignature]
 	if !ok || len(signatures) == 0 {
-		return models.VerifyWebhookResponse{}, client.ErrWebhookHeaderXSignatureMissing
+		return models.VerifyWebhookResponse{}, client.ErrColumSignatureMissing
 	}
 
 	config := req.Config

--- a/internal/connectors/plugins/public/column/webhook_test.go
+++ b/internal/connectors/plugins/public/column/webhook_test.go
@@ -31,7 +31,8 @@ var _ = Describe("Column Plugin Webhooks", func() {
 			client:   c,
 			verifier: verifierMock,
 		}
-		p.initWebhookConfig()
+		err := p.initWebhookConfig()
+		Expect(err).To(BeNil())
 		plg = p
 	})
 
@@ -72,7 +73,8 @@ var _ = Describe("Column Plugin Webhooks", func() {
 			}
 
 			p := Plugin{}
-			p.initWebhookConfig()
+			err := p.initWebhookConfig()
+			Expect(err).To(BeNil())
 			for name, w := range p.supportedWebhooks {
 				url, _ := url.JoinPath(req.WebhookBaseUrl, w.urlPath)
 				httpMock.EXPECT().Do(

--- a/internal/connectors/plugins/public/column/webhook_test.go
+++ b/internal/connectors/plugins/public/column/webhook_test.go
@@ -37,6 +37,10 @@ var _ = Describe("Column Plugin Webhooks", func() {
 		plg = p
 	})
 
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Context("webhooks", func() {
 		var (
 			webhookID                 string
@@ -73,10 +77,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				WebhookBaseUrl: webhookBaseURL,
 			}
 
-			p := Plugin{}
-			err := p.initWebhookConfig()
-			Expect(err).To(BeNil())
-			for name, w := range p.supportedWebhooks {
+			for name, w := range plg.(*Plugin).supportedWebhooks {
 				url, _ := url.JoinPath(req.WebhookBaseUrl, w.urlPath)
 				httpMock.EXPECT().Do(
 					gomock.Any(),
@@ -96,7 +97,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 
 			res, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(res.Others).To(HaveLen(len(p.supportedWebhooks)))
+			Expect(res.Others).To(HaveLen(len(plg.(*Plugin).supportedWebhooks)))
 			Expect(res.Others[0].ID).To(Equal(expectedWebhookResponseID))
 		})
 
@@ -132,7 +133,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 			}
 			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("missing X-Signature-Sha256 header"))
+			Expect(err).To(MatchError("missing Column-Signature header"))
 			Expect(res).To(Equal(models.VerifyWebhookResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/column/webhook_test.go
+++ b/internal/connectors/plugins/public/column/webhook_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 			}
 			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("missing Column-Signature header"))
+			Expect(err).To(MatchError("missing Column-Signature header: webhook verification error"))
 			Expect(res).To(Equal(models.VerifyWebhookResponse{}))
 		})
 
@@ -156,7 +156,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 
 			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
+			Expect(err).To(MatchError("test error: webhook verification error"))
 			Expect(res).To(Equal(models.VerifyWebhookResponse{}))
 		})
 

--- a/internal/connectors/plugins/public/column/webhook_test.go
+++ b/internal/connectors/plugins/public/column/webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/formancehq/go-libs/v3/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/column/client"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -178,7 +179,7 @@ var _ = Describe("Column Plugin Webhooks", func() {
 			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(models.VerifyWebhookResponse{
-				WebhookIdempotencyKey: "1",
+				WebhookIdempotencyKey: pointer.For("1"),
 			}))
 		})
 

--- a/internal/connectors/plugins/public/column/webhook_test.go
+++ b/internal/connectors/plugins/public/column/webhook_test.go
@@ -15,46 +15,40 @@ import (
 
 var _ = Describe("Column Plugin Webhooks", func() {
 	var (
-		plg      *Plugin
-		httpMock *client.MockHTTPClient
-		ctrl     *gomock.Controller
+		plg          models.Plugin
+		httpMock     *client.MockHTTPClient
+		ctrl         *gomock.Controller
+		verifierMock *MockWebhookVerifier
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl = gomock.NewController(GinkgoT())
+		httpMock = client.NewMockHTTPClient(ctrl)
+		verifierMock = NewMockWebhookVerifier(ctrl)
+		c := client.New("test", "aseplye", "https://test.com")
+		c.SetHttpClient(httpMock)
+		p := &Plugin{
+			client:   c,
+			verifier: verifierMock,
+		}
+		p.initWebhookConfig()
+		plg = p
 	})
 
-	Context("create webhooks", func() {
+	Context("webhooks", func() {
 		var (
 			webhookID                 string
 			expectedObjectedID        string
 			expectedWebhookResponseID string
 			webhookBaseURL            string
-			err                       error
-			verifierMock              *MockWebhookVerifier
 			secret                    string
 		)
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			httpMock = client.NewMockHTTPClient(ctrl)
-			verifierMock = NewMockWebhookVerifier(ctrl)
-			plg = &Plugin{
-				client:   client.New("test", "aseplye", "https://test.com"),
-				verifier: verifierMock,
-			}
-			plg.client.SetHttpClient(httpMock)
 			webhookID = "webhook135"
 			expectedObjectedID = "44"
 			expectedWebhookResponseID = "sampleResID"
 			webhookBaseURL = "https://example.com"
 			secret = "test-secret"
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSettled: {
-					urlPath: "/ach/outgoing_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-			Expect(err).To(BeNil())
 		})
 
 		It("skips making calls when webhook url missing", func(ctx SpecContext) {
@@ -76,24 +70,30 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				FromPayload:    json.RawMessage(`{"id":"1"}`),
 				WebhookBaseUrl: webhookBaseURL,
 			}
-			url, _ := url.JoinPath(req.WebhookBaseUrl, "ach/outgoing_transfer/settled")
-			httpMock.EXPECT().Do(
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-				gomock.Any(),
-			).Return(
-				200,
-				nil,
-			).SetArg(2, client.EventSubscription{
-				ID:            expectedWebhookResponseID,
-				URL:           url,
-				Secret:        "test-secret",
-				EnabledEvents: []string{"ach.outgoing_transfer.settled"},
-			})
+
+			p := Plugin{}
+			p.initWebhookConfig()
+			for name, w := range p.supportedWebhooks {
+				url, _ := url.JoinPath(req.WebhookBaseUrl, w.urlPath)
+				httpMock.EXPECT().Do(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(
+					200,
+					nil,
+				).SetArg(2, client.EventSubscription{
+					ID:            expectedWebhookResponseID,
+					URL:           url,
+					Secret:        "test-secret",
+					EnabledEvents: []string{string(name)},
+				})
+			}
+
 			res, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(res.Others).To(HaveLen(1))
+			Expect(res.Others).To(HaveLen(len(p.supportedWebhooks)))
 			Expect(res.Others[0].ID).To(Equal(expectedWebhookResponseID))
 		})
 
@@ -118,22 +118,23 @@ var _ = Describe("Column Plugin Webhooks", func() {
 		})
 
 		It("should return an error - validation error - no header signature", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "test",
+			req := models.VerifyWebhookRequest{
+				Config: &models.WebhookConfig{
+					Name: "test",
+				},
 				Webhook: models.PSPWebhook{
 					Headers: map[string][]string{},
 					Body:    json.RawMessage(`{"id":"1"}`),
 				},
 			}
-			res, err := plg.TranslateWebhook(ctx, req)
+			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError("missing X-Signature-Sha256 header"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
+			Expect(res).To(Equal(models.VerifyWebhookResponse{}))
 		})
 
 		It("should return an error - verify signature error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "ach.outgoing_transfer.settled",
+			req := models.VerifyWebhookRequest{
 				Webhook: models.PSPWebhook{
 					Headers: map[string][]string{
 						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
@@ -143,23 +144,40 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferSettled), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSettled: {
-					urlPath: "/ach/outgoing_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
 			verifierMock.EXPECT().verifyWebhookSignature(
 				req.Webhook.Body,
 				req.Webhook.Headers["Column-Signature"][0],
 				secret,
 			).Return(errors.New("test error"))
 
-			res, err := plg.TranslateWebhook(ctx, req)
+			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError("test error"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
+			Expect(res).To(Equal(models.VerifyWebhookResponse{}))
+		})
+
+		It("should be ok when verifying", func(ctx SpecContext) {
+			req := models.VerifyWebhookRequest{
+				Webhook: models.PSPWebhook{
+					Headers: map[string][]string{
+						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
+					},
+					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s", "type": "ach.outgoing_transfer.settled"}}`, expectedObjectedID)),
+				},
+				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferSettled), Metadata: map[string]string{"secret": secret}},
+			}
+
+			verifierMock.EXPECT().verifyWebhookSignature(
+				req.Webhook.Body,
+				req.Webhook.Headers["Column-Signature"][0],
+				secret,
+			).Return(nil)
+
+			res, err := plg.VerifyWebhook(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(models.VerifyWebhookResponse{
+				WebhookIdempotencyKey: "1",
+			}))
 		})
 
 		It("should return an error - unknown webhook name error", func(ctx SpecContext) {
@@ -173,168 +191,9 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: "ac.created", Metadata: map[string]string{}},
 			}
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSettled: {
-					urlPath: "/ach/outgoing_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError(client.ErrWebhookTypeUnknown.Error()))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
-		})
-
-		It("should return an error - ach.outgoing_transfer.settled error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "ach.outgoing_transfer.settled",
-				Webhook: models.PSPWebhook{
-					Headers: map[string][]string{
-						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
-					},
-					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s"}}`, expectedObjectedID)),
-				},
-				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferSettled), Metadata: map[string]string{"secret": secret}},
-			}
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSettled: {
-					urlPath: "/ach/outgoing_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(errors.New("test error"))
-
-			res, err := plg.TranslateWebhook(ctx, req)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
-		})
-
-		It("should return an error book.transfer.completed error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "book.transfer.completed",
-				Webhook: models.PSPWebhook{
-					Headers: map[string][]string{
-						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
-					},
-					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s", "type": "book.transfer.completed"}}`, expectedObjectedID)),
-				},
-				Config: &models.WebhookConfig{Name: string(client.EventCategoryBookTransferCompleted), Metadata: map[string]string{"secret": secret}},
-			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryBookTransferCompleted: {
-					urlPath: "/book/transfer/completed",
-					fn:      plg.translateBookTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(errors.New("test error"))
-
-			res, err := plg.TranslateWebhook(ctx, req)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
-		})
-
-		It("should return an error realtime.outgoing_transfer.completed error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "realtime.outgoing_transfer.completed",
-				Webhook: models.PSPWebhook{
-					Headers: map[string][]string{
-						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
-					},
-					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s", "type": "realtime.outgoing_transfer.completed"}}`, expectedObjectedID)),
-				},
-				Config: &models.WebhookConfig{Name: string(client.EventCategoryRealtimeTransferCompleted), Metadata: map[string]string{"secret": secret}},
-			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryRealtimeTransferCompleted: {
-					urlPath: "/realtime/outgoing_transfer/completed",
-					fn:      plg.translateRealtimeTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(errors.New("test error"))
-
-			res, err := plg.TranslateWebhook(ctx, req)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
-		})
-
-		It("should return an error - swift.outgoing_transfer.completed error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "swift.outgoing_transfer.completed",
-				Webhook: models.PSPWebhook{
-					Headers: map[string][]string{
-						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
-					},
-					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s", "type":"swift.outgoing_transfer.completed"}}`, expectedObjectedID)),
-				},
-				Config: &models.WebhookConfig{Name: string(client.EventCategoryInternationalWireCompleted), Metadata: map[string]string{"secret": secret}},
-			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryInternationalWireCompleted: {
-					urlPath: "/swift/outgoing_transfer/completed",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(errors.New("test error"))
-
-			res, err := plg.TranslateWebhook(ctx, req)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
-			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
-		})
-
-		It("should return an error - wire.outgoing_transfer.completed error", func(ctx SpecContext) {
-			req := models.TranslateWebhookRequest{
-				Name: "wire.outgoing_transfer.completed",
-				Webhook: models.PSPWebhook{
-					Headers: map[string][]string{
-						"Column-Signature": {"7ebfbadaa1856b9f1374f3e08453de3d760838344862344a103c28129d9173d1"},
-					},
-					Body: json.RawMessage(fmt.Sprintf(`{"id":"1", "data": {"id": "%s", "type": "wire.outgoing_transfer.completed"}}`, expectedObjectedID)),
-				},
-				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferOutgoingCompleted), Metadata: map[string]string{"secret": secret}},
-			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferOutgoingCompleted: {
-					urlPath: "/wire/outgoing_transfer/completed",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(errors.New("test error"))
-
-			res, err := plg.TranslateWebhook(ctx, req)
-			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test error"))
 			Expect(res).To(Equal(models.TranslateWebhookResponse{}))
 		})
 
@@ -363,19 +222,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryBookTransferCompleted), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryBookTransferCompleted: {
-					urlPath: "/book/transfer/completed",
-					fn:      plg.translateBookTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -412,19 +258,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryRealtimeTransferCompleted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryRealtimeTransferCompleted: {
-					urlPath: "/realtime/outgoing_transfer/completed",
-					fn:      plg.translateRealtimeTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -454,19 +287,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferSettled), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSettled: {
-					urlPath: "/ach/outgoing_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -507,19 +327,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryInternationalWireCompleted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryInternationalWireCompleted: {
-					urlPath: "/swift/outgoing_transfer/completed",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -538,19 +345,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferOutgoingCompleted), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferOutgoingCompleted: {
-					urlPath: "/wire/outgoing_transfer/completed",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -580,19 +374,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferReturned), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferReturned: {
-					urlPath: "/ach/outgoing_transfer/returned",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -627,19 +408,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingCancellationRequested), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingCancellationRequested: {
-					urlPath: "/swift/outgoing_transfer/cancellation_requested",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -672,19 +440,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryRealtimeTransferManualReview), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryRealtimeTransferManualReview: {
-					urlPath: "/realtime/outgoing_transfer/manual_review",
-					fn:      plg.translateRealtimeTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -711,19 +466,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferInitiated), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferInitiated: {
-					urlPath: "/wire/outgoing_transfer/initiated",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -753,19 +495,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferIncomingCompleted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferIncomingCompleted: {
-					urlPath: "/wire/incoming_transfer/completed",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -794,19 +523,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferSubmitted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferSubmitted: {
-					urlPath: "/wire/outgoing_transfer/submitted",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -834,19 +550,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferRejected), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferRejected: {
-					urlPath: "/wire/outgoing_transfer/rejected",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -877,19 +580,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryWireTransferManualReview), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryWireTransferManualReview: {
-					urlPath: "/wire/outgoing_transfer/manual_review",
-					fn:      plg.translateWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -917,19 +607,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferInitiated), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferInitiated: {
-					urlPath: "/ach/outgoing_transfer/initiated",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -959,19 +636,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferSubmitted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferSubmitted: {
-					urlPath: "/ach/outgoing_transfer/submitted",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -999,19 +663,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferCompleted), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferCompleted: {
-					urlPath: "/ach/outgoing_transfer/completed",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1042,19 +693,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferManualReview), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferManualReview: {
-					urlPath: "/ach/outgoing_transfer/manual_review",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1082,19 +720,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferCanceled), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferCanceled: {
-					urlPath: "/ach/outgoing_transfer/canceled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1124,19 +749,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferReturnDishonored), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferReturnDishonored: {
-					urlPath: "/ach/outgoing_transfer/return_dishonored",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1164,19 +776,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferReturnContested), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferReturnContested: {
-					urlPath: "/ach/outgoing_transfer/return_contested",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1206,19 +805,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHTransferNOC), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHTransferNOC: {
-					urlPath: "/ach/outgoing_transfer/noc",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1246,19 +832,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingScheduled), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingScheduled: {
-					urlPath: "/ach/incoming_transfer/scheduled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1288,19 +861,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingSettled), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingSettled: {
-					urlPath: "/ach/incoming_transfer/settled",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1328,19 +888,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingNSF), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingNSF: {
-					urlPath: "/ach/incoming_transfer/nsf",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1370,19 +917,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingCompleted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingCompleted: {
-					urlPath: "/ach/incoming_transfer/completed",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1410,19 +944,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingReturned), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingReturned: {
-					urlPath: "/ach/incoming_transfer/returned",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1452,19 +973,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingReturnDishonored), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingReturnDishonored: {
-					urlPath: "/ach/incoming_transfer/return_dishonored",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1493,19 +1001,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategoryACHIncomingReturnContested), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategoryACHIncomingReturnContested: {
-					urlPath: "/ach/incoming_transfer/return_contested",
-					fn:      plg.translateAchTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1533,19 +1028,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingInitiated), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingInitiated: {
-					urlPath: "/swift/outgoing_transfer/initiated",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1576,19 +1058,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingManualReview), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingManualReview: {
-					urlPath: "/swift/outgoing_transfer/manual_review",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1616,19 +1085,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingSubmitted), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingSubmitted: {
-					urlPath: "/swift/outgoing_transfer/submitted",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1658,19 +1114,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingPendingReturn), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingPendingReturn: {
-					urlPath: "/swift/outgoing_transfer/pending_return",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1698,19 +1141,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingReturned), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingReturned: {
-					urlPath: "/swift/outgoing_transfer/returned",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
@@ -1740,19 +1170,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingCancellationAccepted), Metadata: map[string]string{"secret": secret}},
 			}
 
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingCancellationAccepted: {
-					urlPath: "/swift/outgoing_transfer/cancellation_accepted",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
-
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(res.Responses).To(HaveLen(1))
@@ -1780,19 +1197,6 @@ var _ = Describe("Column Plugin Webhooks", func() {
 				},
 				Config: &models.WebhookConfig{Name: string(client.EventCategorySwiftOutgoingCancellationRejected), Metadata: map[string]string{"secret": secret}},
 			}
-
-			plg.supportedWebhooks = map[client.EventCategory]supportedWebhook{
-				client.EventCategorySwiftOutgoingCancellationRejected: {
-					urlPath: "/swift/outgoing_transfer/cancellation_rejected",
-					fn:      plg.translateInternationalWireTransfer,
-				},
-			}
-
-			verifierMock.EXPECT().verifyWebhookSignature(
-				req.Webhook.Body,
-				req.Webhook.Headers["Column-Signature"][0],
-				secret,
-			).Return(nil)
 
 			res, err := plg.TranslateWebhook(ctx, req)
 			Expect(err).To(BeNil())

--- a/internal/connectors/plugins/public/currencycloud/accounts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/currencycloud/accounts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []*client.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]*client.Account, 0)

--- a/internal/connectors/plugins/public/currencycloud/balances_test.go
+++ b/internal/connectors/plugins/public/currencycloud/balances_test.go
@@ -13,14 +13,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/currencycloud/balances_test.go
+++ b/internal/connectors/plugins/public/currencycloud/balances_test.go
@@ -13,24 +13,23 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m              *client.MockClient
 			sampleBalances []*client.Balance
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBalances = []*client.Balance{

--- a/internal/connectors/plugins/public/currencycloud/external_accounts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/external_accounts_test.go
@@ -15,24 +15,24 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m                   *client.MockClient
 			sampleBeneficiaries []*client.Beneficiary
 			now                 time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
+
 			now = time.Now().UTC()
 
 			sampleBeneficiaries = make([]*client.Beneficiary, 0)

--- a/internal/connectors/plugins/public/currencycloud/external_accounts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/external_accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/currencycloud/payments_test.go
+++ b/internal/connectors/plugins/public/currencycloud/payments_test.go
@@ -19,14 +19,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/currencycloud/payments_test.go
+++ b/internal/connectors/plugins/public/currencycloud/payments_test.go
@@ -19,24 +19,23 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next payments", func() {
 		var (
-			m                  *client.MockClient
 			sampleTransactions []client.Transaction
 			now                time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleTransactions = make([]client.Transaction, 0)

--- a/internal/connectors/plugins/public/currencycloud/payouts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/payouts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/currencycloud/payouts_test.go
+++ b/internal/connectors/plugins/public/currencycloud/payouts_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/currencycloud/transfers_test.go
+++ b/internal/connectors/plugins/public/currencycloud/transfers_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/currencycloud/transfers_test.go
+++ b/internal/connectors/plugins/public/currencycloud/transfers_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("CurrencyCloud Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/generic/accounts_test.go
+++ b/internal/connectors/plugins/public/generic/accounts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Generic Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/generic/accounts_test.go
+++ b/internal/connectors/plugins/public/generic/accounts_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Generic Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []genericclient.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]genericclient.Account, 0)

--- a/internal/connectors/plugins/public/generic/balances_test.go
+++ b/internal/connectors/plugins/public/generic/balances_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Generic Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m             *client.MockClient
 			sampleBalance genericclient.Balances
 			now           time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBalance = genericclient.Balances{

--- a/internal/connectors/plugins/public/generic/balances_test.go
+++ b/internal/connectors/plugins/public/generic/balances_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Generic Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/generic/external_accounts_test.go
+++ b/internal/connectors/plugins/public/generic/external_accounts_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Generic Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []genericclient.Beneficiary
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]genericclient.Beneficiary, 0)

--- a/internal/connectors/plugins/public/generic/external_accounts_test.go
+++ b/internal/connectors/plugins/public/generic/external_accounts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Generic Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/generic/payments_test.go
+++ b/internal/connectors/plugins/public/generic/payments_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Generic Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/generic/payments_test.go
+++ b/internal/connectors/plugins/public/generic/payments_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Generic Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next payments", func() {
 		var (
-			m              *client.MockClient
 			samplePayments []genericclient.Transaction
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePayments = make([]genericclient.Transaction, 0)

--- a/internal/connectors/plugins/public/mangopay/accounts_test.go
+++ b/internal/connectors/plugins/public/mangopay/accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Mangopay Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []client.Wallet
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]client.Wallet, 0)

--- a/internal/connectors/plugins/public/mangopay/accounts_test.go
+++ b/internal/connectors/plugins/public/mangopay/accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/mangopay/balances_test.go
+++ b/internal/connectors/plugins/public/mangopay/balances_test.go
@@ -14,14 +14,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/mangopay/balances_test.go
+++ b/internal/connectors/plugins/public/mangopay/balances_test.go
@@ -14,23 +14,22 @@ import (
 
 var _ = Describe("Mangopay Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m             *client.MockClient
 			sampleBalance client.Wallet
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 
 			sampleBalance = client.Wallet{
 				Balance: struct {

--- a/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
@@ -16,25 +16,24 @@ import (
 
 var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create bank account", func() {
 		var (
-			m                   *client.MockClient
 			sampleBankAccount   models.BankAccount
 			sampleClientAddress client.OwnerAddress
 			now                 time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBankAccount = models.BankAccount{

--- a/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/mangopay/bank_account_creation_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Bank Account Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create bank account", func() {

--- a/internal/connectors/plugins/public/mangopay/external_accounts_test.go
+++ b/internal/connectors/plugins/public/mangopay/external_accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Mangopay Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m                  *client.MockClient
 			sampleBankAccounts []client.BankAccount
 			now                time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBankAccounts = make([]client.BankAccount, 0)

--- a/internal/connectors/plugins/public/mangopay/external_accounts_test.go
+++ b/internal/connectors/plugins/public/mangopay/external_accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Mangopay Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/mangopay/payments_test.go
+++ b/internal/connectors/plugins/public/mangopay/payments_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Mangopay Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next payments", func() {
 		var (
-			m                  *client.MockClient
 			sampleTransactions []client.Payment
 			now                time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleTransactions = make([]client.Payment, 0)

--- a/internal/connectors/plugins/public/mangopay/payments_test.go
+++ b/internal/connectors/plugins/public/mangopay/payments_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next payments", func() {

--- a/internal/connectors/plugins/public/mangopay/payouts_test.go
+++ b/internal/connectors/plugins/public/mangopay/payouts_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/mangopay/payouts_test.go
+++ b/internal/connectors/plugins/public/mangopay/payouts_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/mangopay/plugin.go
+++ b/internal/connectors/plugins/public/mangopay/plugin.go
@@ -170,6 +170,12 @@ func (p *Plugin) CreateWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	}, nil
 }
 
+func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	// Nothing to do here, we don't need to verify the webhook and we don't want
+	// to generate an idempotency key from the query values
+	return models.VerifyWebhookResponse{}, nil
+}
+
 func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	if p.client == nil {
 		return models.TranslateWebhookResponse{}, plugins.ErrNotYetInstalled

--- a/internal/connectors/plugins/public/mangopay/transfers_test.go
+++ b/internal/connectors/plugins/public/mangopay/transfers_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/mangopay/transfers_test.go
+++ b/internal/connectors/plugins/public/mangopay/transfers_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Mangopay Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/mangopay/users_test.go
+++ b/internal/connectors/plugins/public/mangopay/users_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Mangopay Plugin Users", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next users", func() {

--- a/internal/connectors/plugins/public/mangopay/users_test.go
+++ b/internal/connectors/plugins/public/mangopay/users_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Mangopay Plugin Users", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next users", func() {
 		var (
-			m           *client.MockClient
 			sampleUsers []client.User
 			now         time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleUsers = make([]client.User, 0)

--- a/internal/connectors/plugins/public/mangopay/webhooks.go
+++ b/internal/connectors/plugins/public/mangopay/webhooks.go
@@ -206,8 +206,7 @@ func (p *Plugin) translateTransfer(ctx context.Context, req webhookTranslateRequ
 	}
 
 	return models.WebhookResponse{
-		IdempotencyKey: fmt.Sprintf("%s-%s-%d", req.webhook.ResourceID, string(req.webhook.EventType), req.webhook.Date),
-		Payment:        &payment,
+		Payment: &payment,
 	}, nil
 }
 
@@ -250,8 +249,7 @@ func (p *Plugin) translatePayout(ctx context.Context, req webhookTranslateReques
 	}
 
 	return models.WebhookResponse{
-		IdempotencyKey: fmt.Sprintf("%s-%s-%d", req.webhook.ResourceID, string(req.webhook.EventType), req.webhook.Date),
-		Payment:        &payment,
+		Payment: &payment,
 	}, nil
 }
 
@@ -290,8 +288,7 @@ func (p *Plugin) translatePayin(ctx context.Context, req webhookTranslateRequest
 	}
 
 	return models.WebhookResponse{
-		IdempotencyKey: fmt.Sprintf("%s-%s-%d", req.webhook.ResourceID, string(req.webhook.EventType), req.webhook.Date),
-		Payment:        &payment,
+		Payment: &payment,
 	}, nil
 }
 
@@ -335,7 +332,6 @@ func (p *Plugin) translateRefund(ctx context.Context, req webhookTranslateReques
 	}
 
 	return models.WebhookResponse{
-		IdempotencyKey: fmt.Sprintf("%s-%s-%d", req.webhook.ResourceID, string(req.webhook.EventType), req.webhook.Date),
-		Payment:        &payment,
+		Payment: &payment,
 	}, nil
 }

--- a/internal/connectors/plugins/public/mangopay/webhooks_test.go
+++ b/internal/connectors/plugins/public/mangopay/webhooks_test.go
@@ -3,7 +3,6 @@ package mangopay
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"strconv"
 	"time"
@@ -18,25 +17,24 @@ import (
 
 var _ = Describe("Mangopay Plugin Create Webhooks", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		p := &Plugin{client: m}
+		p.initWebhookConfig()
+		plg = p
 	})
 
 	Context("create webhooks", func() {
 		var (
-			m                         *client.MockClient
 			listAllValidHooksResponse []*client.Hook
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-			plg.initWebhookConfig()
-
 			listAllValidHooksResponse = []*client.Hook{
 				{
 					ID:        "1",
@@ -205,45 +203,45 @@ var _ = Describe("Mangopay Plugin Create Webhooks", func() {
 			}
 
 			m.EXPECT().ListAllHooks(gomock.Any()).Return(nil, nil)
-			for range plg.supportedWebhooks {
+			p := Plugin{}
+			p.initWebhookConfig()
+			for range p.supportedWebhooks {
 				m.EXPECT().CreateHook(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			}
 
 			resp, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.Configs).To(HaveLen(len(plg.supportedWebhooks)))
+			Expect(resp.Configs).To(HaveLen(len(p.supportedWebhooks)))
 		})
 	})
 })
 
 var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		p := &Plugin{client: m}
+		p.initWebhookConfig()
+		plg = p
 	})
 
 	Context("create webhooks", func() {
 		var (
-			m                      *client.MockClient
 			sampleTransferResponse client.TransferResponse
 			samplePayoutResponse   client.PayoutResponse
 			samplePayinResponse    client.PayinResponse
 			sampleRefundResponse   client.Refund
 			now                    time.Time
-			date                   string
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
-			date = strconv.FormatInt(now.UTC().Unix(), 10)
-			plg.initWebhookConfig()
 
 			sampleTransferResponse = client.TransferResponse{
 				ID:           "1",
@@ -453,7 +451,6 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 				Expect(resp).To(Equal(models.TranslateWebhookResponse{
 					Responses: []models.WebhookResponse{
 						{
-							IdempotencyKey: fmt.Sprintf("1-%s-%s", eventType, date),
 							Payment: &models.PSPPayment{
 								Reference:                   "1",
 								CreatedAt:                   time.Unix(sampleTransferResponse.CreationDate, 0),
@@ -535,7 +532,6 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 				Expect(resp).To(Equal(models.TranslateWebhookResponse{
 					Responses: []models.WebhookResponse{
 						{
-							IdempotencyKey: fmt.Sprintf("1-%s-%s", eventType, date),
 							Payment: &models.PSPPayment{
 								Reference:                   "1",
 								CreatedAt:                   time.Unix(samplePayoutResponse.CreationDate, 0),
@@ -615,7 +611,6 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 				Expect(resp).To(Equal(models.TranslateWebhookResponse{
 					Responses: []models.WebhookResponse{
 						{
-							IdempotencyKey: fmt.Sprintf("1-%s-%s", eventType, date),
 							Payment: &models.PSPPayment{
 								Reference:                   "1",
 								CreatedAt:                   time.Unix(samplePayinResponse.CreationDate, 0),
@@ -719,7 +714,6 @@ var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 				Expect(resp).To(Equal(models.TranslateWebhookResponse{
 					Responses: []models.WebhookResponse{
 						{
-							IdempotencyKey: fmt.Sprintf("1-%s-%s", eventType, date),
 							Payment: &models.PSPPayment{
 								ParentReference: "123",
 								Reference:       "1",

--- a/internal/connectors/plugins/public/mangopay/webhooks_test.go
+++ b/internal/connectors/plugins/public/mangopay/webhooks_test.go
@@ -17,16 +17,21 @@ import (
 
 var _ = Describe("Mangopay Plugin Create Webhooks", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		p := &Plugin{client: m}
 		p.initWebhookConfig()
 		plg = p
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create webhooks", func() {
@@ -203,32 +208,36 @@ var _ = Describe("Mangopay Plugin Create Webhooks", func() {
 			}
 
 			m.EXPECT().ListAllHooks(gomock.Any()).Return(nil, nil)
-			p := Plugin{}
-			p.initWebhookConfig()
-			for range p.supportedWebhooks {
+
+			for range plg.(*Plugin).supportedWebhooks {
 				m.EXPECT().CreateHook(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			}
 
 			resp, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.Configs).To(HaveLen(len(p.supportedWebhooks)))
+			Expect(resp.Configs).To(HaveLen(len(plg.(*Plugin).supportedWebhooks)))
 		})
 	})
 })
 
 var _ = Describe("Mangopay Plugin Translate Webhook", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		p := &Plugin{client: m}
 		p.initWebhookConfig()
 		plg = p
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create webhooks", func() {

--- a/internal/connectors/plugins/public/modulr/accounts_test.go
+++ b/internal/connectors/plugins/public/modulr/accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Modulr Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/modulr/accounts_test.go
+++ b/internal/connectors/plugins/public/modulr/accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Modulr Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleAccounts []client.Account
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleAccounts = make([]client.Account, 0)

--- a/internal/connectors/plugins/public/modulr/balances_test.go
+++ b/internal/connectors/plugins/public/modulr/balances_test.go
@@ -13,14 +13,19 @@ import (
 
 var _ = Describe("Modulr Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next balances", func() {

--- a/internal/connectors/plugins/public/modulr/balances_test.go
+++ b/internal/connectors/plugins/public/modulr/balances_test.go
@@ -13,24 +13,22 @@ import (
 
 var _ = Describe("Modulr Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next balances", func() {
 		var (
-			m             *client.MockClient
 			sampleBalance client.Account
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-
 			sampleBalance = client.Account{
 				Balance:  "150.01",
 				Currency: "USD",

--- a/internal/connectors/plugins/public/modulr/external_accounts_test.go
+++ b/internal/connectors/plugins/public/modulr/external_accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Modulr Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/modulr/external_accounts_test.go
+++ b/internal/connectors/plugins/public/modulr/external_accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Modulr Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m                   *client.MockClient
 			sampleBeneficiaries []client.Beneficiary
 			now                 time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBeneficiaries = make([]client.Beneficiary, 0)

--- a/internal/connectors/plugins/public/modulr/payments_test.go
+++ b/internal/connectors/plugins/public/modulr/payments_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Modulr Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {
@@ -196,15 +201,20 @@ var _ = Describe("Modulr Plugin Payments", func() {
 
 var _ = Describe("Modulr Plugin Transaction to Payments", func() {
 	var (
-		m   *client.MockClient
-		plg *Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  *Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{}
 		plg.client = m
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("transaction to payments", func() {

--- a/internal/connectors/plugins/public/modulr/payments_test.go
+++ b/internal/connectors/plugins/public/modulr/payments_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Modulr Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m                  *client.MockClient
 			sampleTransactions []client.Transaction
 			now                time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleTransactions = make([]client.Transaction, 0)
@@ -197,16 +196,19 @@ var _ = Describe("Modulr Plugin Payments", func() {
 
 var _ = Describe("Modulr Plugin Transaction to Payments", func() {
 	var (
+		m   *client.MockClient
 		plg *Plugin
 	)
 
 	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
 		plg = &Plugin{}
+		plg.client = m
 	})
 
-	Context("fetching next accounts", func() {
+	Context("transaction to payments", func() {
 		var (
-			m                         *client.MockClient
 			samplePayinTransaction    client.Transaction
 			samplePayoutTransaction   client.Transaction
 			sampleTransferTransaction client.Transaction
@@ -215,9 +217,6 @@ var _ = Describe("Modulr Plugin Transaction to Payments", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now, _ = time.Parse("2006-01-02T15:04:05.999-0700", time.Now().UTC().Format("2006-01-02T15:04:05.999-0700"))
 
 			sampleTransfer = client.TransferResponse{

--- a/internal/connectors/plugins/public/modulr/payouts_test.go
+++ b/internal/connectors/plugins/public/modulr/payouts_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Modulr Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now, _ = time.Parse("2006-01-02T15:04:05.999-0700", time.Now().UTC().Format("2006-01-02T15:04:05.999-0700"))
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/modulr/payouts_test.go
+++ b/internal/connectors/plugins/public/modulr/payouts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Modulr Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/modulr/transfers_test.go
+++ b/internal/connectors/plugins/public/modulr/transfers_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Modulr Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now, _ = time.Parse("2006-01-02T15:04:05.999-0700", time.Now().UTC().Format("2006-01-02T15:04:05.999-0700"))
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/modulr/transfers_test.go
+++ b/internal/connectors/plugins/public/modulr/transfers_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Modulr Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/moneycorp/accounts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/accounts_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Moneycorp *Plugin Accounts", func() {
 	Context("fetch next accounts", func() {
 		var (
-			plg *Plugin
+			plg models.Plugin
 			m   *client.MockClient
 
 			sampleAccounts []*client.Account

--- a/internal/connectors/plugins/public/moneycorp/accounts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/accounts_test.go
@@ -15,14 +15,15 @@ import (
 var _ = Describe("Moneycorp *Plugin Accounts", func() {
 	Context("fetch next accounts", func() {
 		var (
-			plg models.Plugin
-			m   *client.MockClient
+			ctrl *gomock.Controller
+			plg  models.Plugin
+			m    *client.MockClient
 
 			sampleAccounts []*client.Account
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg = &Plugin{client: m}
 
@@ -33,6 +34,10 @@ var _ = Describe("Moneycorp *Plugin Accounts", func() {
 				})
 			}
 
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("should return an error - get accounts error", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/moneycorp/balances_test.go
+++ b/internal/connectors/plugins/public/moneycorp/balances_test.go
@@ -15,7 +15,7 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Balances", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 	)
 
 	Context("fetch next balances", func() {

--- a/internal/connectors/plugins/public/moneycorp/balances_test.go
+++ b/internal/connectors/plugins/public/moneycorp/balances_test.go
@@ -20,7 +20,8 @@ var _ = Describe("Moneycorp *Plugin Balances", func() {
 
 	Context("fetch next balances", func() {
 		var (
-			m *client.MockClient
+			ctrl *gomock.Controller
+			m    *client.MockClient
 
 			accRef         string
 			sampleBalance  *client.Balance
@@ -28,7 +29,7 @@ var _ = Describe("Moneycorp *Plugin Balances", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg = &Plugin{client: m}
 
@@ -41,6 +42,11 @@ var _ = Describe("Moneycorp *Plugin Balances", func() {
 				},
 			}
 		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
 		It("fetches next balances", func(ctx SpecContext) {
 			req := models.FetchNextBalancesRequest{
 				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%s"}`, accRef)),

--- a/internal/connectors/plugins/public/moneycorp/external_accounts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/external_accounts_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 	)
 
 	Context("fetch next ExternalAccounts", func() {

--- a/internal/connectors/plugins/public/moneycorp/external_accounts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/external_accounts_test.go
@@ -21,7 +21,8 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 
 	Context("fetch next ExternalAccounts", func() {
 		var (
-			m *client.MockClient
+			ctrl *gomock.Controller
+			m    *client.MockClient
 
 			sampleExternalAccounts []*client.Recipient
 			accRef                 string
@@ -29,7 +30,7 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg = &Plugin{client: m}
 			accRef = "baseAcc"
@@ -45,7 +46,10 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 					},
 				})
 			}
+		})
 
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("should return an error - missing from payload", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/moneycorp/payments_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payments_test.go
@@ -23,7 +23,8 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 
 	Context("fetch next Payments", func() {
 		var (
-			m *client.MockClient
+			ctrl *gomock.Controller
+			m    *client.MockClient
 
 			samplePayments []*client.Transaction
 			sampleTransfer *client.TransferResponse
@@ -32,7 +33,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg = &Plugin{client: m}
 
@@ -129,7 +130,10 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 					},
 				},
 			}
+		})
 
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("fails when payments contain unsupported currencies", func(ctx SpecContext) {
@@ -224,7 +228,8 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 
 	Context("fetch next Payments", func() {
 		var (
-			m *client.MockClient
+			ctrl *gomock.Controller
+			m    *client.MockClient
 
 			samplePayments []*client.Transaction
 			accRef         int32
@@ -232,7 +237,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg = &Plugin{client: m}
 			accRef = 3796
@@ -257,6 +262,10 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 					},
 				})
 			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("should return an error - missing from payload", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/moneycorp/payments_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payments_test.go
@@ -18,7 +18,7 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 	)
 
 	Context("fetch next Payments", func() {
@@ -219,7 +219,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 
 var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 	)
 
 	Context("fetch next Payments", func() {

--- a/internal/connectors/plugins/public/moneycorp/payouts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payouts_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/moneycorp/payouts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payouts_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/moneycorp/transfers_test.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/moneycorp/transfers_test.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Moneycorp *Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/stripe/accounts_test.go
+++ b/internal/connectors/plugins/public/stripe/accounts_test.go
@@ -14,14 +14,19 @@ import (
 
 var _ = Describe("Stripe Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetch next accounts", func() {

--- a/internal/connectors/plugins/public/stripe/accounts_test.go
+++ b/internal/connectors/plugins/public/stripe/accounts_test.go
@@ -14,25 +14,23 @@ import (
 
 var _ = Describe("Stripe Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetch next accounts", func() {
 		var (
-			m *client.MockClient
-
 			pageSize       int
 			sampleAccounts []*stripesdk.Account
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			pageSize = 20
 
 			sampleAccounts = make([]*stripesdk.Account, 0)

--- a/internal/connectors/plugins/public/stripe/balances_test.go
+++ b/internal/connectors/plugins/public/stripe/balances_test.go
@@ -16,26 +16,23 @@ import (
 
 var _ = Describe("Stripe Plugin Balances", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetch next balances", func() {
 		var (
-			m *client.MockClient
-
 			accRef        string
 			sampleBalance *stripesdk.Balance
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-
 			accRef = "abc"
 			sampleBalance = &stripesdk.Balance{
 				Available: []*stripesdk.Amount{

--- a/internal/connectors/plugins/public/stripe/balances_test.go
+++ b/internal/connectors/plugins/public/stripe/balances_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Stripe Plugin Balances", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetch next balances", func() {

--- a/internal/connectors/plugins/public/stripe/create_payouts_test.go
+++ b/internal/connectors/plugins/public/stripe/create_payouts_test.go
@@ -18,14 +18,19 @@ import (
 
 var _ = Describe("Stripe Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/stripe/create_payouts_test.go
+++ b/internal/connectors/plugins/public/stripe/create_payouts_test.go
@@ -18,24 +18,23 @@ import (
 
 var _ = Describe("Stripe Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/stripe/create_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/create_transfers_test.go
@@ -18,14 +18,19 @@ import (
 
 var _ = Describe("Stripe Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/stripe/create_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/create_transfers_test.go
@@ -18,24 +18,23 @@ import (
 
 var _ = Describe("Stripe Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/stripe/external_accounts_test.go
+++ b/internal/connectors/plugins/public/stripe/external_accounts_test.go
@@ -14,17 +14,18 @@ import (
 
 var _ = Describe("Stripe Plugin ExternalAccounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetch next ExternalAccounts", func() {
 		var (
-			m *client.MockClient
-
 			pageSize               int
 			sampleExternalAccounts []*stripesdk.BankAccount
 			accRef                 string
@@ -32,10 +33,6 @@ var _ = Describe("Stripe Plugin ExternalAccounts", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-
 			pageSize = 10
 			accRef = "baseAcc"
 			created = 1483565364

--- a/internal/connectors/plugins/public/stripe/external_accounts_test.go
+++ b/internal/connectors/plugins/public/stripe/external_accounts_test.go
@@ -14,14 +14,19 @@ import (
 
 var _ = Describe("Stripe Plugin ExternalAccounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetch next ExternalAccounts", func() {

--- a/internal/connectors/plugins/public/stripe/payments_test.go
+++ b/internal/connectors/plugins/public/stripe/payments_test.go
@@ -25,7 +25,8 @@ var _ = Describe("Stripe Plugin Payments", func() {
 
 	Context("fetch next Payments", func() {
 		var (
-			m *client.MockClient
+			ctrl *gomock.Controller
+			m    *client.MockClient
 
 			samplePayments []*stripesdk.BalanceTransaction
 			accRef         string
@@ -33,7 +34,7 @@ var _ = Describe("Stripe Plugin Payments", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg.client = m
 
@@ -186,7 +187,10 @@ var _ = Describe("Stripe Plugin Payments", func() {
 					},
 				},
 			}
+		})
 
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("fails when payments contain unsupported currencies", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
@@ -18,14 +18,21 @@ import (
 
 var _ = Describe("Stripe Plugin Transfers Reversal", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
+
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
 	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Context("create transfer", func() {
 		var (
 			samplePSPPaymentInitiationReversal models.PSPPaymentInitiationReversal

--- a/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
+++ b/internal/connectors/plugins/public/stripe/reverse_transfers_test.go
@@ -18,21 +18,20 @@ import (
 
 var _ = Describe("Stripe Plugin Transfers Reversal", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 	Context("create transfer", func() {
 		var (
-			m                                  *client.MockClient
 			samplePSPPaymentInitiationReversal models.PSPPaymentInitiationReversal
 			now                                time.Time
 		)
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 			samplePSPPaymentInitiationReversal = models.PSPPaymentInitiationReversal{
 				Reference:   "test_reversal_1",

--- a/internal/connectors/plugins/public/wise/accounts_test.go
+++ b/internal/connectors/plugins/public/wise/accounts_test.go
@@ -15,24 +15,23 @@ import (
 
 var _ = Describe("Wise Plugin Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m              *client.MockClient
 			sampleBalances []client.Balance
 			now            time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleBalances = make([]client.Balance, 0)

--- a/internal/connectors/plugins/public/wise/accounts_test.go
+++ b/internal/connectors/plugins/public/wise/accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Wise Plugin Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/wise/balances_test.go
+++ b/internal/connectors/plugins/public/wise/balances_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Wise Plugin Balances", func() {
 	var (
-		plg models.Plugin
-		m   *client.MockClient
+		ctrl *gomock.Controller
+		plg  models.Plugin
+		m    *client.MockClient
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetch next balances", func() {

--- a/internal/connectors/plugins/public/wise/balances_test.go
+++ b/internal/connectors/plugins/public/wise/balances_test.go
@@ -15,16 +15,14 @@ import (
 
 var _ = Describe("Wise Plugin Balances", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 		m   *client.MockClient
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
-
 		ctrl := gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg.SetClient(m)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetch next balances", func() {

--- a/internal/connectors/plugins/public/wise/external_accounts_test.go
+++ b/internal/connectors/plugins/public/wise/external_accounts_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Wise Plugin External Accounts", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next external accounts", func() {

--- a/internal/connectors/plugins/public/wise/external_accounts_test.go
+++ b/internal/connectors/plugins/public/wise/external_accounts_test.go
@@ -15,24 +15,22 @@ import (
 
 var _ = Describe("Wise Plugin External Accounts", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next external accounts", func() {
 		var (
-			m                       *client.MockClient
 			sampleRecipientAccounts []*client.RecipientAccount
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
-
 			sampleRecipientAccounts = make([]*client.RecipientAccount, 0)
 			for i := 0; i < 50; i++ {
 				sampleRecipientAccounts = append(sampleRecipientAccounts, &client.RecipientAccount{

--- a/internal/connectors/plugins/public/wise/payments_test.go
+++ b/internal/connectors/plugins/public/wise/payments_test.go
@@ -16,14 +16,19 @@ import (
 
 var _ = Describe("Wise Plugin Payments", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetching next accounts", func() {

--- a/internal/connectors/plugins/public/wise/payments_test.go
+++ b/internal/connectors/plugins/public/wise/payments_test.go
@@ -16,24 +16,23 @@ import (
 
 var _ = Describe("Wise Plugin Payments", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetching next accounts", func() {
 		var (
-			m               *client.MockClient
 			sampleTransfers []client.Transfer
 			now             time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			sampleTransfers = make([]client.Transfer, 0)

--- a/internal/connectors/plugins/public/wise/payouts_test.go
+++ b/internal/connectors/plugins/public/wise/payouts_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Wise Plugin Payouts Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create payout", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/wise/payouts_test.go
+++ b/internal/connectors/plugins/public/wise/payouts_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Wise Plugin Payouts Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create payout", func() {

--- a/internal/connectors/plugins/public/wise/plugin.go
+++ b/internal/connectors/plugins/public/wise/plugin.go
@@ -172,6 +172,38 @@ func (p *Plugin) CreateWebhooks(ctx context.Context, req models.CreateWebhooksRe
 	return p.createWebhooks(ctx, req)
 }
 
+func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	if p.client == nil {
+		return models.VerifyWebhookResponse{}, plugins.ErrNotYetInstalled
+	}
+
+	testNotif, ok := req.Webhook.Headers[HeadersTestNotification]
+	if ok && len(testNotif) > 0 {
+		if testNotif[0] == "true" {
+			return models.VerifyWebhookResponse{}, nil
+		}
+	}
+
+	v, ok := req.Webhook.Headers[HeadersDeliveryID]
+	if !ok || len(v) == 0 {
+		return models.VerifyWebhookResponse{}, ErrWebhookHeaderXDeliveryIDMissing
+	}
+
+	signatures, ok := req.Webhook.Headers[HeadersSignature]
+	if !ok || len(signatures) == 0 {
+		return models.VerifyWebhookResponse{}, ErrWebhookHeaderXSignatureMissing
+	}
+
+	err := p.verifySignature(req.Webhook.Body, signatures[0])
+	if err != nil {
+		return models.VerifyWebhookResponse{}, err
+	}
+
+	return models.VerifyWebhookResponse{
+		WebhookIdempotencyKey: v[0],
+	}, nil
+}
+
 func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	if p.client == nil {
 		return models.TranslateWebhookResponse{}, plugins.ErrNotYetInstalled
@@ -184,21 +216,6 @@ func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebho
 		}
 	}
 
-	v, ok := req.Webhook.Headers[HeadersDeliveryID]
-	if !ok || len(v) == 0 {
-		return models.TranslateWebhookResponse{}, ErrWebhookHeaderXDeliveryIDMissing
-	}
-
-	signatures, ok := req.Webhook.Headers[HeadersSignature]
-	if !ok || len(signatures) == 0 {
-		return models.TranslateWebhookResponse{}, ErrWebhookHeaderXSignatureMissing
-	}
-
-	err := p.verifySignature(req.Webhook.Body, signatures[0])
-	if err != nil {
-		return models.TranslateWebhookResponse{}, err
-	}
-
 	config, ok := p.supportedWebhooks[req.Name]
 	if !ok {
 		return models.TranslateWebhookResponse{}, ErrWebhookNameUnknown
@@ -208,8 +225,6 @@ func (p *Plugin) TranslateWebhook(ctx context.Context, req models.TranslateWebho
 	if err != nil {
 		return models.TranslateWebhookResponse{}, err
 	}
-
-	res.IdempotencyKey = v[0]
 
 	return models.TranslateWebhookResponse{
 		Responses: []models.WebhookResponse{res},

--- a/internal/connectors/plugins/public/wise/plugin.go
+++ b/internal/connectors/plugins/public/wise/plugin.go
@@ -200,7 +200,7 @@ func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 	}
 
 	return models.VerifyWebhookResponse{
-		WebhookIdempotencyKey: v[0],
+		WebhookIdempotencyKey: &v[0],
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/wise/plugin.go
+++ b/internal/connectors/plugins/public/wise/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/formancehq/go-libs/v3/logging"
 	"github.com/formancehq/payments/internal/connectors/plugins"
@@ -186,17 +187,17 @@ func (p *Plugin) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 
 	v, ok := req.Webhook.Headers[HeadersDeliveryID]
 	if !ok || len(v) == 0 {
-		return models.VerifyWebhookResponse{}, ErrWebhookHeaderXDeliveryIDMissing
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", ErrWebhookHeaderXDeliveryIDMissing, models.ErrWebhookVerification)
 	}
 
 	signatures, ok := req.Webhook.Headers[HeadersSignature]
 	if !ok || len(signatures) == 0 {
-		return models.VerifyWebhookResponse{}, ErrWebhookHeaderXSignatureMissing
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", ErrWebhookHeaderXSignatureMissing, models.ErrWebhookVerification)
 	}
 
 	err := p.verifySignature(req.Webhook.Body, signatures[0])
 	if err != nil {
-		return models.VerifyWebhookResponse{}, err
+		return models.VerifyWebhookResponse{}, fmt.Errorf("%w: %w", err, models.ErrWebhookVerification)
 	}
 
 	return models.VerifyWebhookResponse{

--- a/internal/connectors/plugins/public/wise/plugin_test.go
+++ b/internal/connectors/plugins/public/wise/plugin_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Wise Plugin", func() {
 		var (
 			body      []byte
 			signature []byte
+			ctrl      *gomock.Controller
 			m         *client.MockClient
 		)
 
@@ -118,7 +119,7 @@ var _ = Describe("Wise Plugin", func() {
 			plg, err = New("wise", logger, configJson)
 			Expect(err).To(BeNil())
 
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg.SetClient(m)
 
@@ -129,6 +130,10 @@ var _ = Describe("Wise Plugin", func() {
 
 			signature, err = rsa.SignPKCS1v15(rand.Reader, privatekey, crypto.SHA256, digest)
 			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("it fails when X-Delivery-ID header missing", func(ctx SpecContext) {
@@ -171,6 +176,7 @@ var _ = Describe("Wise Plugin", func() {
 		var (
 			body      []byte
 			signature []byte
+			ctrl      *gomock.Controller
 			m         *client.MockClient
 		)
 
@@ -184,7 +190,7 @@ var _ = Describe("Wise Plugin", func() {
 			plg, err = New("wise", logger, configJson)
 			Expect(err).To(BeNil())
 
-			ctrl := gomock.NewController(GinkgoT())
+			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
 			plg.SetClient(m)
 
@@ -195,6 +201,10 @@ var _ = Describe("Wise Plugin", func() {
 
 			signature, err = rsa.SignPKCS1v15(rand.Reader, privatekey, crypto.SHA256, digest)
 			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("it fails when unknown webhook name in request", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/wise/plugin_test.go
+++ b/internal/connectors/plugins/public/wise/plugin_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Wise Plugin", func() {
 
 			res, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(res.WebhookIdempotencyKey).To(Equal(req.Webhook.Headers[HeadersDeliveryID][0]))
+			Expect(res.WebhookIdempotencyKey).To(Equal(&req.Webhook.Headers[HeadersDeliveryID][0]))
 		})
 	})
 

--- a/internal/connectors/plugins/public/wise/profiles_test.go
+++ b/internal/connectors/plugins/public/wise/profiles_test.go
@@ -15,14 +15,19 @@ import (
 
 var _ = Describe("Wise Plugin Profiles", func() {
 	var (
-		plg models.Plugin
-		m   *client.MockClient
+		ctrl *gomock.Controller
+		plg  models.Plugin
+		m    *client.MockClient
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("fetch next profiles", func() {

--- a/internal/connectors/plugins/public/wise/profiles_test.go
+++ b/internal/connectors/plugins/public/wise/profiles_test.go
@@ -15,16 +15,14 @@ import (
 
 var _ = Describe("Wise Plugin Profiles", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 		m   *client.MockClient
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
-
 		ctrl := gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg.SetClient(m)
+		plg = &Plugin{client: m}
 	})
 
 	Context("fetch next profiles", func() {

--- a/internal/connectors/plugins/public/wise/transfers_test.go
+++ b/internal/connectors/plugins/public/wise/transfers_test.go
@@ -17,24 +17,23 @@ import (
 
 var _ = Describe("Wise Plugin Transfers Creation", func() {
 	var (
-		plg *Plugin
+		m   *client.MockClient
+		plg models.Plugin
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
+		ctrl := gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{client: m}
 	})
 
 	Context("create transfer", func() {
 		var (
-			m                          *client.MockClient
 			samplePSPPaymentInitiation models.PSPPaymentInitiation
 			now                        time.Time
 		)
 
 		BeforeEach(func() {
-			ctrl := gomock.NewController(GinkgoT())
-			m = client.NewMockClient(ctrl)
-			plg.client = m
 			now = time.Now().UTC()
 
 			samplePSPPaymentInitiation = models.PSPPaymentInitiation{

--- a/internal/connectors/plugins/public/wise/transfers_test.go
+++ b/internal/connectors/plugins/public/wise/transfers_test.go
@@ -17,14 +17,19 @@ import (
 
 var _ = Describe("Wise Plugin Transfers Creation", func() {
 	var (
-		m   *client.MockClient
-		plg models.Plugin
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  models.Plugin
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create transfer", func() {

--- a/internal/connectors/plugins/public/wise/uninstall_test.go
+++ b/internal/connectors/plugins/public/wise/uninstall_test.go
@@ -12,14 +12,19 @@ import (
 
 var _ = Describe("Wise Plugin Uninstall", func() {
 	var (
-		plg models.Plugin
-		m   *client.MockClient
+		ctrl *gomock.Controller
+		plg  models.Plugin
+		m    *client.MockClient
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{client: m}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("uninstall", func() {

--- a/internal/connectors/plugins/public/wise/uninstall_test.go
+++ b/internal/connectors/plugins/public/wise/uninstall_test.go
@@ -12,16 +12,14 @@ import (
 
 var _ = Describe("Wise Plugin Uninstall", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 		m   *client.MockClient
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
-
 		ctrl := gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg.SetClient(m)
+		plg = &Plugin{client: m}
 	})
 
 	Context("uninstall", func() {

--- a/internal/connectors/plugins/public/wise/webhooks_test.go
+++ b/internal/connectors/plugins/public/wise/webhooks_test.go
@@ -15,16 +15,23 @@ import (
 
 var _ = Describe("Wise Plugin Webhooks", func() {
 	var (
-		plg *Plugin
+		plg models.Plugin
 		m   *client.MockClient
 	)
 
 	BeforeEach(func() {
-		plg = &Plugin{}
-
 		ctrl := gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg.SetClient(m)
+		p := &Plugin{client: m}
+		p.supportedWebhooks = map[string]supportedWebhook{
+			"test": {
+				triggerOn: "transfers#state-change",
+				urlPath:   "/transferstatechanged",
+				fn:        p.translateTransferStateChangedWebhook,
+				version:   "1.0.0",
+			},
+		}
+		plg = p
 	})
 
 	Context("create webhooks", func() {
@@ -38,17 +45,9 @@ var _ = Describe("Wise Plugin Webhooks", func() {
 
 		BeforeEach(func() {
 			expectedProfileID = 44
-			plg.supportedWebhooks = map[string]supportedWebhook{
-				"test": {
-					triggerOn: "transfers#state-change",
-					urlPath:   "/transferstatechanged",
-					fn:        plg.translateTransferStateChangedWebhook,
-					version:   "1.0.0",
-				},
-			}
 			expectedWebhookResponseID = "sampleResID"
 			webhookBaseUrl = "http://example.com"
-			expectedWebhookPath, err = url.JoinPath(webhookBaseUrl, plg.supportedWebhooks["test"].urlPath)
+			expectedWebhookPath, err = url.JoinPath(webhookBaseUrl, "/transferstatechanged")
 			Expect(err).To(BeNil())
 		})
 
@@ -70,9 +69,9 @@ var _ = Describe("Wise Plugin Webhooks", func() {
 				gomock.Any(),
 				expectedProfileID,
 				"test",
-				plg.supportedWebhooks["test"].triggerOn,
+				"transfers#state-change",
 				expectedWebhookPath,
-				plg.supportedWebhooks["test"].version,
+				"1.0.0",
 			).Return(
 				&client.WebhookSubscriptionResponse{ID: expectedWebhookResponseID},
 				nil,
@@ -80,7 +79,7 @@ var _ = Describe("Wise Plugin Webhooks", func() {
 
 			res, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(res.Others).To(HaveLen(len(plg.supportedWebhooks)))
+			Expect(res.Others).To(HaveLen(1))
 			Expect(res.Others[0].ID).To(Equal(expectedWebhookResponseID))
 		})
 	})

--- a/internal/connectors/plugins/public/wise/webhooks_test.go
+++ b/internal/connectors/plugins/public/wise/webhooks_test.go
@@ -15,12 +15,13 @@ import (
 
 var _ = Describe("Wise Plugin Webhooks", func() {
 	var (
-		plg models.Plugin
-		m   *client.MockClient
+		ctrl *gomock.Controller
+		plg  models.Plugin
+		m    *client.MockClient
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		p := &Plugin{client: m}
 		p.supportedWebhooks = map[string]supportedWebhook{
@@ -32,6 +33,10 @@ var _ = Describe("Wise Plugin Webhooks", func() {
 			},
 		}
 		plg = p
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("create webhooks", func() {

--- a/internal/connectors/plugins/registry/wrapper.go
+++ b/internal/connectors/plugins/registry/wrapper.go
@@ -295,6 +295,24 @@ func (i *impl) CreateWebhooks(ctx context.Context, req models.CreateWebhooksRequ
 	return resp, nil
 }
 
+func (i *impl) VerifyWebhook(ctx context.Context, req models.VerifyWebhookRequest) (models.VerifyWebhookResponse, error) {
+	ctx, span := otel.StartSpan(ctx, "plugin.VerifyWebhook", attribute.String("psp", i.plugin.Name()), attribute.String("verifyWebhookRequest.name", req.Config.Name))
+	defer span.End()
+
+	i.logger.WithField("name", i.plugin.Name()).Info("verifying webhook...")
+
+	resp, err := i.plugin.VerifyWebhook(ctx, req)
+	if err != nil {
+		i.logger.WithField("name", i.plugin.Name()).Error("verifying webhook failed: %v", err)
+		otel.RecordError(span, err)
+		return models.VerifyWebhookResponse{}, translateError(err)
+	}
+
+	i.logger.WithField("name", i.plugin.Name()).Info("verified webhook succeeded!")
+
+	return resp, nil
+}
+
 func (i *impl) TranslateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {
 	ctx, span := otel.StartSpan(ctx, "plugin.TranslateWebhook", attribute.String("psp", i.plugin.Name()), attribute.String("translateWebhookRequest.name", req.Name))
 	defer span.End()

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrMissingAccountInRequest     = errors.New("missing account number in request")
 	ErrInvalidRequest              = errors.New("invalid request")
 	ErrValidation                  = errors.New("validation error")
+	ErrWebhookVerification         = errors.New("webhook verification error")
 
 	ErrMissingConnectorMetadata = errors.New("missing required metadata in request")
 	ErrMissingConnectorField    = errors.New("missing required field in request")

--- a/internal/models/plugin.go
+++ b/internal/models/plugin.go
@@ -36,6 +36,7 @@ type PSPPlugin interface {
 	PollPayoutStatus(context.Context, PollPayoutStatusRequest) (PollPayoutStatusResponse, error)
 
 	CreateWebhooks(context.Context, CreateWebhooksRequest) (CreateWebhooksResponse, error)
+	VerifyWebhook(context.Context, VerifyWebhookRequest) (VerifyWebhookResponse, error)
 	TranslateWebhook(context.Context, TranslateWebhookRequest) (TranslateWebhookResponse, error)
 }
 
@@ -145,7 +146,6 @@ type TranslateWebhookRequest struct {
 }
 
 type WebhookResponse struct {
-	IdempotencyKey  string
 	Account         *PSPAccount
 	ExternalAccount *PSPAccount
 	Payment         *PSPPayment
@@ -153,6 +153,15 @@ type WebhookResponse struct {
 
 type TranslateWebhookResponse struct {
 	Responses []WebhookResponse
+}
+
+type VerifyWebhookRequest struct {
+	Webhook PSPWebhook
+	Config  *WebhookConfig
+}
+
+type VerifyWebhookResponse struct {
+	WebhookIdempotencyKey string
 }
 
 type CreateTransferRequest struct {

--- a/internal/models/plugin.go
+++ b/internal/models/plugin.go
@@ -161,7 +161,7 @@ type VerifyWebhookRequest struct {
 }
 
 type VerifyWebhookResponse struct {
-	WebhookIdempotencyKey string
+	WebhookIdempotencyKey *string
 }
 
 type CreateTransferRequest struct {

--- a/internal/models/plugin_generated.go
+++ b/internal/models/plugin_generated.go
@@ -20,6 +20,7 @@ import (
 type MockPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginMockRecorder
+	isgomock struct{}
 }
 
 // MockPluginMockRecorder is the mock recorder for MockPlugin.
@@ -312,6 +313,7 @@ func (mr *MockPluginMockRecorder) VerifyWebhook(arg0, arg1 any) *gomock.Call {
 type MockPSPPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPSPPluginMockRecorder
+	isgomock struct{}
 }
 
 // MockPSPPluginMockRecorder is the mock recorder for MockPSPPlugin.
@@ -560,6 +562,7 @@ func (mr *MockPSPPluginMockRecorder) VerifyWebhook(arg0, arg1 any) *gomock.Call 
 type MockPSPBankingBridge struct {
 	ctrl     *gomock.Controller
 	recorder *MockPSPBankingBridgeMockRecorder
+	isgomock struct{}
 }
 
 // MockPSPBankingBridgeMockRecorder is the mock recorder for MockPSPBankingBridge.

--- a/internal/models/plugin_generated.go
+++ b/internal/models/plugin_generated.go
@@ -20,7 +20,6 @@ import (
 type MockPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginMockRecorder
-	isgomock struct{}
 }
 
 // MockPluginMockRecorder is the mock recorder for MockPlugin.
@@ -294,11 +293,25 @@ func (mr *MockPluginMockRecorder) Uninstall(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Uninstall", reflect.TypeOf((*MockPlugin)(nil).Uninstall), arg0, arg1)
 }
 
+// VerifyWebhook mocks base method.
+func (m *MockPlugin) VerifyWebhook(arg0 context.Context, arg1 VerifyWebhookRequest) (VerifyWebhookResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyWebhook", arg0, arg1)
+	ret0, _ := ret[0].(VerifyWebhookResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyWebhook indicates an expected call of VerifyWebhook.
+func (mr *MockPluginMockRecorder) VerifyWebhook(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyWebhook", reflect.TypeOf((*MockPlugin)(nil).VerifyWebhook), arg0, arg1)
+}
+
 // MockPSPPlugin is a mock of PSPPlugin interface.
 type MockPSPPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPSPPluginMockRecorder
-	isgomock struct{}
 }
 
 // MockPSPPluginMockRecorder is the mock recorder for MockPSPPlugin.
@@ -528,11 +541,25 @@ func (mr *MockPSPPluginMockRecorder) TranslateWebhook(arg0, arg1 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TranslateWebhook", reflect.TypeOf((*MockPSPPlugin)(nil).TranslateWebhook), arg0, arg1)
 }
 
+// VerifyWebhook mocks base method.
+func (m *MockPSPPlugin) VerifyWebhook(arg0 context.Context, arg1 VerifyWebhookRequest) (VerifyWebhookResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyWebhook", arg0, arg1)
+	ret0, _ := ret[0].(VerifyWebhookResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyWebhook indicates an expected call of VerifyWebhook.
+func (mr *MockPSPPluginMockRecorder) VerifyWebhook(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyWebhook", reflect.TypeOf((*MockPSPPlugin)(nil).VerifyWebhook), arg0, arg1)
+}
+
 // MockPSPBankingBridge is a mock of PSPBankingBridge interface.
 type MockPSPBankingBridge struct {
 	ctrl     *gomock.Controller
 	recorder *MockPSPBankingBridgeMockRecorder
-	isgomock struct{}
 }
 
 // MockPSPBankingBridgeMockRecorder is the mock recorder for MockPSPBankingBridge.

--- a/internal/models/webhooks.go
+++ b/internal/models/webhooks.go
@@ -31,10 +31,11 @@ type PSPWebhook struct {
 }
 
 type Webhook struct {
-	ID          string              `json:"id"`
-	ConnectorID ConnectorID         `json:"connectorID"`
-	BasicAuth   *BasicAuth          `json:"basicAuth"`
-	QueryValues map[string][]string `json:"queryValues"`
-	Headers     map[string][]string `json:"headers"`
-	Body        []byte              `json:"payload"`
+	ID             string              `json:"id"`
+	ConnectorID    ConnectorID         `json:"connectorID"`
+	IdempotencyKey string              `json:"idempotencyKey"`
+	BasicAuth      *BasicAuth          `json:"basicAuth"`
+	QueryValues    map[string][]string `json:"queryValues"`
+	Headers        map[string][]string `json:"headers"`
+	Body           []byte              `json:"payload"`
 }

--- a/internal/models/webhooks.go
+++ b/internal/models/webhooks.go
@@ -33,7 +33,7 @@ type PSPWebhook struct {
 type Webhook struct {
 	ID             string              `json:"id"`
 	ConnectorID    ConnectorID         `json:"connectorID"`
-	IdempotencyKey string              `json:"idempotencyKey"`
+	IdempotencyKey *string             `json:"idempotencyKey"`
 	BasicAuth      *BasicAuth          `json:"basicAuth"`
 	QueryValues    map[string][]string `json:"queryValues"`
 	Headers        map[string][]string `json:"headers"`

--- a/internal/storage/migrations/16-webhooks-idempotency-key.sql
+++ b/internal/storage/migrations/16-webhooks-idempotency-key.sql
@@ -1,0 +1,4 @@
+alter table webhooks
+    add column if not exists idempotency_key text;
+
+create unique index webhooks_unique_idempotency_key on webhooks (connector_id, idempotency_key);

--- a/internal/storage/webhooks.go
+++ b/internal/storage/webhooks.go
@@ -15,9 +15,10 @@ type webhook struct {
 	ConnectorID models.ConnectorID `bun:"connector_id,type:character varying,notnull"`
 
 	// Optional fields
-	Headers     map[string][]string `bun:"headers,type:json"`
-	QueryValues map[string][]string `bun:"query_values,type:json"`
-	Body        []byte              `bun:"body,type:bytea,nullzero"`
+	IdempotencyKey string              `bun:"idempotency_key,type:text"`
+	Headers        map[string][]string `bun:"headers,type:json"`
+	QueryValues    map[string][]string `bun:"query_values,type:json"`
+	Body           []byte              `bun:"body,type:bytea,nullzero"`
 }
 
 func (s *store) WebhooksInsert(ctx context.Context, webhook models.Webhook) error {
@@ -61,20 +62,22 @@ func (s *store) WebhooksDeleteFromConnectorID(ctx context.Context, connectorID m
 
 func fromWebhookModels(from models.Webhook) webhook {
 	return webhook{
-		ID:          from.ID,
-		ConnectorID: from.ConnectorID,
-		Headers:     from.Headers,
-		QueryValues: from.QueryValues,
-		Body:        from.Body,
+		ID:             from.ID,
+		ConnectorID:    from.ConnectorID,
+		IdempotencyKey: from.IdempotencyKey,
+		Headers:        from.Headers,
+		QueryValues:    from.QueryValues,
+		Body:           from.Body,
 	}
 }
 
 func toWebhookModels(from webhook) models.Webhook {
 	return models.Webhook{
-		ID:          from.ID,
-		ConnectorID: from.ConnectorID,
-		Headers:     from.Headers,
-		QueryValues: from.QueryValues,
-		Body:        from.Body,
+		ID:             from.ID,
+		ConnectorID:    from.ConnectorID,
+		IdempotencyKey: from.IdempotencyKey,
+		Headers:        from.Headers,
+		QueryValues:    from.QueryValues,
+		Body:           from.Body,
 	}
 }

--- a/internal/storage/webhooks.go
+++ b/internal/storage/webhooks.go
@@ -15,7 +15,7 @@ type webhook struct {
 	ConnectorID models.ConnectorID `bun:"connector_id,type:character varying,notnull"`
 
 	// Optional fields
-	IdempotencyKey string              `bun:"idempotency_key,type:text"`
+	IdempotencyKey *string             `bun:"idempotency_key,type:text"`
 	Headers        map[string][]string `bun:"headers,type:json"`
 	QueryValues    map[string][]string `bun:"query_values,type:json"`
 	Body           []byte              `bun:"body,type:bytea,nullzero"`

--- a/internal/storage/webhooks_test.go
+++ b/internal/storage/webhooks_test.go
@@ -24,8 +24,9 @@ var (
 			Body: []byte(`{}`),
 		},
 		{
-			ID:          "test2",
-			ConnectorID: defaultConnector.ID,
+			ID:             "test2",
+			ConnectorID:    defaultConnector.ID,
+			IdempotencyKey: "test",
 			QueryValues: map[string][]string{
 				"foo3": {"bar3"},
 			},

--- a/internal/storage/webhooks_test.go
+++ b/internal/storage/webhooks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ var (
 		{
 			ID:             "test2",
 			ConnectorID:    defaultConnector.ID,
-			IdempotencyKey: "test",
+			IdempotencyKey: pointer.For("test"),
 			QueryValues: map[string][]string{
 				"foo3": {"bar3"},
 			},
@@ -77,6 +78,42 @@ func TestWebhooksInsert(t *testing.T) {
 		}
 
 		require.Error(t, store.WebhooksInsert(ctx, webhook))
+	})
+
+	t.Run("same null idempotency key", func(t *testing.T) {
+		w := models.Webhook{
+			ID:          "new",
+			ConnectorID: defaultConnector.ID,
+			QueryValues: map[string][]string{
+				"foo3": {"bar3"},
+			},
+			Headers: map[string][]string{
+				"foo4": {"bar4"},
+			},
+			Body: []byte(`{}`),
+		}
+
+		err := store.WebhooksInsert(ctx, w)
+		require.NoError(t, err)
+	})
+
+	t.Run("same idempotency key", func(t *testing.T) {
+		w := models.Webhook{
+			ID:             "new2",
+			ConnectorID:    defaultConnector.ID,
+			IdempotencyKey: pointer.For("test"),
+			QueryValues: map[string][]string{
+				"foo3": {"bar3"},
+			},
+			Headers: map[string][]string{
+				"foo4": {"bar4"},
+			},
+			Body: []byte(`{}`),
+		}
+
+		err := store.WebhooksInsert(ctx, w)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDuplicateKeyValue)
 	})
 }
 


### PR DESCRIPTION
# Description

This PR introduces two fixes:

## Webhook Idempotency Key

### Context

As of today, we have a kind of Idempotency Key implemented for webhooks. It's filled in the response of the TranslateWebhook call to the plugin and is pass inside the workflowID of temporal with a policy of rejecting duplicates in order to not store the responses in case we already processed this event in the past.

This is partially working because we do not retain all workflows in temporal forever. So if a webhook is replayed after the workflow is deleted from temporal, it will process it again.

### Solution

The solution I came by is:
- We add a new column to the webhook storage table called idempotency key. This way, we depend on our storage instead of temporal.
- The addition of a new plugin function called VerifyWebhook which as its name says, verify that the webhook is valid though signatures etc... and also send as a response an IdempotencyKey, which can be either what the PSP gave us (for example wise and column give us an id for the event), the sha256 of the payload or nothing.

## Plugins tests

## Context

In most of the plugin tests, we are using the Plugin struct to test the main and sub functions. Since this Plugin structure have in composition the base plugin, we can't tests if we make a type in the override of the function, so we need to ensure that all plugin interface function that we implemented are the right ones.

## Solution

The solution I came by is:
- Use the models.Plugin interface instead of directly the structure inside all plugin tests. That way, we ensure that all function are implemented correctly.



Fixes PMNT-105
Fixes PMNT-106