### PR TITLE
fix(adyen): fix missing hmac key when pod is restarted

### DIFF
--- a/internal/connectors/plugins/public/adyen/client/client.go
+++ b/internal/connectors/plugins/public/adyen/client/client.go
@@ -18,9 +18,9 @@ import (
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
 type Client interface {
 	GetMerchantAccounts(ctx context.Context, pageNumber, pageSize int32) ([]management.Merchant, error)
-	CreateWebhook(ctx context.Context, url string, connectorID string) error
+	CreateWebhook(ctx context.Context, url string, connectorID string) (CreateWebhookResponse, error)
 	VerifyWebhookBasicAuth(basicAuth *models.BasicAuth) bool
-	VerifyWebhookHMAC(item webhook.NotificationItem) bool
+	VerifyWebhookHMAC(item webhook.NotificationItem, hmacKey string) bool
 	DeleteWebhook(ctx context.Context, connectorID string) error
 	TranslateWebhook(req string) (*webhook.Webhook, error)
 }
@@ -34,7 +34,6 @@ type client struct {
 	companyID string
 
 	standardWebhook *management.Webhook
-	hmacKey         string
 }
 
 func New(

--- a/internal/connectors/plugins/public/adyen/client/client_generated.go
+++ b/internal/connectors/plugins/public/adyen/client/client_generated.go
@@ -44,11 +44,12 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateWebhook mocks base method.
-func (m *MockClient) CreateWebhook(ctx context.Context, url, connectorID string) error {
+func (m *MockClient) CreateWebhook(ctx context.Context, url, connectorID string) (CreateWebhookResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateWebhook", ctx, url, connectorID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(CreateWebhookResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateWebhook indicates an expected call of CreateWebhook.
@@ -116,15 +117,15 @@ func (mr *MockClientMockRecorder) VerifyWebhookBasicAuth(basicAuth any) *gomock.
 }
 
 // VerifyWebhookHMAC mocks base method.
-func (m *MockClient) VerifyWebhookHMAC(item webhook.NotificationItem) bool {
+func (m *MockClient) VerifyWebhookHMAC(item webhook.NotificationItem, hmacKey string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyWebhookHMAC", item)
+	ret := m.ctrl.Call(m, "VerifyWebhookHMAC", item, hmacKey)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // VerifyWebhookHMAC indicates an expected call of VerifyWebhookHMAC.
-func (mr *MockClientMockRecorder) VerifyWebhookHMAC(item any) *gomock.Call {
+func (mr *MockClientMockRecorder) VerifyWebhookHMAC(item, hmacKey any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyWebhookHMAC", reflect.TypeOf((*MockClient)(nil).VerifyWebhookHMAC), item)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyWebhookHMAC", reflect.TypeOf((*MockClient)(nil).VerifyWebhookHMAC), item, hmacKey)
 }

--- a/internal/connectors/plugins/public/adyen/webhooks_test.go
+++ b/internal/connectors/plugins/public/adyen/webhooks_test.go
@@ -65,11 +65,12 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 			}
 
 			expectedURL := "http://localhost:8080/test/standard"
-			m.EXPECT().CreateWebhook(gomock.Any(), expectedURL, req.ConnectorID).Return(nil)
+			m.EXPECT().CreateWebhook(gomock.Any(), expectedURL, req.ConnectorID).Return(client.CreateWebhookResponse{HMACKey: "test"}, nil)
 
 			configs, err := plg.CreateWebhooks(ctx, req)
 			Expect(err).To(BeNil())
 			Expect(configs.Configs).To(HaveLen(1))
+			Expect(configs.Configs[0].Metadata[webhookHMACMetadataKey]).To(Equal("test"))
 		})
 	})
 
@@ -105,6 +106,9 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 			req := models.VerifyWebhookRequest{
 				Config: &models.WebhookConfig{
 					Name: "standard",
+					Metadata: map[string]string{
+						webhookHMACMetadataKey: "test",
+					},
 				},
 				Webhook: models.PSPWebhook{
 					BasicAuth: &models.BasicAuth{
@@ -132,6 +136,9 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 			req := models.VerifyWebhookRequest{
 				Config: &models.WebhookConfig{
 					Name: "standard",
+					Metadata: map[string]string{
+						webhookHMACMetadataKey: "test",
+					},
 				},
 				Webhook: models.PSPWebhook{
 					QueryValues: map[string][]string{},
@@ -142,7 +149,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			m.EXPECT().VerifyWebhookBasicAuth(req.Webhook.BasicAuth).Return(true)
 			m.EXPECT().TranslateWebhook(string(req.Webhook.Body)).Return(&w, nil)
-			m.EXPECT().VerifyWebhookHMAC(gomock.Any()).Return(false)
+			m.EXPECT().VerifyWebhookHMAC(gomock.Any(), "test").Return(false)
 
 			resp, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).ToNot(BeNil())
@@ -157,6 +164,9 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 			req := models.VerifyWebhookRequest{
 				Config: &models.WebhookConfig{
 					Name: "standard",
+					Metadata: map[string]string{
+						webhookHMACMetadataKey: "test",
+					},
 				},
 				Webhook: models.PSPWebhook{
 					QueryValues: map[string][]string{},
@@ -167,7 +177,7 @@ var _ = Describe("Adyen Plugin Accounts", func() {
 
 			m.EXPECT().VerifyWebhookBasicAuth(req.Webhook.BasicAuth).Return(true)
 			m.EXPECT().TranslateWebhook(string(req.Webhook.Body)).Return(&w, nil)
-			m.EXPECT().VerifyWebhookHMAC(gomock.Any()).Return(true)
+			m.EXPECT().VerifyWebhookHMAC(gomock.Any(), "test").Return(true)
 
 			resp, err := plg.VerifyWebhook(ctx, req)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
# Description

## Context

When we first install Adyen, the CreateWebhooks workflow is called and calls the right function inside adyen plugin. Inside the client, the webhooks are created on the adyen psp and an hmac key is generated and store in memory. When rebooting the worker pod, the hmac key is then empty and cannot be retrieved anymore, hence all the webhooks coming after the reboot are failing the hmac verification

## Solution

I'm adding the hmac key inside the metadata of the webhooks creation in order to get it when a webhook is coming inside the config

Fixes PMNT-107