### PR TITLE
fix(generic): fix missing sorting query param

### DIFF
--- a/internal/connectors/plugins/public/generic/client/accounts.go
+++ b/internal/connectors/plugins/public/generic/client/accounts.go
@@ -12,7 +12,8 @@ func (c *client) ListAccounts(ctx context.Context, page, pageSize int64, created
 	req := c.apiClient.DefaultApi.
 		GetAccounts(metrics.OperationContext(ctx, "list_accounts")).
 		Page(page).
-		PageSize(pageSize)
+		PageSize(pageSize).
+		Sort("createdAt:asc")
 
 	if !createdAtFrom.IsZero() {
 		req = req.CreatedAtFrom(createdAtFrom)

--- a/internal/connectors/plugins/public/generic/client/beneficiaries.go
+++ b/internal/connectors/plugins/public/generic/client/beneficiaries.go
@@ -12,7 +12,8 @@ func (c *client) ListBeneficiaries(ctx context.Context, page, pageSize int64, cr
 	req := c.apiClient.DefaultApi.
 		GetBeneficiaries(metrics.OperationContext(ctx, "list_beneficiaries")).
 		Page(page).
-		PageSize(pageSize)
+		PageSize(pageSize).
+		Sort("createdAt:asc")
 
 	if !createdAtFrom.IsZero() {
 		req = req.CreatedAtFrom(createdAtFrom)

--- a/internal/connectors/plugins/public/generic/client/transactions.go
+++ b/internal/connectors/plugins/public/generic/client/transactions.go
@@ -11,7 +11,8 @@ import (
 func (c *client) ListTransactions(ctx context.Context, page, pageSize int64, updatedAtFrom time.Time) ([]genericclient.Transaction, error) {
 	req := c.apiClient.DefaultApi.GetTransactions(metrics.OperationContext(ctx, "list_transactions")).
 		Page(page).
-		PageSize(pageSize)
+		PageSize(pageSize).
+		Sort("updatedAt:asc")
 
 	if !updatedAtFrom.IsZero() {
 		req = req.UpdatedAtFrom(updatedAtFrom)


### PR DESCRIPTION
# Description

## Context

When passing through the tests yesterday, I noticed that we were missing the sorting parameters when calling the psp

## Solution

This PR adds the sorting query params according to the open api we defined for the generic connector

Fixes PMNT-108