### PR TITLE
feat(events): add task updated events

### DIFF
--- a/internal/connectors/engine/activities/activity.go
+++ b/internal/connectors/engine/activities/activity.go
@@ -328,6 +328,10 @@ func (a Activities) DefinitionSet() temporalworker.DefinitionSet {
 			Func: a.EventsSendPaymentInitiationRelatedPayment,
 		}).
 		Append(temporalworker.Definition{
+			Name: "EventsSendTaskUpdated",
+			Func: a.EventsSendTaskUpdated,
+		}).
+		Append(temporalworker.Definition{
 			Name: "TemporalScheduleCreate",
 			Func: a.TemporalScheduleCreate,
 		}).

--- a/internal/connectors/engine/activities/events_send_task_updated.go
+++ b/internal/connectors/engine/activities/events_send_task_updated.go
@@ -1,0 +1,18 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/formancehq/payments/internal/models"
+	"go.temporal.io/sdk/workflow"
+)
+
+func (a Activities) EventsSendTaskUpdated(ctx context.Context, task models.Task) error {
+	return a.events.Publish(ctx, a.events.NewEventUpdatedTask(task))
+}
+
+var EventsSendTaskUpdatedActivity = Activities{}.EventsSendTaskUpdated
+
+func EventsSendTaskUpdated(ctx workflow.Context, task models.Task) error {
+	return executeActivity(ctx, EventsSendTaskUpdatedActivity, nil, task)
+}

--- a/internal/connectors/engine/workflow/create_bank_account_test.go
+++ b/internal/connectors/engine/workflow/create_bank_account_test.go
@@ -45,6 +45,17 @@ func (s *UnitTestSuite) Test_CreateBankAccount_Success() {
 		s.Equal(models.TASK_STATUS_SUCCEEDED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, sendEvents SendEvents) error {
+		s.Nil(sendEvents.Balance)
+		s.Nil(sendEvents.Account)
+		s.Nil(sendEvents.ConnectorReset)
+		s.Nil(sendEvents.Payment)
+		s.Nil(sendEvents.PoolsCreation)
+		s.Nil(sendEvents.PoolsDeletion)
+		s.Nil(sendEvents.BankAccount)
+		s.NotNil(sendEvents.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunCreateBankAccount, CreateBankAccount{
 		TaskID: models.TaskID{
@@ -62,10 +73,14 @@ func (s *UnitTestSuite) Test_CreateBankAccount_Success() {
 func (s *UnitTestSuite) Test_CreateBankAccount_PluginCreateBankAccount_Error() {
 	s.env.OnActivity(activities.PluginCreateBankAccountActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, sendEvents SendEvents) error {
+		s.NotNil(sendEvents.Task)
 		return nil
 	})
 
@@ -81,6 +96,7 @@ func (s *UnitTestSuite) Test_CreateBankAccount_PluginCreateBankAccount_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateBankAccount_StorageAccountsStore_Error() {
@@ -88,10 +104,14 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageAccountsStore_Error() {
 		RelatedAccount: s.pspAccount,
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, sendEvents SendEvents) error {
+		s.NotNil(sendEvents.Task)
 		return nil
 	})
 
@@ -107,6 +127,7 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageAccountsStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateBankAccount_StorageBankAccountsAddRelatedAccount_Error() {
@@ -115,10 +136,14 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageBankAccountsAddRelatedAcco
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageBankAccountsAddRelatedAccountActivity, mock.Anything, s.bankAccount.ID, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, sendEvents SendEvents) error {
+		s.NotNil(sendEvents.Task)
 		return nil
 	})
 
@@ -134,6 +159,7 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageBankAccountsAddRelatedAcco
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateBankAccount_RunSendEvents_Error() {
@@ -142,9 +168,13 @@ func (s *UnitTestSuite) Test_CreateBankAccount_RunSendEvents_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageBankAccountsAddRelatedAccountActivity, mock.Anything, s.bankAccount.ID, mock.Anything).Once().Return(nil)
-	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")))
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")))
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, sendEvents SendEvents) error {
+		s.NotNil(sendEvents.Task)
 		return nil
 	})
 
@@ -160,6 +190,7 @@ func (s *UnitTestSuite) Test_CreateBankAccount_RunSendEvents_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateBankAccount_StorageTasksStore_Error() {
@@ -168,10 +199,10 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageTasksStore_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageBankAccountsAddRelatedAccountActivity, mock.Anything, s.bankAccount.ID, mock.Anything).Once().Return(nil)
-	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")))
+	s.env.OnWorkflow(s.w.runSendEvents, mock.Anything, mock.Anything).Once().Return(temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")))
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
-		return temporal.NewNonRetryableApplicationError("test", "test", errors.New("test"))
+		return temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test"))
 	})
 
 	s.env.ExecuteWorkflow(RunCreateBankAccount, CreateBankAccount{
@@ -186,5 +217,5 @@ func (s *UnitTestSuite) Test_CreateBankAccount_StorageTasksStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test")
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/create_webhooks_test.go
+++ b/internal/connectors/engine/workflow/create_webhooks_test.go
@@ -49,7 +49,7 @@ func (s *UnitTestSuite) Test_CreateWebhooks_Success() {
 func (s *UnitTestSuite) Test_CreateWebhooks_PluginCreateWebhooksActivity_Error() {
 	s.env.OnActivity(activities.PluginCreateWebhooksActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunCreateWebhooks, CreateWebhooks{
@@ -61,6 +61,7 @@ func (s *UnitTestSuite) Test_CreateWebhooks_PluginCreateWebhooksActivity_Error()
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateWebhooks_StorageWebhooksConfigsStoreActivity_Error() {
@@ -79,7 +80,7 @@ func (s *UnitTestSuite) Test_CreateWebhooks_StorageWebhooksConfigsStoreActivity_
 		},
 	}, nil)
 	s.env.OnActivity(activities.StorageWebhooksConfigsStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, configs []models.WebhookConfig) error {
-		return errors.New("something")
+		return temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test"))
 	})
 
 	s.env.ExecuteWorkflow(RunCreateWebhooks, CreateWebhooks{
@@ -91,6 +92,7 @@ func (s *UnitTestSuite) Test_CreateWebhooks_StorageWebhooksConfigsStoreActivity_
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_CreateWebhooks_Run_Error() {
@@ -108,7 +110,7 @@ func (s *UnitTestSuite) Test_CreateWebhooks_Run_Error() {
 		}, nil
 	})
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunCreateWebhooks, CreateWebhooks{
@@ -120,4 +122,5 @@ func (s *UnitTestSuite) Test_CreateWebhooks_Run_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/fetch_accounts_test.go
+++ b/internal/connectors/engine/workflow/fetch_accounts_test.go
@@ -186,7 +186,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_HasMoreLoop_Success() {
 
 func (s *UnitTestSuite) Test_FetchNextAccounts_StorageInstancesStore_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test")),
 	)
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -203,14 +203,15 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageInstancesStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_FetchNextAccounts_StorageStatesGet_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesGetActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -231,6 +232,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageStatesGet_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -247,7 +249,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_PluginFetchNextAccounts_Error() {
 		},
 		nil,
 	)
-	expectedErr := temporal.NewNonRetryableApplicationError("test", "PLUGIN", errors.New("test"))
+	expectedErr := temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", errors.New("error-test"))
 	s.env.OnActivity(activities.PluginFetchNextAccountsActivity, mock.Anything, mock.Anything).Once().Return(nil, expectedErr)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -269,6 +271,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_PluginFetchNextAccounts_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 	workflowErr, ok := err.(*temporal.WorkflowExecutionError)
 	s.True(ok)
 	s.ErrorContains(workflowErr.Unwrap(), expectedErr.Error())
@@ -294,9 +297,9 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageAccountsStore_Error() {
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -317,6 +320,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageAccountsStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -340,7 +344,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_RunSendEvents_Error() {
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := temporal.NewNonRetryableApplicationError("test", "WORKFLOW", errors.New("test"))
+	expectedErr := temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", errors.New("error-test"))
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(expectedErr)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
@@ -363,6 +367,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_RunSendEvents_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 	workflowErr, ok := err.(*temporal.WorkflowExecutionError)
 	s.True(ok)
 	s.ErrorContains(workflowErr.Unwrap(), expectedErr.Error())
@@ -390,7 +395,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_Run_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := temporal.NewNonRetryableApplicationError("test", "WORKFLOW", errors.New("test"))
+	expectedErr := temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", errors.New("error-test"))
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(expectedErr)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -412,6 +417,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_Run_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 	workflowErr, ok := err.(*temporal.WorkflowExecutionError)
 	s.True(ok)
 	s.ErrorContains(workflowErr.Unwrap(), expectedErr.Error())
@@ -440,7 +446,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageStatesStore_Error() {
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test"))
+	expectedErr := temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test"))
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(expectedErr)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -462,6 +468,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageStatesStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 	workflowErr, ok := err.(*temporal.WorkflowExecutionError)
 	s.True(ok)
 	s.ErrorContains(workflowErr.Unwrap(), expectedErr.Error())
@@ -491,7 +498,7 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageInstancesUpdate_Error() {
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test"))
+	expectedErr := temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test"))
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
 		s.Nil(instance.Error)
@@ -511,5 +518,6 @@ func (s *UnitTestSuite) Test_FetchNextAccounts_StorageInstancesUpdate_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }

--- a/internal/connectors/engine/workflow/fetch_balances_test.go
+++ b/internal/connectors/engine/workflow/fetch_balances_test.go
@@ -185,9 +185,9 @@ func (s *UnitTestSuite) Test_FetchNextBalances_HasMoreLoop_Success() {
 }
 
 func (s *UnitTestSuite) Test_FetchNextBalances_StorageInstancesStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -203,15 +203,16 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageInstancesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
 func (s *UnitTestSuite) Test_FetchNextBalances_StorageStatesGet_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesGetActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -232,6 +233,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageStatesGet_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -248,10 +250,10 @@ func (s *UnitTestSuite) Test_FetchNextBalances_PluginFetchNextBalances_Error() {
 		},
 		nil,
 	)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.PluginFetchNextBalancesActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -272,6 +274,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_PluginFetchNextBalances_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -295,9 +298,9 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageBalancesStore_Error() {
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageBalancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -318,6 +321,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageBalancesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -342,9 +346,9 @@ func (s *UnitTestSuite) Test_FetchNextBalances_RunSendEvents_Error() {
 		HasMore:  false,
 	}, nil)
 	s.env.OnActivity(activities.StorageBalancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -365,6 +369,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_RunSendEvents_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -390,9 +395,9 @@ func (s *UnitTestSuite) Test_FetchNextBalances_Run_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageBalancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -413,6 +418,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_Run_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -439,9 +445,9 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageStatesStore_Error() {
 	s.env.OnActivity(activities.StorageBalancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -462,6 +468,7 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageStatesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -489,11 +496,11 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageInstancesUpdate_Error() {
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
 		s.Nil(instance.Error)
-		return temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr)
+		return temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr)
 	})
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -509,5 +516,6 @@ func (s *UnitTestSuite) Test_FetchNextBalances_StorageInstancesUpdate_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }

--- a/internal/connectors/engine/workflow/fetch_external_accounts_test.go
+++ b/internal/connectors/engine/workflow/fetch_external_accounts_test.go
@@ -185,9 +185,9 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_HasMoreLoop_Success() {
 }
 
 func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageInstancesStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -209,10 +209,10 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageInstancesStore_Err
 
 func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageStatesGet_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesGetActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -233,6 +233,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageStatesGet_Error() 
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -249,10 +250,10 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_PluginFetchNextExternalAc
 		},
 		nil,
 	)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.PluginFetchNextExternalAccountsActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -273,6 +274,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_PluginFetchNextExternalAc
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -296,9 +298,9 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageAccountsStore_Erro
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -319,6 +321,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageAccountsStore_Erro
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -343,9 +346,9 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_RunSendEvents_Error() {
 		HasMore:  false,
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -366,6 +369,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_RunSendEvents_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -391,9 +395,9 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_Run_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -414,6 +418,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_Run_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -440,9 +445,9 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageStatesStore_Error(
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -463,6 +468,7 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageStatesStore_Error(
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -490,11 +496,11 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageInstancesUpdate_Er
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
 		s.Nil(instance.Error)
-		return temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr)
+		return temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr)
 	})
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -510,5 +516,6 @@ func (s *UnitTestSuite) Test_FetchNextExternalAccounts_StorageInstancesUpdate_Er
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }

--- a/internal/connectors/engine/workflow/fetch_others_test.go
+++ b/internal/connectors/engine/workflow/fetch_others_test.go
@@ -167,9 +167,9 @@ func (s *UnitTestSuite) Test_FetchNextOthers_HasMoreLoop_Success() {
 }
 
 func (s *UnitTestSuite) Test_FetchNextOthers_StorageInstancesStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -185,15 +185,16 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageInstancesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
 func (s *UnitTestSuite) Test_FetchNextOthers_StorageStatesGet_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesGetActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -214,6 +215,7 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageStatesGet_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -230,10 +232,10 @@ func (s *UnitTestSuite) Test_FetchNextOthers_PluginFetchNextOthers_Error() {
 		},
 		nil,
 	)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.PluginFetchNextOthersActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -254,6 +256,7 @@ func (s *UnitTestSuite) Test_FetchNextOthers_PluginFetchNextOthers_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -277,9 +280,9 @@ func (s *UnitTestSuite) Test_FetchNextOthers_Run_Error() {
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -300,6 +303,7 @@ func (s *UnitTestSuite) Test_FetchNextOthers_Run_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -324,9 +328,9 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageStatesStore_Error() {
 		HasMore:  false,
 	}, nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -347,6 +351,7 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageStatesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -372,11 +377,11 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageInstancesUpdate_Error() {
 	}, nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
 		s.Nil(instance.Error)
-		return temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr)
+		return temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr)
 	})
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -392,5 +397,6 @@ func (s *UnitTestSuite) Test_FetchNextOthers_StorageInstancesUpdate_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }

--- a/internal/connectors/engine/workflow/fetch_payments_test.go
+++ b/internal/connectors/engine/workflow/fetch_payments_test.go
@@ -198,9 +198,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_HasMoreLoop_Success() {
 }
 
 func (s *UnitTestSuite) Test_FetchNextPayments_StorageInstancesStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -216,15 +216,16 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageInstancesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
 func (s *UnitTestSuite) Test_FetchNextPayments_StorageStatesGet_Error() {
 	s.env.OnActivity(activities.StorageInstancesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesGetActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -245,6 +246,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageStatesGet_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -261,10 +263,10 @@ func (s *UnitTestSuite) Test_FetchNextPayments_PluginFetchNextPayments_Error() {
 		},
 		nil,
 	)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.PluginFetchNextPaymentsActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -285,6 +287,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_PluginFetchNextPayments_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -308,9 +311,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StoragePaymentsStore_Error() {
 		NewState: []byte(`{}`),
 		HasMore:  false,
 	}, nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -331,6 +334,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StoragePaymentsStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -355,9 +359,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_RunUpdatePaymentInitiationFromPay
 		HasMore:  false,
 	}, nil)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(RunUpdatePaymentInitiationFromPayment, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -378,6 +382,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_RunUpdatePaymentInitiationFromPay
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -403,9 +408,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_RunSendEvents_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunUpdatePaymentInitiationFromPayment, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -426,6 +431,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_RunSendEvents_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -452,9 +458,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_Run_Error() {
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunUpdatePaymentInitiationFromPayment, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -475,6 +481,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_Run_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -502,9 +509,9 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageStatesStore_Error() {
 	s.env.OnWorkflow(RunUpdatePaymentInitiationFromPayment, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
@@ -525,6 +532,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageStatesStore_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -553,11 +561,11 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageInstancesUpdate_Error() {
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageInstancesUpdateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, instance models.Instance) error {
 		s.True(instance.Terminated)
 		s.Nil(instance.Error)
-		return temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr)
+		return temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr)
 	})
 
 	err := s.env.SetTypedSearchAttributesOnStart(temporal.NewSearchAttributes(temporal.NewSearchAttributeKeyKeyword(SearchAttributeScheduleID).ValueSet("test")))
@@ -573,6 +581,7 @@ func (s *UnitTestSuite) Test_FetchNextPayments_StorageInstancesUpdate_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err = s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -614,9 +623,9 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_Account_Success() {
 }
 
 func (s *UnitTestSuite) Test_StoreWebhookTranslation_Account_StorageAccountsStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	s.env.ExecuteWorkflow(RunStoreWebhookTranslation, StoreWebhookTranslation{
@@ -626,6 +635,7 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_Account_StorageAccountsStor
 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
@@ -657,9 +667,9 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_ExternalAccount_Success() {
 }
 
 func (s *UnitTestSuite) Test_StoreWebhookTranslation_ExternalAccount_StorageAccountsStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StorageAccountsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	s.env.ExecuteWorkflow(RunStoreWebhookTranslation, StoreWebhookTranslation{
@@ -670,6 +680,7 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_ExternalAccount_StorageAcco
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_StoreWebhookTranslation_Payment_Success() {
@@ -700,9 +711,9 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_Payment_Success() {
 }
 
 func (s *UnitTestSuite) Test_StoreWebhookTranslation_Payment_StoragePaymentsStore_Error() {
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", expectedErr),
 	)
 
 	s.env.ExecuteWorkflow(RunStoreWebhookTranslation, StoreWebhookTranslation{
@@ -712,14 +723,15 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_Payment_StoragePaymentsStor
 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }
 
 func (s *UnitTestSuite) Test_StoreWebhookTranslation_RunSendEvents_Error() {
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
-	expectedErr := errors.New("test")
+	expectedErr := errors.New("error-test")
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", expectedErr),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", expectedErr),
 	)
 
 	s.env.ExecuteWorkflow(RunStoreWebhookTranslation, StoreWebhookTranslation{
@@ -729,5 +741,6 @@ func (s *UnitTestSuite) Test_StoreWebhookTranslation_RunSendEvents_Error() {
 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
+	s.Error(err)
 	s.ErrorContains(err, expectedErr.Error())
 }

--- a/internal/connectors/engine/workflow/handle_webhooks_test.go
+++ b/internal/connectors/engine/workflow/handle_webhooks_test.go
@@ -153,7 +153,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_NoConfigForWebhook_Error() {
 func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksConfigsGet_Error() {
 	s.env.OnActivity(activities.StorageWebhooksConfigsGetActivity, mock.Anything, s.connectorID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
@@ -175,6 +175,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksConfigsGet_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_HandleWebhooks_PluginVerifyWebhook_Error() {
@@ -190,7 +191,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_PluginVerifyWebhook_Error() {
 	)
 	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
@@ -212,6 +213,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_PluginVerifyWebhook_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksStore_Error() {
@@ -227,7 +229,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksStore_Error() {
 	)
 	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(&models.VerifyWebhookResponse{}, nil)
 	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
@@ -249,6 +251,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_StorageWebhooksStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_HandleWebhooks_PluginTranslateWebhook_Error() {
@@ -265,7 +268,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_PluginTranslateWebhook_Error() {
 	s.env.OnActivity(activities.PluginVerifyWebhookActivity, mock.Anything, mock.Anything).Once().Return(&models.VerifyWebhookResponse{}, nil)
 	s.env.OnActivity(activities.StorageWebhooksStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.PluginTranslateWebhookActivity, mock.Anything, mock.Anything).Once().Return(nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
@@ -287,6 +290,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_PluginTranslateWebhook_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_HandleWebhooks_RunStoreWebhookTranslation_Error() {
@@ -314,7 +318,7 @@ func (s *UnitTestSuite) Test_HandleWebhooks_RunStoreWebhookTranslation_Error() {
 		}, nil
 	})
 	s.env.OnWorkflow(RunStoreWebhookTranslation, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunHandleWebhooks, HandleWebhooks{
@@ -336,4 +340,5 @@ func (s *UnitTestSuite) Test_HandleWebhooks_RunStoreWebhookTranslation_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/install_connector_test.go
+++ b/internal/connectors/engine/workflow/install_connector_test.go
@@ -56,7 +56,7 @@ func (s *UnitTestSuite) Test_InstallConnector_NoConfigs_Success() {
 func (s *UnitTestSuite) Test_InstallConnector_PluginInstallConnector_Error() {
 	s.env.OnActivity(activities.PluginInstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "PLUGIN", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("test", "PLUGIN", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageConnectorsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 
@@ -68,7 +68,7 @@ func (s *UnitTestSuite) Test_InstallConnector_PluginInstallConnector_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_InstallConnector_StorageConnectorTasksTreeStore_Error() {
@@ -77,7 +77,7 @@ func (s *UnitTestSuite) Test_InstallConnector_StorageConnectorTasksTreeStore_Err
 			Workflow: []models.ConnectorTaskTree{},
 		}, nil)
 	s.env.OnActivity(activities.StorageConnectorTasksTreeStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageConnectorsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 
@@ -89,16 +89,18 @@ func (s *UnitTestSuite) Test_InstallConnector_StorageConnectorTasksTreeStore_Err
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_InstallConnector_StorageConnectorsDelete_Error() {
 	s.env.OnActivity(activities.PluginInstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(&models.InstallResponse{
 		Workflow: []models.ConnectorTaskTree{},
 	}, nil)
-	s.env.OnActivity(activities.StorageConnectorTasksTreeStoreActivity, mock.Anything, mock.Anything).Once().Return(errors.New("something"))
+	s.env.OnActivity(activities.StorageConnectorTasksTreeStoreActivity, mock.Anything, mock.Anything).Once().Return(
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test")),
+	)
 	s.env.OnActivity(activities.StorageConnectorsDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test-error-connector")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunInstallConnector, InstallConnector{
@@ -109,7 +111,7 @@ func (s *UnitTestSuite) Test_InstallConnector_StorageConnectorsDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error-connector")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_InstallConnector_Run_Error() {
@@ -118,7 +120,7 @@ func (s *UnitTestSuite) Test_InstallConnector_Run_Error() {
 	}, nil)
 	s.env.OnActivity(activities.StorageConnectorTasksTreeStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(Run, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("test", "STORAGE", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunInstallConnector, InstallConnector{

--- a/internal/connectors/engine/workflow/plugin_workflow_test.go
+++ b/internal/connectors/engine/workflow/plugin_workflow_test.go
@@ -346,7 +346,7 @@ func (s *UnitTestSuite) Test_Run_UnknownTaskType_Error() {
 func (s *UnitTestSuite) Test_Run_StorageConnectorsGet_Error() {
 	s.env.OnActivity(activities.StorageConnectorsGetActivity, mock.Anything, s.connectorID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(
@@ -370,6 +370,7 @@ func (s *UnitTestSuite) Test_Run_StorageConnectorsGet_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_Run_StorageSchedulesStore_Error() {
@@ -378,7 +379,7 @@ func (s *UnitTestSuite) Test_Run_StorageSchedulesStore_Error() {
 		nil,
 	)
 	s.env.OnActivity(activities.StorageSchedulesStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(
@@ -402,6 +403,7 @@ func (s *UnitTestSuite) Test_Run_StorageSchedulesStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_Run_TemporalScheduleCreate_Error() {
@@ -411,7 +413,7 @@ func (s *UnitTestSuite) Test_Run_TemporalScheduleCreate_Error() {
 	)
 	s.env.OnActivity(activities.StorageSchedulesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.TemporalScheduleCreateActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(
@@ -435,4 +437,5 @@ func (s *UnitTestSuite) Test_Run_TemporalScheduleCreate_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/poll_transfer_test.go
+++ b/internal/connectors/engine/workflow/poll_transfer_test.go
@@ -56,6 +56,18 @@ func (s *UnitTestSuite) Test_PollTransfer_WithPayment_Success() {
 		s.Equal(models.TASK_STATUS_SUCCEEDED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.Nil(req.Payment)
+		s.Nil(req.PaymentInitiationRelatedPayment)
+		s.Nil(req.Account)
+		s.Nil(req.Balance)
+		s.Nil(req.BankAccount)
+		s.Nil(req.ConnectorReset)
+		s.Nil(req.PoolsCreation)
+		s.Nil(req.PoolsDeletion)
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunPollTransfer, PollTransfer{
 		TaskID: models.TaskID{
@@ -101,7 +113,7 @@ func (s *UnitTestSuite) Test_PollTransfer_WithError_Success() {
 		s.Equal(s.connectorID, req.ConnectorID)
 		s.Equal("test-transfer", req.Req.TransferID)
 		return &models.PollTransferStatusResponse{
-			Error: pointer.For("test-error"),
+			Error: pointer.For("error-test"),
 		}, nil
 	})
 
@@ -110,7 +122,18 @@ func (s *UnitTestSuite) Test_PollTransfer_WithError_Success() {
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.NotNil(task.Error)
-		s.ErrorContains(task.Error, "test-error")
+		s.ErrorContains(task.Error, "error-test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.Nil(req.PaymentInitiationRelatedPayment)
+		s.Nil(req.Account)
+		s.Nil(req.Balance)
+		s.Nil(req.BankAccount)
+		s.Nil(req.ConnectorReset)
+		s.Nil(req.PoolsCreation)
+		s.Nil(req.PoolsDeletion)
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -141,6 +164,10 @@ func (s *UnitTestSuite) Test_PollTransfer_PluginPollTransferStatus_Error() {
 		s.ErrorContains(task.Error, "test")
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunPollTransfer, PollTransfer{
 		TaskID: models.TaskID{
@@ -166,11 +193,15 @@ func (s *UnitTestSuite) Test_PollTransfer_StoragePaymentsStore_Error() {
 		nil,
 	)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.ErrorContains(task.Error, "test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -204,11 +235,15 @@ func (s *UnitTestSuite) Test_PollTransfer_RunSendEvents_Error() {
 		return nil
 	})
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", fmt.Errorf("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.ErrorContains(task.Error, "test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -237,11 +272,15 @@ func (s *UnitTestSuite) Test_PollTransfer_StoragePaymentInitiationsRelatedPaymen
 	)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsRelatedPaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.ErrorContains(task.Error, "test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -272,11 +311,15 @@ func (s *UnitTestSuite) Test_PollTransfer_StoragePaymentInitiationsAdjustmentsSt
 	s.env.OnActivity(activities.StoragePaymentInitiationsRelatedPaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.ErrorContains(task.Error, "test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -314,6 +357,10 @@ func (s *UnitTestSuite) Test_PollTransfer_TemporalDeleteSchedule_Error() {
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		s.ErrorContains(task.Error, "test")
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -354,6 +401,10 @@ func (s *UnitTestSuite) Test_PollTransfer_StorageSchedulesDelete_Error() {
 		s.ErrorContains(task.Error, "test")
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunPollTransfer, PollTransfer{
 		TaskID: models.TaskID{
@@ -388,7 +439,7 @@ func (s *UnitTestSuite) Test_PollTransfer_StorageTasksStore_Error() {
 		temporal.NewNonRetryableApplicationError("test", "TEMPORAL", fmt.Errorf("test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunPollTransfer, PollTransfer{
@@ -405,4 +456,5 @@ func (s *UnitTestSuite) Test_PollTransfer_StorageTasksStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/reset_connector_test.go
+++ b/internal/connectors/engine/workflow/reset_connector_test.go
@@ -42,6 +42,10 @@ func (s *UnitTestSuite) Test_ResetConnector_Success() {
 		s.Equal(models.TASK_STATUS_SUCCEEDED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -60,10 +64,14 @@ func (s *UnitTestSuite) Test_ResetConnector_Success() {
 func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsGet_Error() {
 	s.env.OnActivity(activities.StorageConnectorsGetActivity, mock.Anything, s.connectorID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -79,6 +87,7 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsGet_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsScheduleForDeletion_Error() {
@@ -87,8 +96,16 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsScheduleForDeletion
 		nil,
 	)
 	s.env.OnActivity(activities.StorageConnectorsScheduleForDeletionActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -102,6 +119,7 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsScheduleForDeletion
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_RunUninstallConnector_Error() {
@@ -111,8 +129,16 @@ func (s *UnitTestSuite) Test_ResetConnector_RunUninstallConnector_Error() {
 	)
 	s.env.OnActivity(activities.StorageConnectorsScheduleForDeletionActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnWorkflow(RunUninstallConnector, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "WORKFLOW", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "WORKFLOW", fmt.Errorf("error-test")),
 	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -126,6 +152,7 @@ func (s *UnitTestSuite) Test_ResetConnector_RunUninstallConnector_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsStore_Error() {
@@ -136,8 +163,16 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsStore_Error() {
 	s.env.OnActivity(activities.StorageConnectorsScheduleForDeletionActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnWorkflow(RunUninstallConnector, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -151,6 +186,7 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageConnectorsStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_RunInstallConnector_Error() {
@@ -162,8 +198,16 @@ func (s *UnitTestSuite) Test_ResetConnector_RunInstallConnector_Error() {
 	s.env.OnWorkflow(RunUninstallConnector, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunInstallConnector, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -177,6 +221,7 @@ func (s *UnitTestSuite) Test_ResetConnector_RunInstallConnector_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_RunSendEvents_Error() {
@@ -189,8 +234,16 @@ func (s *UnitTestSuite) Test_ResetConnector_RunSendEvents_Error() {
 	s.env.OnActivity(activities.StorageConnectorsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunInstallConnector, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
 		ConnectorID:       s.connectorID,
@@ -204,6 +257,7 @@ func (s *UnitTestSuite) Test_ResetConnector_RunSendEvents_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ResetConnector_StorageTasksStoreActivity_Error() {
@@ -217,7 +271,7 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageTasksStoreActivity_Error() {
 	s.env.OnWorkflow(RunInstallConnector, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "STORAGE", fmt.Errorf("test")),
+		temporal.NewNonRetryableApplicationError("error-test", "STORAGE", fmt.Errorf("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunResetConnector, ResetConnector{
@@ -232,4 +286,5 @@ func (s *UnitTestSuite) Test_ResetConnector_StorageTasksStoreActivity_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/reverse_payout_test.go
+++ b/internal/connectors/engine/workflow/reverse_payout_test.go
@@ -112,6 +112,10 @@ func (s *UnitTestSuite) Test_ReversePayout_Success() {
 		s.Equal(models.TASK_STATUS_SUCCEEDED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunReversePayout, ReversePayout{
 		TaskID: models.TaskID{
@@ -182,7 +186,7 @@ func (s *UnitTestSuite) Test_ReversePayout_PluginReversePayout_Error_Success() {
 		nil,
 	)
 	s.env.OnActivity(activities.PluginReversePayoutActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.ReversePayoutRequest) (*models.ReversePayoutResponse, error) {
-		return nil, temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error"))
+		return nil, temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test"))
 	})
 	s.env.OnActivity(activities.StoragePaymentInitiationReversalsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, adj models.PaymentInitiationReversalAdjustment) error {
 		s.Equal(models.PAYMENT_INITIATION_REVERSAL_STATUS_FAILED, adj.Status)
@@ -200,29 +204,8 @@ func (s *UnitTestSuite) Test_ReversePayout_PluginReversePayout_Error_Success() {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		return nil
 	})
-
-	s.env.ExecuteWorkflow(RunReversePayout, ReversePayout{
-		TaskID: models.TaskID{
-			Reference:   "test",
-			ConnectorID: s.connectorID,
-		},
-		ConnectorID:                 s.connectorID,
-		PaymentInitiationReversalID: s.paymentReversalID,
-	})
-
-	s.True(s.env.IsWorkflowCompleted())
-	err := s.env.GetWorkflowError()
-	s.Error(err)
-	s.ErrorContains(err, "test-error")
-}
-
-func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsGet_Error() {
-	s.env.OnActivity(activities.StoragePaymentInitiationReversalsGetActivity, mock.Anything, s.paymentReversalID).Once().Return(
-		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
-	)
-	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
-		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -238,7 +221,36 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsGet_
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
+}
+
+func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsGet_Error() {
+	s.env.OnActivity(activities.StoragePaymentInitiationReversalsGetActivity, mock.Anything, s.paymentReversalID).Once().Return(
+		nil,
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
+	)
+	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
+		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
+
+	s.env.ExecuteWorkflow(RunReversePayout, ReversePayout{
+		TaskID: models.TaskID{
+			Reference:   "test",
+			ConnectorID: s.connectorID,
+		},
+		ConnectorID:                 s.connectorID,
+		PaymentInitiationReversalID: s.paymentReversalID,
+	})
+
+	s.True(s.env.IsWorkflowCompleted())
+	err := s.env.GetWorkflowError()
+	s.Error(err)
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsGet_Error() {
@@ -248,10 +260,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsGet_Error() 
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationsGetActivity, mock.Anything, s.paymentInitiationID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -267,7 +283,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsGet_Error() 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationAdjustmentsList_Error() {
@@ -281,10 +297,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationAdjustmentsLi
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationAdjustmentsListActivity, mock.Anything, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -300,7 +320,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationAdjustmentsLi
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_ValidatePaymentInitiationProcessed_Error() {
@@ -323,6 +343,10 @@ func (s *UnitTestSuite) Test_ReversePayout_ValidatePaymentInitiationProcessed_Er
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -376,10 +400,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationAdjustmentsLi
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationAdjustmentsListActivity, mock.Anything, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -395,7 +423,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationAdjustmentsLi
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_ValidateReverseAmount_Error() {
@@ -459,6 +487,10 @@ func (s *UnitTestSuite) Test_ReversePayout_ValidateReverseAmount_Error() {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunReversePayout, ReversePayout{
 		TaskID: models.TaskID{
@@ -518,10 +550,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjusmentsIf
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjusmentsIfStatusEqualStoreActivity, mock.Anything, mock.Anything, mock.Anything).Once().Return(
 		true,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -537,7 +573,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjusmentsIf
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_ValidateOnlyReverse_Error() {
@@ -584,6 +620,10 @@ func (s *UnitTestSuite) Test_ReversePayout_ValidateOnlyReverse_Error() {
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjusmentsIfStatusEqualStoreActivity, mock.Anything, mock.Anything, mock.Anything).Once().Return(false, nil)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -647,10 +687,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageAccountsGet_Error() {
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageAccountsGetActivity, mock.Anything, *s.paymentInitiationPayout.SourceAccountID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -666,7 +710,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageAccountsGet_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StorageAccountsGet_2_Error() {
@@ -718,10 +762,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageAccountsGet_2_Error() {
 	)
 	s.env.OnActivity(activities.StorageAccountsGetActivity, mock.Anything, *s.paymentInitiationPayout.DestinationAccountID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -737,7 +785,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageAccountsGet_2_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentsStore_Error() {
@@ -798,10 +846,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentsStore_Error() {
 		nil,
 	)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -817,7 +869,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentsStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_RunSendEvents_Error() {
@@ -880,10 +932,14 @@ func (s *UnitTestSuite) Test_ReversePayout_RunSendEvents_Error() {
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsRelatedPaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -899,7 +955,7 @@ func (s *UnitTestSuite) Test_ReversePayout_RunSendEvents_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsRelatedPaymentsStore_Error() {
@@ -961,10 +1017,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsRelatedPayme
 	)
 	s.env.OnActivity(activities.StoragePaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsRelatedPaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -980,7 +1040,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsRelatedPayme
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsStore_Error() {
@@ -1044,10 +1104,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsS
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsRelatedPaymentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -1063,7 +1127,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsS
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdjustmentsStore_Error() {
@@ -1129,10 +1193,14 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdju
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationReversalsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -1148,7 +1216,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdju
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StorageTasksStore_Error() {
@@ -1215,7 +1283,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageTasksStore_Error() {
 	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationReversalsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunReversePayout, ReversePayout{
@@ -1230,7 +1298,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StorageTasksStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdjustmentsStore_2_Error() {
@@ -1285,13 +1353,17 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdju
 		nil,
 	)
 	s.env.OnActivity(activities.PluginReversePayoutActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.ReversePayoutRequest) (*models.ReversePayoutResponse, error) {
-		return nil, temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error"))
+		return nil, temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test"))
 	})
 	s.env.OnActivity(activities.StoragePaymentInitiationReversalsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -1307,7 +1379,7 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationReversalsAdju
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsStore_2_Error() {
@@ -1362,14 +1434,18 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsS
 		nil,
 	)
 	s.env.OnActivity(activities.PluginReversePayoutActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.ReversePayoutRequest) (*models.ReversePayoutResponse, error) {
-		return nil, temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error"))
+		return nil, temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test"))
 	})
 	s.env.OnActivity(activities.StoragePaymentInitiationReversalsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -1385,5 +1461,5 @@ func (s *UnitTestSuite) Test_ReversePayout_StoragePaymentInitiationsAdjustmentsS
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/send_events.go
+++ b/internal/connectors/engine/workflow/send_events.go
@@ -23,6 +23,7 @@ type SendEvents struct {
 	PaymentInitiation               *models.PaymentInitiation
 	PaymentInitiationAdjustment     *models.PaymentInitiationAdjustment
 	PaymentInitiationRelatedPayment *models.PaymentInitiationRelatedPayments
+	Task                            *models.Task
 }
 
 func (w Workflow) runSendEvents(
@@ -196,6 +197,23 @@ func (w Workflow) runSendEvents(
 				return activities.EventsSendPaymentInitiationRelatedPayment(
 					infiniteRetryContext(ctx),
 					*sendEvents.PaymentInitiationRelatedPayment,
+				)
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if sendEvents.Task != nil {
+		err := sendEvent(
+			ctx,
+			sendEvents.Task.IdempotencyKey(),
+			sendEvents.Task.ConnectorID,
+			func(ctx workflow.Context) error {
+				return activities.EventsSendTaskUpdated(
+					infiniteRetryContext(ctx),
+					*sendEvents.Task,
 				)
 			},
 		)

--- a/internal/connectors/engine/workflow/terminate_schedules_test.go
+++ b/internal/connectors/engine/workflow/terminate_schedules_test.go
@@ -97,7 +97,7 @@ func (s *UnitTestSuite) Test_TerminateSchedules_HasMore_Success() {
 func (s *UnitTestSuite) Test_TerminateSchedules_StorageSchedulesList_Error() {
 	s.env.OnActivity(activities.StorageSchedulesListActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunTerminateSchedules, UninstallConnector{
@@ -108,7 +108,7 @@ func (s *UnitTestSuite) Test_TerminateSchedules_StorageSchedulesList_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_TerminateSchedules_TemporalScheduleDelete_Error() {
@@ -127,7 +127,7 @@ func (s *UnitTestSuite) Test_TerminateSchedules_TemporalScheduleDelete_Error() {
 		nil,
 	)
 	s.env.OnActivity(activities.TemporalScheduleDeleteActivity, mock.Anything, "test").Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunTerminateSchedules, UninstallConnector{

--- a/internal/connectors/engine/workflow/terminate_workflows_test.go
+++ b/internal/connectors/engine/workflow/terminate_workflows_test.go
@@ -83,7 +83,7 @@ func (s *UnitTestSuite) Test_TerminateWorkflows_NotRunningWorkflows_Success() {
 func (s *UnitTestSuite) Test_TerminateWorkflows_TemporalWorkflowExecutionsList_Error() {
 	s.env.OnActivity(activities.TemporalWorkflowExecutionsListActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunTerminateWorkflows, TerminateWorkflows{
@@ -93,7 +93,7 @@ func (s *UnitTestSuite) Test_TerminateWorkflows_TemporalWorkflowExecutionsList_E
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_TerminateWorkflows_TemporalWorkflowTerminate_Error() {
@@ -112,7 +112,7 @@ func (s *UnitTestSuite) Test_TerminateWorkflows_TemporalWorkflowTerminate_Error(
 		nil,
 	)
 	s.env.OnActivity(activities.TemporalWorkflowTerminateActivity, mock.Anything, "test-workflow", "test-run", "uninstalling connector").Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunTerminateWorkflows, TerminateWorkflows{
@@ -122,5 +122,5 @@ func (s *UnitTestSuite) Test_TerminateWorkflows_TemporalWorkflowTerminate_Error(
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/uninstall_connector_test.go
+++ b/internal/connectors/engine/workflow/uninstall_connector_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/payments/internal/models"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
 )
 
 func (s *UnitTestSuite) Test_UninstallConnector_WithoutTaskID_Success() {
@@ -59,6 +60,10 @@ func (s *UnitTestSuite) Test_UninstallConnector_WithTaskID_Success() {
 		s.Equal(models.TASK_STATUS_SUCCEEDED, task.Status)
 		return nil
 	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
+		return nil
+	})
 
 	s.env.ExecuteWorkflow(RunUninstallConnector, UninstallConnector{
 		ConnectorID: s.connectorID,
@@ -75,10 +80,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_WithTaskID_Success() {
 
 func (s *UnitTestSuite) Test_UninstallConnector_RunTerminateSchedules_Error() {
 	s.env.OnWorkflow(RunTerminateSchedules, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -93,16 +102,20 @@ func (s *UnitTestSuite) Test_UninstallConnector_RunTerminateSchedules_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_PluginUninstallConnector_Error() {
 	s.env.OnWorkflow(RunTerminateSchedules, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnWorkflow(RunTerminateWorkflows, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.PluginUninstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")))
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")))
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -117,7 +130,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_PluginUninstallConnector_Error()
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageEventsSentDelete_Error() {
@@ -125,10 +138,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageEventsSentDelete_Error() 
 	s.env.OnWorkflow(RunTerminateWorkflows, mock.Anything, mock.Anything).Once().Return(nil)
 	s.env.OnActivity(activities.PluginUninstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(nil, nil)
 	s.env.OnActivity(activities.StorageEventsSentDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -143,7 +160,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageEventsSentDelete_Error() 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageSchedulesDeleteFromConnectorID_Error() {
@@ -152,10 +169,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageSchedulesDeleteFromConnec
 	s.env.OnActivity(activities.PluginUninstallConnectorActivity, mock.Anything, mock.Anything).Once().Return(nil, nil)
 	s.env.OnActivity(activities.StorageEventsSentDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageSchedulesDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -170,7 +191,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageSchedulesDeleteFromConnec
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageInstancesDelete_Error() {
@@ -180,10 +201,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageInstancesDelete_Error() {
 	s.env.OnActivity(activities.StorageEventsSentDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageSchedulesDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageInstancesDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -198,7 +223,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageInstancesDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorTasksTreeDelete_Error() {
@@ -209,10 +234,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorTasksTreeDelete_
 	s.env.OnActivity(activities.StorageSchedulesDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageInstancesDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorTasksTreeDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -227,7 +256,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorTasksTreeDelete_
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksDeleteFromConnectorID_Error() {
@@ -239,10 +268,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksDeleteFromConnectorI
 	s.env.OnActivity(activities.StorageInstancesDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorTasksTreeDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageTasksDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -257,7 +290,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksDeleteFromConnectorI
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageBankAccountsDeleteRelatedAccounts_Error() {
@@ -270,10 +303,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageBankAccountsDeleteRelated
 	s.env.OnActivity(activities.StorageConnectorTasksTreeDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageTasksDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageBankAccountsDeleteRelatedAccountsActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -288,7 +325,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageBankAccountsDeleteRelated
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageAccountsDelete_Error() {
@@ -302,10 +339,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageAccountsDelete_Error() {
 	s.env.OnActivity(activities.StorageTasksDeleteFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageBankAccountsDeleteRelatedAccountsActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageAccountsDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -320,7 +361,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageAccountsDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StoragePaymentsDelete_Error() {
@@ -335,10 +376,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StoragePaymentsDelete_Error() {
 	s.env.OnActivity(activities.StorageBankAccountsDeleteRelatedAccountsActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageAccountsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentsDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -353,7 +398,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StoragePaymentsDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageStatesDelete_Error() {
@@ -369,10 +414,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageStatesDelete_Error() {
 	s.env.OnActivity(activities.StorageAccountsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePaymentsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -387,7 +436,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageStatesDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksConfigsDelete_Error() {
@@ -404,10 +453,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksConfigsDelete_Err
 	s.env.OnActivity(activities.StoragePaymentsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageStatesDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageWebhooksConfigsDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -422,7 +475,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksConfigsDelete_Err
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksDelete_Error() {
@@ -440,10 +493,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksDelete_Error() {
 	s.env.OnActivity(activities.StorageStatesDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageWebhooksConfigsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageWebhooksDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -458,7 +515,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageWebhooksDelete_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StoragePoolsRemoveAccountsFromConnectorID_Error() {
@@ -477,10 +534,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StoragePoolsRemoveAccountsFromCo
 	s.env.OnActivity(activities.StorageWebhooksConfigsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageWebhooksDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePoolsRemoveAccountsFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -495,7 +556,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StoragePoolsRemoveAccountsFromCo
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorsDelete_Error() {
@@ -515,10 +576,14 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorsDelete_Error() 
 	s.env.OnActivity(activities.StorageWebhooksDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StoragePoolsRemoveAccountsFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorsDeleteActivity, mock.Anything, s.connectorID).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {
 		s.Equal(models.TASK_STATUS_FAILED, task.Status)
+		return nil
+	})
+	s.env.OnWorkflow(RunSendEvents, mock.Anything, mock.Anything).Once().Return(func(ctx workflow.Context, req SendEvents) error {
+		s.NotNil(req.Task)
 		return nil
 	})
 
@@ -533,7 +598,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageConnectorsDelete_Error() 
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksStore_Error() {
@@ -554,7 +619,7 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksStore_Error() {
 	s.env.OnActivity(activities.StoragePoolsRemoveAccountsFromConnectorIDActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageConnectorsDeleteActivity, mock.Anything, s.connectorID).Once().Return(nil)
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunUninstallConnector, UninstallConnector{
@@ -568,5 +633,5 @@ func (s *UnitTestSuite) Test_UninstallConnector_StorageTasksStore_Error() {
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/update_payment_initiation_from_payment_test.go
+++ b/internal/connectors/engine/workflow/update_payment_initiation_from_payment_test.go
@@ -62,7 +62,7 @@ func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_SkipAdjustment_S
 func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_StoragePaymentInitiationIDsListFromPaymentID_Error() {
 	s.env.OnActivity(activities.StoragePaymentInitiationIDsListFromPaymentIDActivity, mock.Anything, s.paymentPayoutID).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunUpdatePaymentInitiationFromPayment, UpdatePaymentInitiationFromPayment{
@@ -72,7 +72,7 @@ func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_StoragePaymentIn
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }
 
 func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_StoragePaymentInitiationsAdjustmentsStore_Error() {
@@ -81,7 +81,7 @@ func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_StoragePaymentIn
 		nil,
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(
-		temporal.NewNonRetryableApplicationError("test", "test", errors.New("test-error")),
+		temporal.NewNonRetryableApplicationError("error-test", "error-test", errors.New("error-test")),
 	)
 
 	s.env.ExecuteWorkflow(RunUpdatePaymentInitiationFromPayment, UpdatePaymentInitiationFromPayment{
@@ -91,5 +91,5 @@ func (s *UnitTestSuite) Test_UpdatePaymentInitiationFromPayment_StoragePaymentIn
 	s.True(s.env.IsWorkflowCompleted())
 	err := s.env.GetWorkflowError()
 	s.Error(err)
-	s.ErrorContains(err, "test-error")
+	s.ErrorContains(err, "error-test")
 }

--- a/internal/connectors/engine/workflow/update_tasks.go
+++ b/internal/connectors/engine/workflow/update_tasks.go
@@ -1,9 +1,12 @@
 package workflow
 
 import (
+	"fmt"
+
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
 	errorsutils "github.com/formancehq/payments/internal/utils/errors"
+	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -11,18 +14,18 @@ func (w Workflow) updateTasksError(
 	ctx workflow.Context,
 	taskID models.TaskID,
 	connectorID *models.ConnectorID,
-	err error,
+	cause error,
 ) error {
-	cause := errorsutils.Cause(err)
-	return activities.StorageTasksStore(
-		infiniteRetryContext(ctx),
-		models.Task{
-			ID:          taskID,
-			ConnectorID: connectorID,
-			Status:      models.TASK_STATUS_FAILED,
-			UpdatedAt:   workflow.Now(ctx).UTC(),
-			Error:       cause,
-		})
+	cause = errorsutils.Cause(cause)
+	task := models.Task{
+		ID:          taskID,
+		ConnectorID: connectorID,
+		Status:      models.TASK_STATUS_FAILED,
+		UpdatedAt:   workflow.Now(ctx).UTC(),
+		Error:       cause,
+	}
+
+	return w.updateTask(ctx, task)
 }
 
 func (w Workflow) updateTaskSuccess(
@@ -31,13 +34,43 @@ func (w Workflow) updateTaskSuccess(
 	connectorID *models.ConnectorID,
 	relatedObjectID string,
 ) error {
-	return activities.StorageTasksStore(
+	task := models.Task{
+		ID:              taskID,
+		ConnectorID:     connectorID,
+		Status:          models.TASK_STATUS_SUCCEEDED,
+		UpdatedAt:       workflow.Now(ctx).UTC(),
+		CreatedObjectID: &relatedObjectID,
+	}
+
+	return w.updateTask(ctx, task)
+}
+
+func (w Workflow) updateTask(ctx workflow.Context, task models.Task) error {
+	if err := activities.StorageTasksStore(
 		infiniteRetryContext(ctx),
-		models.Task{
-			ID:              taskID,
-			ConnectorID:     connectorID,
-			Status:          models.TASK_STATUS_SUCCEEDED,
-			UpdatedAt:       workflow.Now(ctx).UTC(),
-			CreatedObjectID: &relatedObjectID,
-		})
+		task,
+	); err != nil {
+		return err
+	}
+
+	if err := workflow.ExecuteChildWorkflow(
+		workflow.WithChildOptions(
+			ctx,
+			workflow.ChildWorkflowOptions{
+				TaskQueue:         w.getDefaultTaskQueue(),
+				ParentClosePolicy: enums.PARENT_CLOSE_POLICY_ABANDON,
+				SearchAttributes: map[string]interface{}{
+					SearchAttributeStack: w.stack,
+				},
+			},
+		),
+		RunSendEvents,
+		SendEvents{
+			Task: &task,
+		},
+	).GetChildWorkflowExecution().Get(ctx, nil); err != nil {
+		return fmt.Errorf("send events: %w", err)
+	}
+
+	return nil
 }

--- a/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
+++ b/internal/connectors/plugins/public/atlar/bank_account_creation_test.go
@@ -101,11 +101,11 @@ var _ = Describe("Atlar Plugin Bank Account Creation", func() {
 				BankAccount: ba,
 			}
 
-			m.EXPECT().PostV1CounterParties(ctx, ba).Return(nil, errors.New("test-error"))
+			m.EXPECT().PostV1CounterParties(ctx, ba).Return(nil, errors.New("error-test"))
 
 			res, err := plg.CreateBankAccount(ctx, req)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError("test-error"))
+			Expect(err).To(MatchError("error-test"))
 			Expect(res).To(Equal(models.CreateBankAccountResponse{}))
 		})
 

--- a/internal/events/task.go
+++ b/internal/events/task.go
@@ -1,0 +1,53 @@
+package events
+
+import (
+	"time"
+
+	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/go-libs/v3/publish"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/pkg/events"
+)
+
+type taskMessagePayload struct {
+	ID              string    `json:"id"`
+	ConnectorID     *string   `json:"connectorID"`
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+	CreatedObjectID *string   `json:"createdObjectID"`
+	Error           *string   `json:"error"`
+}
+
+func (e Events) NewEventUpdatedTask(task models.Task) publish.EventMessage {
+	payload := taskMessagePayload{
+		ID: task.ID.String(),
+		ConnectorID: func() *string {
+			if task.ConnectorID == nil {
+				return nil
+			}
+
+			return pointer.For(task.ConnectorID.String())
+		}(),
+		Status:          string(task.Status),
+		CreatedAt:       task.CreatedAt,
+		UpdatedAt:       task.UpdatedAt,
+		CreatedObjectID: task.CreatedObjectID,
+		Error: func() *string {
+			if task.Error == nil {
+				return nil
+			}
+
+			return pointer.For(task.Error.Error())
+		}(),
+	}
+
+	return publish.EventMessage{
+		IdempotencyKey: task.IdempotencyKey(),
+		Date:           time.Now().UTC(),
+		App:            events.EventApp,
+		Version:        events.EventVersion,
+		Type:           events.EventTypeUpdatedTask,
+		Payload:        payload,
+	}
+}

--- a/internal/models/tasks.go
+++ b/internal/models/tasks.go
@@ -32,6 +32,10 @@ type Task struct {
 	Error           error   `json:"error,omitempty"`
 }
 
+func (t *Task) IdempotencyKey() string {
+	return IdempotencyKey(t)
+}
+
 func (t Task) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		ID              string     `json:"id"`

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -16,4 +16,5 @@ const (
 	EventTypeSavedPaymentInitiation               = "SAVED_PAYMENT_INITIATION"
 	EventTypeSavedPaymentInitiationAdjustment     = "SAVED_PAYMENT_INITIATION_ADJUSTMENT"
 	EventTypeSavedPaymentInitiationRelatedPayment = "SAVED_PAYMENT_INITIATION_RELATED_PAYMENT"
+	EventTypeUpdatedTask                          = "UPDATED_TASK"
 )


### PR DESCRIPTION
# Description

This PR does two things:
- Add events when a task is updated
- Fix temporal workflow tests when the error wanted is not what we had

## Context

### Tasks

When a user creates something via the API (bank accounts, payouts, transfers...), he currently has to poll the api to get the object id when the task is updated which is a bit of a pain. 

### Tests

When testing temporal workflows, sometimes we test that the workflow returns an error, but we never test what is the error. Some workflows were failing because we missed the mock of a specific functions and the actual error was not catched.

## Solution

### Tasks

This PR adds a new event for tasks, that the user can listen through nats/webhooks in order to get the created object.

### Tests

This PR adds specific errors to catch in the test to be sure that we have the right error