### PR TITLE
test: improve e2e error handling

### DIFF
--- a/test/e2e/api_connectors_test.go
+++ b/test/e2e/api_connectors_test.go
@@ -453,7 +453,7 @@ func blockTillWorkflowComplete(ctx context.Context, connectorIDStr string, searc
 
 	connectorID := models.MustConnectorIDFromString(connectorIDStr)
 	cl := temporalServer.GetValue().DefaultClient()
-	iterateThroughTemporalWorkflowExecutions(ctx, cl, func(info *v17.WorkflowExecutionInfo) bool {
+	iterateThroughTemporalWorkflowExecutions(ctx, cl, 25, func(info *v17.WorkflowExecutionInfo) bool {
 		if (strings.Contains(info.Execution.WorkflowId, connectorID.Reference.String()) ||
 			strings.Contains(info.Execution.WorkflowId, connectorID.String())) &&
 			strings.HasPrefix(info.Execution.WorkflowId, searchKeyword) {


### PR DESCRIPTION
We don't want unbounded goroutines generated by this flush command, so this moves the concurrency control to the iteration command which can limit them to the number of pages fetched