### PR TITLE
Dynamic pool account query implementation

### DIFF
--- a/internal/api/v3/handler_pools_add_account.go
+++ b/internal/api/v3/handler_pools_add_account.go
@@ -24,6 +24,12 @@ func poolsAddAccount(backend backend.Backend) http.HandlerFunc {
 			return
 		}
 
+		// Forbid adding accounts to dynamic pools (query-based)
+		if p, err := backend.PoolsGet(ctx, id); err == nil && p != nil && p.Query != nil {
+			api.BadRequest(w, ErrValidation, models.ErrValidation)
+			return
+		}
+
 		span.SetAttributes(attribute.String("accountID", accountID(r)))
 		accountID, err := models.AccountIDFromString(accountID(r))
 		if err != nil {

--- a/internal/api/v3/handler_pools_create.go
+++ b/internal/api/v3/handler_pools_create.go
@@ -18,7 +18,8 @@ import (
 
 type CreatePoolRequest struct {
 	Name       string   `json:"name" validate:"required"`
-	AccountIDs []string `json:"accountIDs" validate:"min=1,dive,accountID"`
+	AccountIDs []string `json:"accountIDs" validate:"omitempty,min=1,dive,accountID"`
+	Query      *string  `json:"query"`
 }
 
 func poolsCreate(backend backend.Backend, validator *validation.Validator) http.HandlerFunc {
@@ -42,24 +43,37 @@ func poolsCreate(backend backend.Backend, validator *validation.Validator) http.
 			return
 		}
 
+		if CreatePoolRequest.Query == nil && len(CreatePoolRequest.AccountIDs) == 0 {
+			api.BadRequest(w, ErrValidation, fmt.Errorf("either accountIDs or query must be provided"))
+			return
+		}
+		if CreatePoolRequest.Query != nil && len(CreatePoolRequest.AccountIDs) > 0 {
+			api.BadRequest(w, ErrValidation, fmt.Errorf("accountIDs and query are mutually exclusive"))
+			return
+		}
+
 		pool := models.Pool{
 			ID:        uuid.New(),
 			Name:      CreatePoolRequest.Name,
 			CreatedAt: time.Now().UTC(),
 		}
 
-		accounts := make([]models.AccountID, len(CreatePoolRequest.AccountIDs))
-		for i, accountID := range CreatePoolRequest.AccountIDs {
-			aID, err := models.AccountIDFromString(accountID)
-			if err != nil {
-				otel.RecordError(span, err)
-				api.BadRequest(w, ErrValidation, err)
-				return
-			}
+		if CreatePoolRequest.Query != nil {
+			pool.Query = CreatePoolRequest.Query
+		} else {
+			accounts := make([]models.AccountID, len(CreatePoolRequest.AccountIDs))
+			for i, accountID := range CreatePoolRequest.AccountIDs {
+				aID, err := models.AccountIDFromString(accountID)
+				if err != nil {
+					otel.RecordError(span, err)
+					api.BadRequest(w, ErrValidation, err)
+					return
+				}
 
-			accounts[i] = aID
+				accounts[i] = aID
+			}
+			pool.PoolAccounts = accounts
 		}
-		pool.PoolAccounts = accounts
 
 		err = backend.PoolsCreate(ctx, pool)
 		if err != nil {
@@ -76,5 +90,8 @@ func populateSpanFromCreatePoolRequest(span trace.Span, req CreatePoolRequest) {
 	span.SetAttributes(attribute.String("name", req.Name))
 	for i, acc := range req.AccountIDs {
 		span.SetAttributes(attribute.String(fmt.Sprintf("accountIDs[%d]", i), acc))
+	}
+	if req.Query != nil {
+		span.SetAttributes(attribute.String("query", *req.Query))
 	}
 }

--- a/internal/api/v3/handler_pools_remove_account.go
+++ b/internal/api/v3/handler_pools_remove_account.go
@@ -24,6 +24,12 @@ func poolsRemoveAccount(backend backend.Backend) http.HandlerFunc {
 			return
 		}
 
+		// Forbid removing accounts from dynamic pools (query-based)
+		if p, err := backend.PoolsGet(ctx, id); err == nil && p != nil && p.Query != nil {
+			api.BadRequest(w, ErrValidation, models.ErrValidation)
+			return
+		}
+
 		span.SetAttributes(attribute.String("accountID", accountID(r)))
 		accountID, err := models.AccountIDFromString(accountID(r))
 		if err != nil {

--- a/internal/models/pools.go
+++ b/internal/models/pools.go
@@ -13,6 +13,7 @@ type Pool struct {
 	CreatedAt time.Time `json:"createdAt"`
 
 	PoolAccounts []AccountID `json:"poolAccounts"`
+	Query        *string    `json:"query,omitempty"`
 }
 
 func (p Pool) MarshalJSON() ([]byte, error) {
@@ -21,6 +22,7 @@ func (p Pool) MarshalJSON() ([]byte, error) {
 		Name         string    `json:"name"`
 		CreatedAt    time.Time `json:"createdAt"`
 		PoolAccounts []string  `json:"poolAccounts"`
+		Query        *string   `json:"query,omitempty"`
 	}
 
 	aux.ID = p.ID.String()
@@ -31,6 +33,7 @@ func (p Pool) MarshalJSON() ([]byte, error) {
 	for i := range p.PoolAccounts {
 		aux.PoolAccounts[i] = p.PoolAccounts[i].String()
 	}
+	aux.Query = p.Query
 
 	return json.Marshal(aux)
 }
@@ -41,6 +44,7 @@ func (p *Pool) UnmarshalJSON(data []byte) error {
 		Name         string    `json:"name"`
 		CreatedAt    time.Time `json:"createdAt"`
 		PoolAccounts []string  `json:"poolAccounts"`
+		Query        *string   `json:"query"`
 	}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -65,6 +69,7 @@ func (p *Pool) UnmarshalJSON(data []byte) error {
 	p.Name = aux.Name
 	p.CreatedAt = aux.CreatedAt
 	p.PoolAccounts = poolAccounts
+	p.Query = aux.Query
 
 	return nil
 }
@@ -77,9 +82,11 @@ func (p *Pool) IdempotencyKey() string {
 	var ik = struct {
 		ID              string
 		RelatedAccounts []string
+		Query           *string
 	}{
 		ID:              p.ID.String(),
 		RelatedAccounts: relatedAccounts,
+		Query:           p.Query,
 	}
 	return IdempotencyKey(ik)
 }

--- a/internal/storage/migrations/23-pools-query.sql
+++ b/internal/storage/migrations/23-pools-query.sql
@@ -1,0 +1,6 @@
+ALTER TABLE pools
+    ADD COLUMN IF NOT EXISTS query jsonb;
+
+-- Optional index to speed up querying dynamic pools by query content if needed later
+-- CREATE INDEX IF NOT EXISTS pools_query_gin ON pools USING GIN (query);
+

--- a/internal/storage/migrations/migrations.go
+++ b/internal/storage/migrations/migrations.go
@@ -48,6 +48,8 @@ var psuConnectionPaymentsAccounts string
 
 //go:embed 22-rename-bank-bridges-open-banking.sql
 var renameBankBridgesOpenBanking string
+//go:embed 23-pools-query.sql
+var poolsQuery string
 
 func registerMigrations(logger logging.Logger, migrator *migrations.Migrator, encryptionKey string) {
 	migrator.RegisterMigrations(
@@ -318,6 +320,17 @@ func registerMigrations(logger logging.Logger, migrator *migrations.Migrator, en
 					logger.Info("running rename bank bridges to open banking migration...")
 					_, err := tx.ExecContext(ctx, renameBankBridgesOpenBanking)
 					logger.WithField("error", err).Info("finished running rename bank bridges open banking migration")
+					return err
+				})
+			},
+		},
+		migrations.Migration{
+			Name: "pools query column",
+			Up: func(ctx context.Context, db bun.IDB) error {
+				return db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+					logger.Info("running pools query column migration...")
+					_, err := tx.ExecContext(ctx, poolsQuery)
+					logger.WithField("error", err).Info("finished running pools query column migration")
 					return err
 				})
 			},

--- a/openapi/v3/v3-schemas.yaml
+++ b/openapi/v3/v3-schemas.yaml
@@ -1553,7 +1553,6 @@ components:
       type: object
       required:
         - name
-        - accountIDs
       properties:
         name:
           type: string
@@ -1561,6 +1560,9 @@ components:
           type: array
           items:
             type: string
+        query:
+          type: string
+          description: JSON query builder to dynamically include accounts. Mutually exclusive with accountIDs.
 
     V3CreatePoolResponse:
       type: object
@@ -1637,6 +1639,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/V3AccountID'
+        query:
+          type: string
+          description: JSON query defining dynamic membership for the pool.
 
     V3PoolBalances:
       type: array


### PR DESCRIPTION
Add support for dynamic pool membership, allowing pools to be defined by an account-finding query instead of a static list of account IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-504f7dfd-5054-4c95-9075-8a98bda68dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-504f7dfd-5054-4c95-9075-8a98bda68dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

