### PR TITLE
fix(server): Ensure that OTLP middleware doesn't write body before http recoverer can write status code 500

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/go-libs/v3/api"
 	"github.com/formancehq/go-libs/v3/auth"
 	"github.com/formancehq/go-libs/v3/health"
+	"github.com/formancehq/go-libs/v3/service"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -40,13 +41,14 @@ func NewRouter(
 	debug bool,
 	versions ...Version) *chi.Mux {
 	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
 	r.Use(func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			handler.ServeHTTP(w, r)
 		})
 	})
+	r.Use(service.OTLPMiddleware("payments", debug))
+	r.Use(middleware.Recoverer)
 	r.Get("/_healthcheck", healthController.Check)
 	r.Get("/_info", api.InfoHandler(info))
 

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v3/auth"
-	"github.com/formancehq/go-libs/v3/service"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/go-chi/chi/v5"
@@ -15,8 +14,6 @@ func newRouter(backend backend.Backend, a auth.Authenticator, debug bool) *chi.M
 	validator := validation.NewValidator()
 
 	r.Group(func(r chi.Router) {
-		r.Use(service.OTLPMiddleware("payments", debug))
-
 		// Public routes
 		r.Group(func(r chi.Router) {
 			r.Post("/connectors/webhooks/{connector}/connectorID", connectorsWebhooks(backend))

--- a/internal/api/v3/router.go
+++ b/internal/api/v3/router.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v3/auth"
-	"github.com/formancehq/go-libs/v3/service"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
 	"github.com/go-chi/chi/v5"
@@ -15,8 +14,6 @@ func newRouter(backend backend.Backend, a auth.Authenticator, debug bool) *chi.M
 	validator := validation.NewValidator()
 
 	r.Group(func(r chi.Router) {
-		r.Use(service.OTLPMiddleware("payments", debug))
-
 		// Public routes
 		r.Group(func(r chi.Router) {
 			r.Handle("/connectors/webhooks/{connectorID}/*", connectorsWebhooks(backend))


### PR DESCRIPTION
Fixes: CONN-125

The order in which we call middleware is important. What is declared first will be on the "outside".

The OTLP middleware writes to the http response writer and therefore needs to be on the outside, because status code declaration (inside the Recoverer) must take place before the call to Write.