### PR TITLE
Improve create-link error handling

### DIFF
--- a/internal/connectors/engine/engine.go
+++ b/internal/connectors/engine/engine.go
@@ -996,6 +996,9 @@ func (e *engine) CreatePaymentServiceUserLink(ctx context.Context, applicationNa
 	openBankingForwardedUser, err := e.storage.OpenBankingForwardedUserGet(ctx, psuID, connectorID)
 	if err != nil {
 		otel.RecordError(span, err)
+		if errors.Is(err, storage.ErrNotFound) {
+			return "", "", fmt.Errorf("payment service user has not been forwarded to connector '%s'. Please forward the payment service user to the connector before creating a link: %w", connectorID, ErrValidation)
+		}
 		return "", "", err
 	}
 
@@ -1089,6 +1092,9 @@ func (e *engine) UpdatePaymentServiceUserLink(ctx context.Context, applicationNa
 	openBankingForwardedUser, err := e.storage.OpenBankingForwardedUserGet(ctx, psuID, connectorID)
 	if err != nil {
 		otel.RecordError(span, err)
+		if errors.Is(err, storage.ErrNotFound) {
+			return "", "", fmt.Errorf("payment service user has not been forwarded to connector '%s'. Please forward the payment service user to the connector before updating a link: %w", connectorID, ErrValidation)
+		}
 		return "", "", err
 	}
 

--- a/internal/connectors/engine/engine_test.go
+++ b/internal/connectors/engine/engine_test.go
@@ -917,7 +917,8 @@ var _ = Describe("Engine Tests", func() {
 			store.EXPECT().OpenBankingForwardedUserGet(gomock.Any(), psuID, connectorID).Return(nil, storage.ErrNotFound)
 			_, _, err := eng.CreatePaymentServiceUserLink(ctx, "Test", psuID, connectorID, idempotencyKey, clientRedirectURL)
 			Expect(err).NotTo(BeNil())
-			Expect(err).To(MatchError(storage.ErrNotFound))
+			Expect(err).To(MatchError(ContainSubstring("payment service user has not been forwarded to connector")))
+			Expect(err).To(MatchError(ContainSubstring("Please forward the payment service user to the connector before creating a link")))
 		})
 
 		It("should return error when connection attempt upsert fails", func(ctx SpecContext) {
@@ -1045,7 +1046,8 @@ var _ = Describe("Engine Tests", func() {
 			store.EXPECT().OpenBankingForwardedUserGet(gomock.Any(), psuID, connectorID).Return(nil, storage.ErrNotFound)
 			_, _, err := eng.UpdatePaymentServiceUserLink(ctx, "Test", psuID, connectorID, connectionID, idempotencyKey, clientRedirectURL)
 			Expect(err).NotTo(BeNil())
-			Expect(err).To(MatchError(storage.ErrNotFound))
+			Expect(err).To(MatchError(ContainSubstring("payment service user has not been forwarded to connector")))
+			Expect(err).To(MatchError(ContainSubstring("Please forward the payment service user to the connector before updating a link")))
 		})
 
 		It("should return error when connection not found", func(ctx SpecContext) {


### PR DESCRIPTION
Improve error message for `create-link` and `update-link` operations when the Payment Service User (PSU) has not been forwarded to the connector.

Previously, calling `create-link` or `update-link` without a pre-forwarded PSU resulted in a generic "not found" error. This change provides a specific error message guiding the user to first forward the PSU to the connector.

---
[Slack Thread](https://numary.slack.com/archives/D09KATMKFUH/p1765448973836449?thread_ts=1765448973.836449&cid=D09KATMKFUH)

<a href="https://cursor.com/background-agent?bcId=bc-23f1be5b-8ad6-4e86-a9a8-0230e65a1dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23f1be5b-8ad6-4e86-a9a8-0230e65a1dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear validation errors for create-link and update-link when the PSU hasn’t been forwarded to the connector, replacing the generic “not found” response. This guides users to forward the PSU before linking.

- **Bug Fixes**
  - Engine maps storage.ErrNotFound to a validation error with an actionable message for both create and update link flows.
  - Tests updated: unit tests assert the new error text; added an e2e test for create-link without a forwarded PSU.

<sup>Written for commit 06102d4265562169c26c788db4a57a3c7c1c17b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

