### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -84,6 +84,7 @@ func commonOptions(cmd *cobra.Command) (fx.Option, error) {
 		}),
 		health.Module(),
 		publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
+		fx.Supply(connectionOptions),
 		licence.FXModuleFromFlags(cmd, ServiceName),
 		storage.Module(cmd, *connectionOptions, configEncryptionKey),
 		profiling.FXModuleFromFlags(cmd),


### PR DESCRIPTION
Add `fx.Supply(connectionOptions)` to provide DB connection options to the fx container.

The Circuit Breaker storage module requires `*bunconnect.ConnectionOptions` as an fx dependency, which was previously not supplied, preventing it from creating its DB connection when active.

---
<a href="https://cursor.com/background-agent?bcId=bc-808a12a2-7bae-4b65-9398-765381c55b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-808a12a2-7bae-4b65-9398-765381c55b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

