### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -84,5 +84,6 @@ func commonOptions(cmd *cobra.Command) (fx.Option, error) {
 		licence.FXModuleFromFlags(cmd, ServiceName),
 		storage.Module(cmd, *connectionOptions, configEncryptionKey),
 		profiling.FXModuleFromFlags(cmd),
+		fx.Supply(connectionOptions),
 	), nil
 }


### PR DESCRIPTION
Supply database connection options to the Fx container to resolve a Circuit Breaker module dependency.

The Circuit Breaker storage module required `*bunconnect.ConnectionOptions` as an Fx dependency to create its database connection, but these options were not being supplied to the Fx container.

---
<a href="https://cursor.com/background-agent?bcId=bc-365fe254-1507-4685-a098-1673bb2006e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-365fe254-1507-4685-a098-1673bb2006e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

