### PR TITLE
feat: add Teller open banking connector plugin

### DIFF
--- a/internal/connectors/plugins/public/list.go
+++ b/internal/connectors/plugins/public/list.go
@@ -18,6 +18,7 @@ import (
     _ "github.com/formancehq/payments/internal/connectors/plugins/public/powens"
     _ "github.com/formancehq/payments/internal/connectors/plugins/public/qonto"
     _ "github.com/formancehq/payments/internal/connectors/plugins/public/stripe"
+    _ "github.com/formancehq/payments/internal/connectors/plugins/public/teller"
     _ "github.com/formancehq/payments/internal/connectors/plugins/public/tink"
     _ "github.com/formancehq/payments/internal/connectors/plugins/public/wise"
 )

--- a/internal/connectors/plugins/public/teller/accounts.go
+++ b/internal/connectors/plugins/public/teller/accounts.go
@@ -1,0 +1,79 @@
+package teller
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/payments/internal/connectors/plugins/public/teller/client"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/google/uuid"
+)
+
+type tellerAccountWithBalance struct {
+	Account client.Account  `json:"account"`
+	Balance *client.Balance `json:"balance"`
+}
+
+func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
+	var from models.OpenBankingForwardedUserFromPayload
+	if err := json.Unmarshal(req.FromPayload, &from); err != nil {
+		return models.FetchNextAccountsResponse{}, err
+	}
+
+	accessToken := from.OpenBankingConnection.AccessToken.Token
+
+	tellerAccounts, err := p.client.ListAccounts(ctx, accessToken)
+	if err != nil {
+		return models.FetchNextAccountsResponse{}, err
+	}
+
+	accounts := make([]models.PSPAccount, 0, len(tellerAccounts))
+	for _, account := range tellerAccounts {
+		// Fetch balance for each account and embed in Raw
+		balance, err := p.client.GetBalance(ctx, accessToken, account.ID)
+		if err != nil {
+			// Log but don't fail — balance fetch might fail for some account types
+			p.logger.Errorf("failed to fetch balance for account %s: %v", account.ID, err)
+			balance = nil
+		}
+
+		pspAccount := translateTellerAccountToPSPAccount(account, balance, from.PSUID, from.OpenBankingConnection.ConnectionID)
+		accounts = append(accounts, pspAccount)
+	}
+
+	return models.FetchNextAccountsResponse{
+		Accounts: accounts,
+	}, nil
+}
+
+func translateTellerAccountToPSPAccount(account client.Account, balance *client.Balance, psuID uuid.UUID, connectionID string) models.PSPAccount {
+	combined := tellerAccountWithBalance{
+		Account: account,
+		Balance: balance,
+	}
+	raw, err := json.Marshal(combined)
+	if err != nil {
+		return models.PSPAccount{}
+	}
+
+	curr := strings.ToUpper(account.Currency)
+
+	return models.PSPAccount{
+		Reference:               account.ID,
+		CreatedAt:               time.Now().UTC(),
+		Name:                    &account.Name,
+		DefaultAsset:            pointer.For(curr + "/2"),
+		PsuID:                   &psuID,
+		OpenBankingConnectionID: &connectionID,
+		Metadata: map[string]string{
+			"accountType":    account.Type,
+			"accountSubtype": account.Subtype,
+			"institution":    account.Institution.Name,
+			"lastFour":       account.LastFour,
+		},
+		Raw: raw,
+	}
+}

--- a/internal/connectors/plugins/public/teller/balances.go
+++ b/internal/connectors/plugins/public/teller/balances.go
@@ -1,0 +1,71 @@
+package teller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/currency"
+	"github.com/formancehq/payments/internal/models"
+)
+
+func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBalancesRequest) (models.FetchNextBalancesResponse, error) {
+	var pspAccount models.PSPAccount
+	if err := json.Unmarshal(req.FromPayload, &pspAccount); err != nil {
+		return models.FetchNextBalancesResponse{}, err
+	}
+
+	pspBalance, err := toPSPBalance(pspAccount)
+	if err != nil {
+		return models.FetchNextBalancesResponse{}, err
+	}
+
+	return models.FetchNextBalancesResponse{
+		Balances: []models.PSPBalance{pspBalance},
+	}, nil
+}
+
+func toPSPBalance(pspAccount models.PSPAccount) (models.PSPBalance, error) {
+	var accountWithBalance tellerAccountWithBalance
+	if err := json.Unmarshal(pspAccount.Raw, &accountWithBalance); err != nil {
+		return models.PSPBalance{}, err
+	}
+
+	if accountWithBalance.Balance == nil {
+		return models.PSPBalance{}, fmt.Errorf("balance is not available for account %s", accountWithBalance.Account.ID)
+	}
+
+	balance := accountWithBalance.Balance
+
+	// Prefer available balance over ledger
+	amountStr := balance.Available
+	if amountStr == "" {
+		amountStr = balance.Ledger
+	}
+	if amountStr == "" {
+		return models.PSPBalance{}, fmt.Errorf("no balance value available for account %s", accountWithBalance.Account.ID)
+	}
+
+	curr := strings.ToUpper(accountWithBalance.Account.Currency)
+
+	precision, err := currency.GetPrecision(supportedCurrenciesWithDecimal, curr)
+	if err != nil {
+		return models.PSPBalance{}, err
+	}
+
+	amount, err := currency.GetAmountWithPrecisionFromString(amountStr, precision)
+	if err != nil {
+		return models.PSPBalance{}, err
+	}
+
+	return models.PSPBalance{
+		AccountReference:        accountWithBalance.Account.ID,
+		CreatedAt:               time.Now().UTC(),
+		Amount:                  amount,
+		Asset:                   currency.FormatAssetWithPrecision(curr, precision),
+		PsuID:                   pspAccount.PsuID,
+		OpenBankingConnectionID: pspAccount.OpenBankingConnectionID,
+	}, nil
+}

--- a/internal/connectors/plugins/public/teller/capabilities.go
+++ b/internal/connectors/plugins/public/teller/capabilities.go
@@ -1,0 +1,9 @@
+package teller
+
+import "github.com/formancehq/payments/internal/models"
+
+var capabilities = []models.Capability{
+	models.CAPABILITY_FETCH_ACCOUNTS,
+	models.CAPABILITY_FETCH_BALANCES,
+	models.CAPABILITY_FETCH_PAYMENTS,
+}

--- a/internal/connectors/plugins/public/teller/client/client.go
+++ b/internal/connectors/plugins/public/teller/client/client.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/formancehq/payments/internal/connectors/metrics"
+	"github.com/formancehq/payments/internal/models"
+)
+
+const (
+	sandboxBaseURL    = "https://api.teller.io"
+	productionBaseURL = "https://api.teller.io"
+)
+
+// Teller API model types
+
+type Account struct {
+	ID            string          `json:"id"`
+	Currency      string          `json:"currency"`
+	EnrollmentID  string          `json:"enrollment_id"`
+	Institution   Institution     `json:"institution"`
+	LastFour      string          `json:"last_four"`
+	Links         json.RawMessage `json:"links"`
+	Name          string          `json:"name"`
+	Status        string          `json:"status"`
+	Subtype       string          `json:"subtype"`
+	Type          string          `json:"type"`
+}
+
+type Institution struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Balance struct {
+	AccountID string `json:"account_id"`
+	Available string `json:"available"`
+	Ledger    string `json:"ledger"`
+	Links     json.RawMessage `json:"links"`
+}
+
+type Transaction struct {
+	ID          string          `json:"id"`
+	AccountID   string          `json:"account_id"`
+	Amount      string          `json:"amount"`
+	Date        string          `json:"date"`
+	Description string          `json:"description"`
+	Details     TransactionDetails `json:"details"`
+	Links       json.RawMessage `json:"links"`
+	RunningBalance *string      `json:"running_balance"`
+	Status      string          `json:"status"`
+	Type        string          `json:"type"`
+}
+
+type TransactionDetails struct {
+	Category      string `json:"category"`
+	Counterparty  Counterparty `json:"counterparty"`
+	ProcessingStatus string `json:"processing_status"`
+}
+
+type Counterparty struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+//go:generate mockgen -source client.go -destination client_generated.go -package client . Client
+type Client interface {
+	ListAccounts(ctx context.Context, accessToken string) ([]Account, error)
+	GetBalance(ctx context.Context, accessToken string, accountID string) (*Balance, error)
+	ListTransactions(ctx context.Context, accessToken string, accountID string, fromID string, count int) ([]Transaction, error)
+}
+
+type client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func New(connectorName string, isSandbox bool) Client {
+	baseURL := productionBaseURL
+	if isSandbox {
+		baseURL = sandboxBaseURL
+	}
+
+	return &client{
+		httpClient: metrics.NewHTTPClient(connectorName, models.DefaultConnectorClientTimeout),
+		baseURL:    baseURL,
+	}
+}
+
+func (c *client) ListAccounts(ctx context.Context, accessToken string) ([]Account, error) {
+	ctx = metrics.OperationContext(ctx, "list_accounts")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/accounts", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.SetBasicAuth(accessToken, "")
+
+	var accounts []Account
+	if err := c.do(req, &accounts); err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+func (c *client) GetBalance(ctx context.Context, accessToken string, accountID string) (*Balance, error) {
+	ctx = metrics.OperationContext(ctx, "get_balance")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/accounts/%s/balances", c.baseURL, accountID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.SetBasicAuth(accessToken, "")
+
+	var balance Balance
+	if err := c.do(req, &balance); err != nil {
+		return nil, err
+	}
+	return &balance, nil
+}
+
+func (c *client) ListTransactions(ctx context.Context, accessToken string, accountID string, fromID string, count int) ([]Transaction, error) {
+	ctx = metrics.OperationContext(ctx, "list_transactions")
+
+	url := fmt.Sprintf("%s/accounts/%s/transactions", c.baseURL, accountID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.SetBasicAuth(accessToken, "")
+
+	q := req.URL.Query()
+	if fromID != "" {
+		q.Set("from_id", fromID)
+	}
+	if count > 0 {
+		q.Set("count", fmt.Sprintf("%d", count))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	var transactions []Transaction
+	if err := c.do(req, &transactions); err != nil {
+		return nil, err
+	}
+	return transactions, nil
+}
+
+func (c *client) do(req *http.Request, v any) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := resp.Header.Get("Retry-After")
+		return fmt.Errorf("rate limited by teller (retry-after: %s)", retryAfter)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		var tellerErr struct {
+			Error struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if decErr := json.NewDecoder(resp.Body).Decode(&tellerErr); decErr == nil && tellerErr.Error.Code != "" {
+			return fmt.Errorf("teller API error (status %d): %s: %s", resp.StatusCode, tellerErr.Error.Code, tellerErr.Error.Message)
+		}
+		return fmt.Errorf("teller API error: unexpected status code %d", resp.StatusCode)
+	}
+
+	if v != nil {
+		if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+	}
+
+	return nil
+}
+

--- a/internal/connectors/plugins/public/teller/cmd/sandbox-test/main.go
+++ b/internal/connectors/plugins/public/teller/cmd/sandbox-test/main.go
@@ -1,0 +1,151 @@
+//go:build ignore
+
+// Quick sandbox test for the Teller connector.
+// Run: go run ./internal/connectors/plugins/public/teller/cmd/sandbox-test/
+//
+// This starts a local server that:
+// 1. Serves a page with the Teller Connect widget (sandbox mode)
+// 2. After enrollment, captures the access token
+// 3. Tests the Teller API endpoints via our client
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	tellerclient "github.com/formancehq/payments/internal/connectors/plugins/public/teller/client"
+)
+
+const applicationID = "app_pov8nkrv5e98k7qnq8000"
+
+func main() {
+	port := "9876"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
+
+	c := tellerclient.New("teller-sandbox-test", true)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, indexHTML, applicationID)
+	})
+
+	http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		accessToken := r.URL.Query().Get("access_token")
+		enrollmentID := r.URL.Query().Get("enrollment_id")
+		if accessToken == "" {
+			http.Error(w, "missing access_token", 400)
+			return
+		}
+
+		log.Printf("=== Enrollment complete ===")
+		log.Printf("  access_token:  %s", accessToken)
+		log.Printf("  enrollment_id: %s", enrollmentID)
+
+		ctx := context.Background()
+
+		// Test 1: List accounts
+		log.Printf("\n--- List Accounts ---")
+		accounts, err := c.ListAccounts(ctx, accessToken)
+		if err != nil {
+			log.Printf("ERROR listing accounts: %v", err)
+			http.Error(w, fmt.Sprintf("list accounts failed: %v", err), 500)
+			return
+		}
+		for _, a := range accounts {
+			log.Printf("  Account: %s (%s/%s) at %s", a.ID, a.Type, a.Subtype, a.Institution.Name)
+		}
+
+		// Test 2: Get balances for each account
+		log.Printf("\n--- Get Balances ---")
+		for _, a := range accounts {
+			bal, err := c.GetBalance(ctx, accessToken, a.ID)
+			if err != nil {
+				log.Printf("  ERROR balance for %s: %v", a.ID, err)
+				continue
+			}
+			log.Printf("  Balance for %s: available=%s, ledger=%s", a.ID, bal.Available, bal.Ledger)
+		}
+
+		// Test 3: List transactions for each account
+		log.Printf("\n--- List Transactions ---")
+		for _, a := range accounts {
+			txns, err := c.ListTransactions(ctx, accessToken, a.ID, "", 5)
+			if err != nil {
+				log.Printf("  ERROR transactions for %s: %v", a.ID, err)
+				continue
+			}
+			log.Printf("  Transactions for %s (%d returned):", a.ID, len(txns))
+			for _, tx := range txns {
+				log.Printf("    %s | %s | %s | %s | %s", tx.ID, tx.Date, tx.Amount, tx.Description, tx.Status)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		result := map[string]interface{}{
+			"status":        "ok",
+			"accounts":      len(accounts),
+			"access_token":  accessToken,
+			"enrollment_id": enrollmentID,
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+
+	log.Printf("Starting Teller sandbox test server on http://localhost:%s", port)
+	log.Printf("Open the URL in your browser, click Connect, use credentials: username / password")
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+const indexHTML = `<!DOCTYPE html>
+<html>
+<head><title>Teller Sandbox Test</title></head>
+<body>
+  <h1>Teller Sandbox Test</h1>
+  <p>Click the button below to open Teller Connect (sandbox mode).</p>
+  <p>Use credentials: <b>username</b> / <b>password</b></p>
+  <button id="connect-btn" style="font-size:18px;padding:12px 24px;cursor:pointer">Connect Bank Account</button>
+  <pre id="result" style="margin-top:20px;background:#f4f4f4;padding:16px;display:none"></pre>
+
+  <script src="https://cdn.teller.io/connect/connect.js"></script>
+  <script>
+    var tellerConnect = TellerConnect.setup({
+      applicationId: "%s",
+      environment: "sandbox",
+      onSuccess: function(enrollment) {
+        console.log("Enrollment success:", enrollment);
+        var params = new URLSearchParams({
+          access_token: enrollment.accessToken,
+          enrollment_id: enrollment.enrollment.id,
+          institution: enrollment.enrollment.institution.name,
+        });
+        fetch("/callback?" + params.toString())
+          .then(r => r.json())
+          .then(data => {
+            document.getElementById("result").style.display = "block";
+            document.getElementById("result").textContent = JSON.stringify(data, null, 2);
+          })
+          .catch(err => {
+            document.getElementById("result").style.display = "block";
+            document.getElementById("result").textContent = "Error: " + err;
+          });
+      },
+      onFailure: function(failure) {
+        console.error("Enrollment failed:", failure);
+        alert("Enrollment failed: " + JSON.stringify(failure));
+      },
+      onExit: function() {
+        console.log("User exited Teller Connect");
+      }
+    });
+    document.getElementById("connect-btn").addEventListener("click", function() {
+      tellerConnect.open();
+    });
+  </script>
+</body>
+</html>
+`

--- a/internal/connectors/plugins/public/teller/cmd/sandbox-test/main.go
+++ b/internal/connectors/plugins/public/teller/cmd/sandbox-test/main.go
@@ -1,12 +1,19 @@
 //go:build ignore
 
 // Quick sandbox test for the Teller connector.
-// Run: go run ./internal/connectors/plugins/public/teller/cmd/sandbox-test/
+// Run: go run ./internal/connectors/plugins/public/teller/cmd/sandbox-test/main.go
 //
 // This starts a local server that:
-// 1. Serves a page with the Teller Connect widget (sandbox mode)
+// 1. Serves a page with the Teller Connect widget (sandbox mode) (by default on http://localhost:9876)
 // 2. After enrollment, captures the access token
 // 3. Tests the Teller API endpoints via our client
+//
+// If you want to test the actual plugin, still use this endpoint after doing the usual connector install, PSU creation
+// PSU forward and PSU link creation. Take note of the attemptID.
+// As the link is not a real link, use the enrollment ID generated here to manually create the link:
+// In addition, we need the state, which is can be generated like so:
+// `echo '{"attemptId": "<attemptId>"}' | base64`
+// <paymentURL>/v3/connectors/open-banking/<connectorID>/?state=<state>&access_token=<accessToken>&enrollment_id=<enrollmentID>
 package main
 
 import (

--- a/internal/connectors/plugins/public/teller/complete_user_link.go
+++ b/internal/connectors/plugins/public/teller/complete_user_link.go
@@ -1,0 +1,53 @@
+package teller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+const (
+	AccessTokenQueryParam  = "access_token"
+	EnrollmentIDQueryParam = "enrollment_id"
+)
+
+func validateCompleteUserLinkRequest(req models.CompleteUserLinkRequest) error {
+	if req.HTTPCallInformation.QueryValues == nil {
+		return fmt.Errorf("missing query values: %w", models.ErrInvalidRequest)
+	}
+
+	if _, ok := req.HTTPCallInformation.QueryValues[AccessTokenQueryParam]; !ok {
+		return fmt.Errorf("missing access_token: %w", models.ErrInvalidRequest)
+	}
+
+	if _, ok := req.HTTPCallInformation.QueryValues[EnrollmentIDQueryParam]; !ok {
+		return fmt.Errorf("missing enrollment_id: %w", models.ErrInvalidRequest)
+	}
+
+	return nil
+}
+
+func (p *Plugin) completeUserLink(ctx context.Context, req models.CompleteUserLinkRequest) (models.CompleteUserLinkResponse, error) {
+	if err := validateCompleteUserLinkRequest(req); err != nil {
+		return models.CompleteUserLinkResponse{}, err
+	}
+
+	accessToken := req.HTTPCallInformation.QueryValues[AccessTokenQueryParam][0]
+	enrollmentID := req.HTTPCallInformation.QueryValues[EnrollmentIDQueryParam][0]
+
+	return models.CompleteUserLinkResponse{
+		Success: &models.UserLinkSuccessResponse{
+			Connections: []models.PSPOpenBankingConnection{
+				{
+					CreatedAt:    time.Now().UTC(),
+					ConnectionID: enrollmentID,
+					AccessToken: &models.Token{
+						Token: accessToken,
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/connectors/plugins/public/teller/config.go
+++ b/internal/connectors/plugins/public/teller/config.go
@@ -1,0 +1,25 @@
+package teller
+
+import (
+	"encoding/json"
+
+	"github.com/formancehq/payments/internal/models"
+	"github.com/go-playground/validator/v10"
+	"github.com/pkg/errors"
+)
+
+const PAGE_SIZE = 100
+
+type Config struct {
+	ApplicationID string `json:"applicationID" validate:"required"`
+	IsSandbox     bool   `json:"isSandbox" validate:""`
+}
+
+func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
+	var config Config
+	if err := json.Unmarshal(payload, &config); err != nil {
+		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())
+	}
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	return config, validate.Struct(config)
+}

--- a/internal/connectors/plugins/public/teller/create_user.go
+++ b/internal/connectors/plugins/public/teller/create_user.go
@@ -1,0 +1,15 @@
+package teller
+
+import (
+	"context"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+func (p *Plugin) createUser(ctx context.Context, req models.CreateUserRequest) (models.CreateUserResponse, error) {
+	// Teller Connect is a client-side JS widget. There is no server-side
+	// user creation — this is a no-op.
+	return models.CreateUserResponse{
+		Metadata: map[string]string{},
+	}, nil
+}

--- a/internal/connectors/plugins/public/teller/create_user_link.go
+++ b/internal/connectors/plugins/public/teller/create_user_link.go
@@ -1,0 +1,37 @@
+package teller
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+type tellerConnectConfig struct {
+	ApplicationID string `json:"applicationID"`
+	Environment   string `json:"environment"`
+}
+
+func (p *Plugin) createUserLink(ctx context.Context, req models.CreateUserLinkRequest) (models.CreateUserLinkResponse, error) {
+	environment := "production"
+	if p.config.IsSandbox {
+		environment = "sandbox"
+	}
+
+	cfg := tellerConnectConfig{
+		ApplicationID: p.config.ApplicationID,
+		Environment:   environment,
+	}
+
+	linkPayload, err := json.Marshal(cfg)
+	if err != nil {
+		return models.CreateUserLinkResponse{}, err
+	}
+
+	// Teller Connect is a JS widget, not a redirect URL.
+	// The Link field carries a JSON payload that the frontend uses to
+	// initialize the Teller Connect widget.
+	return models.CreateUserLinkResponse{
+		Link: string(linkPayload),
+	}, nil
+}

--- a/internal/connectors/plugins/public/teller/currencies.go
+++ b/internal/connectors/plugins/public/teller/currencies.go
@@ -1,0 +1,5 @@
+package teller
+
+import "github.com/formancehq/go-libs/v3/currency"
+
+var supportedCurrenciesWithDecimal = currency.ISO4217Currencies

--- a/internal/connectors/plugins/public/teller/payments.go
+++ b/internal/connectors/plugins/public/teller/payments.go
@@ -1,0 +1,156 @@
+package teller
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/formancehq/go-libs/v3/currency"
+	"github.com/formancehq/payments/internal/connectors/plugins/public/teller/client"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/google/uuid"
+)
+
+type paymentsState struct {
+	LastTransactionID string `json:"lastTransactionID"`
+}
+
+func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
+	var oldState paymentsState
+	if req.State != nil {
+		if err := json.Unmarshal(req.State, &oldState); err != nil {
+			return models.FetchNextPaymentsResponse{}, err
+		}
+	}
+
+	var from models.OpenBankingForwardedUserFromPayload
+	if err := json.Unmarshal(req.FromPayload, &from); err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+
+	// The accountID is carried in the inner FromPayload as a string
+	var accountID string
+	if err := json.Unmarshal(from.FromPayload, &accountID); err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+
+	accessToken := from.OpenBankingConnection.AccessToken.Token
+
+	transactions, err := p.client.ListTransactions(
+		ctx,
+		accessToken,
+		accountID,
+		oldState.LastTransactionID,
+		req.PageSize,
+	)
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+
+	payments := make([]models.PSPPayment, 0, len(transactions))
+	for _, tx := range transactions {
+		payment, err := translateTellerTransactionToPSPPayment(tx, from.PSUID, from.OpenBankingConnection.ConnectionID)
+		if err != nil {
+			return models.FetchNextPaymentsResponse{}, err
+		}
+		payments = append(payments, payment)
+	}
+
+	newState := paymentsState{
+		LastTransactionID: oldState.LastTransactionID,
+	}
+	if len(transactions) > 0 {
+		newState.LastTransactionID = transactions[len(transactions)-1].ID
+	}
+
+	payload, err := json.Marshal(newState)
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+
+	return models.FetchNextPaymentsResponse{
+		Payments: payments,
+		NewState: payload,
+		HasMore:  len(transactions) == req.PageSize,
+	}, nil
+}
+
+func translateTellerTransactionToPSPPayment(tx client.Transaction, psuID uuid.UUID, connectionID string) (models.PSPPayment, error) {
+	// Parse amount string to determine direction
+	// Teller returns amounts as strings like "-100.50" or "200.00"
+	amountStr := tx.Amount
+	isNegative := strings.HasPrefix(amountStr, "-")
+	if isNegative {
+		amountStr = amountStr[1:]
+	}
+
+	var sourceAccountReference *string
+	var destinationAccountReference *string
+	var paymentType models.PaymentType
+	if isNegative {
+		// Negative amount = money leaving the account = PAYOUT
+		paymentType = models.PAYMENT_TYPE_PAYOUT
+		sourceAccountReference = &tx.AccountID
+	} else {
+		// Positive amount = money entering the account = PAYIN
+		paymentType = models.PAYMENT_TYPE_PAYIN
+		destinationAccountReference = &tx.AccountID
+	}
+
+	// Teller is USD-only for this prototype
+	curr := "USD"
+	precision, err := currency.GetPrecision(supportedCurrenciesWithDecimal, curr)
+	if err != nil {
+		return models.PSPPayment{}, err
+	}
+
+	amount, err := currency.GetAmountWithPrecisionFromString(amountStr, precision)
+	if err != nil {
+		return models.PSPPayment{}, err
+	}
+
+	// Ensure amount is non-negative (absolute value)
+	if amount.Sign() < 0 {
+		amount = new(big.Int).Abs(amount)
+	}
+
+	assetName := currency.FormatAssetWithPrecision(curr, precision)
+
+	createdAt, err := time.Parse(time.DateOnly, tx.Date)
+	if err != nil {
+		createdAt = time.Now().UTC()
+	}
+
+	// Map Teller status to payment status
+	var status models.PaymentStatus
+	switch tx.Status {
+	case "posted":
+		status = models.PAYMENT_STATUS_SUCCEEDED
+	case "pending":
+		status = models.PAYMENT_STATUS_PENDING
+	default:
+		status = models.PAYMENT_STATUS_OTHER
+	}
+
+	raw, err := json.Marshal(tx)
+	if err != nil {
+		return models.PSPPayment{}, err
+	}
+
+	return models.PSPPayment{
+		Reference:                   tx.ID,
+		CreatedAt:                   createdAt.UTC(),
+		Type:                        paymentType,
+		Amount:                      amount,
+		Asset:                       assetName,
+		Scheme:                      models.PAYMENT_SCHEME_OTHER,
+		Status:                      status,
+		SourceAccountReference:      sourceAccountReference,
+		DestinationAccountReference: destinationAccountReference,
+		PsuID:                       &psuID,
+		OpenBankingConnectionID:     &connectionID,
+		Raw:                         raw,
+	}, nil
+}

--- a/internal/connectors/plugins/public/teller/plugin.go
+++ b/internal/connectors/plugins/public/teller/plugin.go
@@ -1,0 +1,99 @@
+package teller
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/payments/internal/connectors/plugins"
+	"github.com/formancehq/payments/internal/connectors/plugins/public/teller/client"
+	"github.com/formancehq/payments/internal/connectors/plugins/registry"
+	"github.com/formancehq/payments/internal/models"
+)
+
+const ProviderName = "teller"
+
+func init() {
+	registry.RegisterPlugin(ProviderName, models.PluginTypeOpenBanking, func(connectorID models.ConnectorID, name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
+		return New(name, logger, rm)
+	}, capabilities, Config{}, PAGE_SIZE)
+}
+
+type Plugin struct {
+	models.Plugin
+
+	name   string
+	logger logging.Logger
+
+	client client.Client
+	config Config
+}
+
+func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {
+	config, err := unmarshalAndValidateConfig(rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := client.New(name, config.IsSandbox)
+
+	return &Plugin{
+		Plugin: plugins.NewBasePlugin(),
+
+		name:   name,
+		logger: logger,
+		client: client,
+		config: config,
+	}, nil
+}
+
+func (p *Plugin) Name() string {
+	return p.name
+}
+
+func (p *Plugin) Config() models.PluginInternalConfig {
+	return p.config
+}
+
+func (p *Plugin) Install(ctx context.Context, req models.InstallRequest) (models.InstallResponse, error) {
+	return models.InstallResponse{
+		Workflow: workflow(),
+	}, nil
+}
+
+func (p *Plugin) Uninstall(ctx context.Context, req models.UninstallRequest) (models.UninstallResponse, error) {
+	return models.UninstallResponse{}, nil
+}
+
+func (p *Plugin) FetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
+	if p.client == nil {
+		return models.FetchNextAccountsResponse{}, plugins.ErrNotYetInstalled
+	}
+	return p.fetchNextAccounts(ctx, req)
+}
+
+func (p *Plugin) FetchNextBalances(ctx context.Context, req models.FetchNextBalancesRequest) (models.FetchNextBalancesResponse, error) {
+	if p.client == nil {
+		return models.FetchNextBalancesResponse{}, plugins.ErrNotYetInstalled
+	}
+	return p.fetchNextBalances(ctx, req)
+}
+
+func (p *Plugin) FetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
+	if p.client == nil {
+		return models.FetchNextPaymentsResponse{}, plugins.ErrNotYetInstalled
+	}
+	return p.fetchNextPayments(ctx, req)
+}
+
+func (p *Plugin) CreateUser(ctx context.Context, req models.CreateUserRequest) (models.CreateUserResponse, error) {
+	return p.createUser(ctx, req)
+}
+
+func (p *Plugin) CreateUserLink(ctx context.Context, req models.CreateUserLinkRequest) (models.CreateUserLinkResponse, error) {
+	return p.createUserLink(ctx, req)
+}
+
+func (p *Plugin) CompleteUserLink(ctx context.Context, req models.CompleteUserLinkRequest) (models.CompleteUserLinkResponse, error) {
+	return p.completeUserLink(ctx, req)
+}

--- a/internal/connectors/plugins/public/teller/workflow.go
+++ b/internal/connectors/plugins/public/teller/workflow.go
@@ -1,0 +1,9 @@
+package teller
+
+import "github.com/formancehq/payments/internal/models"
+
+func workflow() models.ConnectorTasksTree {
+	// Teller has no webhook API and no periodic polling for the prototype.
+	// Data fetching is triggered by open banking link completion.
+	return []models.ConnectorTaskTree{}
+}


### PR DESCRIPTION
## Summary
- Adds a new Teller connector plugin implementing the open banking interface
- Supports account fetching (with inline balances), transaction/payment fetching with pagination, and balance extraction
- Implements the full enrollment flow: CreateUser, CreateUserLink (returns Teller Connect widget config), CompleteUserLink
- Includes sandbox mode support for testing with Teller Connect test tokens
- Registers the Teller plugin in the connector registry (`list.go`)

## Test plan
- [ ] `go build ./...` compiles
- [ ] Start workbench with `go run . workbench --provider=teller --config='{"applicationID":"app_xxx","isSandbox":true}'`
- [ ] Verify sandbox enrollment flow with test token `test_token_4ym3xrehmhhla` and enrollment `enr_pov97lskpg6tn2p08m000`
- [ ] Verify accounts, payments, and balances are fetched correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Jira: [EN-193](https://formance-team.atlassian.net/browse/EN-193)


[EN-193]: https://formance-team.atlassian.net/browse/EN-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ