### PR TITLE
refactor: add pkg/connector architecture for external connectors

### DIFF
--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -1,117 +1,20 @@
+// Package httpwrapper re-exports pkg/connector/httpwrapper for internal use.
 package httpwrapper
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
-
-	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/payments/internal/models"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"golang.org/x/oauth2"
+	"github.com/formancehq/payments/pkg/connector/httpwrapper"
 )
 
+// Client is a convenience wrapper that encapsulates common code related to interacting with HTTP endpoints.
+type Client = httpwrapper.Client
+
+// NewClient creates a new HTTP client wrapper with the given configuration.
+var NewClient = httpwrapper.NewClient
+
+// Error variables re-exported from pkg/connector/httpwrapper.
 var (
-	ErrStatusCodeUnexpected      = errors.New("unexpected status code")
-	ErrStatusCodeClientError     = fmt.Errorf("%w: http client error", ErrStatusCodeUnexpected)
-	ErrStatusCodeServerError     = fmt.Errorf("%w: http server error", ErrStatusCodeUnexpected)
-	ErrStatusCodeTooManyRequests = fmt.Errorf("%w: http too many requests error", ErrStatusCodeUnexpected)
-
-	defaultHttpErrorCheckerFn = func(statusCode int) error {
-		if statusCode == http.StatusTooManyRequests {
-			return ErrStatusCodeTooManyRequests
-		}
-
-		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
-			return ErrStatusCodeClientError
-		} else if statusCode >= http.StatusInternalServerError {
-			return ErrStatusCodeServerError
-		}
-		return nil
-	}
+	ErrStatusCodeUnexpected      = httpwrapper.ErrStatusCodeUnexpected
+	ErrStatusCodeClientError     = httpwrapper.ErrStatusCodeClientError
+	ErrStatusCodeServerError     = httpwrapper.ErrStatusCodeServerError
+	ErrStatusCodeTooManyRequests = httpwrapper.ErrStatusCodeTooManyRequests
 )
-
-// Client is a convenience wrapper that encapsulates common code related to interacting with HTTP endpoints
-type Client interface {
-	// Do performs an HTTP request while handling errors and unmarshaling success and error responses into the provided interfaces
-	// expectedBody and errorBody should be pointers to structs
-	Do(ctx context.Context, req *http.Request, expectedBody, errorBody any) (statusCode int, err error)
-}
-
-type client struct {
-	httpClient *http.Client
-
-	httpErrorCheckerFn func(statusCode int) error
-}
-
-func NewClient(config *Config) Client {
-	if config.Timeout == 0 {
-		config.Timeout = models.DefaultConnectorClientTimeout
-	}
-	if config.Transport != nil {
-		config.Transport = otelhttp.NewTransport(config.Transport)
-	} else {
-		config.Transport = http.DefaultTransport.(*http.Transport).Clone()
-	}
-
-	httpClient := &http.Client{
-		Timeout:   config.Timeout,
-		Transport: config.Transport,
-	}
-	if config.OAuthConfig != nil {
-		// pass a pre-configured http client to oauth lib via the context
-		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
-		httpClient = config.OAuthConfig.Client(ctx)
-	}
-
-	if config.HttpErrorCheckerFn == nil {
-		config.HttpErrorCheckerFn = defaultHttpErrorCheckerFn
-	}
-
-	return &client{
-		httpErrorCheckerFn: config.HttpErrorCheckerFn,
-		httpClient:         httpClient,
-	}
-}
-
-func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorBody any) (int, error) {
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("failed to make request: %w", err)
-	}
-
-	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
-	// the caller doesn't care about the response body so we return early
-	if resp.Body == nil || (reqErr == nil && expectedBody == nil) || (reqErr != nil && errorBody == nil) {
-		return resp.StatusCode, reqErr
-	}
-
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			logging.FromContext(ctx).Errorf("failed to close response body: %w", err)
-		}
-	}()
-
-	// TODO: reading everything into memory might not be optimal if we expect long responses
-	rawBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp.StatusCode, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if reqErr != nil {
-		if err = json.Unmarshal(rawBody, errorBody); err != nil {
-			return resp.StatusCode, fmt.Errorf("failed to unmarshal error response (%w) with status %d: %w", err, resp.StatusCode, reqErr)
-		}
-		return resp.StatusCode, reqErr
-	}
-
-	// TODO: assuming json bodies for now, but may need to handle other body types
-	if err = json.Unmarshal(rawBody, expectedBody); err != nil {
-		return resp.StatusCode, fmt.Errorf("failed to unmarshal response with status %d: %w", resp.StatusCode, err)
-	}
-	return resp.StatusCode, nil
-}

--- a/internal/connectors/httpwrapper/config.go
+++ b/internal/connectors/httpwrapper/config.go
@@ -1,16 +1,8 @@
 package httpwrapper
 
 import (
-	"net/http"
-	"time"
-
-	"golang.org/x/oauth2/clientcredentials"
+	"github.com/formancehq/payments/pkg/connector/httpwrapper"
 )
 
-type Config struct {
-	HttpErrorCheckerFn func(code int) error
-
-	Timeout     time.Duration
-	Transport   http.RoundTripper
-	OAuthConfig *clientcredentials.Config
-}
+// Config holds the configuration for an HTTP client wrapper.
+type Config = httpwrapper.Config

--- a/internal/connectors/metrics/client.go
+++ b/internal/connectors/metrics/client.go
@@ -1,13 +1,8 @@
 package metrics
 
 import (
-	"net/http"
-	"time"
+	"github.com/formancehq/payments/pkg/connector/metrics"
 )
 
-func NewHTTPClient(connectorName string, timeout time.Duration) *http.Client {
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: NewTransport(connectorName, TransportOpts{}),
-	}
-}
+// NewHTTPClient creates a new HTTP client with metrics instrumentation.
+var NewHTTPClient = metrics.NewHTTPClient

--- a/internal/connectors/plugins/errors.go
+++ b/internal/connectors/plugins/errors.go
@@ -1,13 +1,15 @@
 package plugins
 
 import (
-	"errors"
+	"github.com/formancehq/payments/pkg/connector"
 )
 
+// Error aliases for backward compatibility.
+// The canonical definitions now live in pkg/connector.
 var (
-	ErrNotImplemented       = errors.New("not implemented")
-	ErrNotYetInstalled      = errors.New("not yet installed")
-	ErrInvalidClientRequest = errors.New("invalid client request")
-	ErrUpstreamRatelimit    = errors.New("rate limited by upstream server")
-	ErrCurrencyNotSupported = errors.New("currency not supported")
+	ErrNotImplemented       = connector.ErrNotImplemented
+	ErrNotYetInstalled      = connector.ErrNotYetInstalled
+	ErrInvalidClientRequest = connector.ErrInvalidClientRequest
+	ErrUpstreamRatelimit    = connector.ErrUpstreamRatelimit
+	ErrCurrencyNotSupported = connector.ErrCurrencyNotSupported
 )

--- a/internal/connectors/plugins/registry/configs.go
+++ b/internal/connectors/plugins/registry/configs.go
@@ -1,33 +1,22 @@
 package registry
 
-type Type string
+import (
+	pkgregistry "github.com/formancehq/payments/pkg/registry"
+)
+
+// Type aliases for backward compatibility.
+// These delegate to pkg/registry where the canonical types now live.
+type Type = pkgregistry.Type
 
 const (
-	TypeLongString      Type = "long string"
-	TypeString          Type = "string"
-	TypeDurationNs      Type = "duration ns"
-	TypeUnsignedInteger Type = "unsigned integer"
-	TypeBoolean         Type = "boolean"
+	TypeLongString      = pkgregistry.TypeLongString
+	TypeString          = pkgregistry.TypeString
+	TypeDurationNs      = pkgregistry.TypeDurationNs
+	TypeUnsignedInteger = pkgregistry.TypeUnsignedInteger
+	TypeBoolean         = pkgregistry.TypeBoolean
 )
 
-type Configs map[string]Config
-type Config map[string]Parameter
-type Parameter struct {
-	DataType     Type   `json:"dataType"`
-	Required     bool   `json:"required"`
-	DefaultValue string `json:"defaultValue"`
-}
-
-var (
-	defaultParameters = map[string]Parameter{
-		"pollingPeriod": {
-			DataType:     TypeDurationNs,
-			Required:     false,
-			DefaultValue: "30m",
-		},
-		"name": {
-			DataType: TypeString,
-			Required: true,
-		},
-	}
-)
+// Configs, Config, and Parameter are aliases to pkg/registry types.
+type Configs = pkgregistry.Configs
+type Config = pkgregistry.Config
+type Parameter = pkgregistry.Parameter

--- a/internal/connectors/plugins/registry/errors.go
+++ b/internal/connectors/plugins/registry/errors.go
@@ -4,29 +4,29 @@ import (
 	"errors"
 
 	"github.com/formancehq/payments/internal/connectors/httpwrapper"
-	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	errorsutils "github.com/formancehq/payments/internal/utils/errors"
+	"github.com/formancehq/payments/pkg/connector"
 )
 
 func translateError(err error) error {
 	switch {
-	case errors.Is(err, plugins.ErrNotImplemented):
+	case errors.Is(err, connector.ErrNotImplemented):
 		return err
 	case errors.Is(err, models.ErrMissingFromPayloadInRequest),
 		errors.Is(err, models.ErrMissingAccountInRequest),
 		errors.Is(err, models.ErrInvalidRequest),
-		errors.Is(err, plugins.ErrCurrencyNotSupported),
+		errors.Is(err, connector.ErrCurrencyNotSupported),
 		errors.Is(err, httpwrapper.ErrStatusCodeClientError),
 		errors.Is(err, models.ErrInvalidConfig):
 		return errorsutils.NewWrappedError(
 			err,
-			plugins.ErrInvalidClientRequest,
+			connector.ErrInvalidClientRequest,
 		)
 	case errors.Is(err, httpwrapper.ErrStatusCodeTooManyRequests):
 		return errorsutils.NewWrappedError(
 			err,
-			plugins.ErrUpstreamRatelimit,
+			connector.ErrUpstreamRatelimit,
 		)
 	default:
 		return err

--- a/internal/connectors/plugins/registry/plugins.go
+++ b/internal/connectors/plugins/registry/plugins.go
@@ -2,43 +2,29 @@ package registry
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"log"
-	"reflect"
-	"regexp"
+	"errors"
 	"strings"
 
 	"github.com/formancehq/go-libs/v3/logging"
 	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/pkg/connector"
+	pkgregistry "github.com/formancehq/payments/pkg/registry"
 )
 
-const DummyPSPName = "dummypay"
+// DummyPSPName is an alias to pkg/registry for backward compatibility.
+const DummyPSPName = pkgregistry.DummyPSPName
 
-type PluginCreateFunction func(
-	models.ConnectorID,
-	string,
-	logging.Logger,
-	json.RawMessage,
-) (models.Plugin, error)
+// PluginCreateFunction is an alias to pkg/registry for backward compatibility.
+type PluginCreateFunction = pkgregistry.PluginCreateFunction
 
-type PluginInformation struct {
-	pluginType   models.PluginType
-	capabilities []models.Capability
-	createFunc   PluginCreateFunction
-	config       Config
-	pageSize     uint64
-}
+// ErrPluginNotFound is an alias to pkg/registry for backward compatibility.
+var ErrPluginNotFound = pkgregistry.ErrPluginNotFound
 
-var (
-	pluginsRegistry map[string]PluginInformation = make(map[string]PluginInformation)
+var ErrPluginEnterpriseOnly = errors.New("plugin requires Enterprise Edition")
 
-	ErrPluginNotFound              = errors.New("plugin not found")
-	ErrPluginEnterpriseOnly        = errors.New("plugin requires Enterprise Edition")
-
-	checkRequired = regexp.MustCompile("required")
-)
-
+// RegisterPlugin delegates to pkg/registry.RegisterPlugin.
+// This allows connectors to use either import path.
 func RegisterPlugin(
 	provider string,
 	pluginType models.PluginType,
@@ -47,136 +33,73 @@ func RegisterPlugin(
 	conf any,
 	pageSize uint64,
 ) {
-	pluginsRegistry[provider] = PluginInformation{
-		pluginType:   pluginType,
-		capabilities: capabilities,
-		createFunc:   createFunc,
-		config:       setupConfig(conf),
-		pageSize:     pageSize,
+	// Convert models types to connector types (they're the same underlying types)
+	connectorCaps := make([]connector.Capability, len(capabilities))
+	for i, c := range capabilities {
+		connectorCaps[i] = connector.Capability(c)
 	}
+
+	pkgregistry.RegisterPlugin(provider, connector.PluginType(pluginType), createFunc, connectorCaps, conf, pageSize)
 }
 
-func setupConfig(conf any) Config {
-	config := make(Config)
-	for paramName, param := range defaultParameters {
-		if _, ok := config[paramName]; !ok {
-			config[paramName] = param
-		}
-	}
-
-	val := reflect.ValueOf(conf)
-	if val.Kind() == reflect.Invalid {
-		log.Panicf("RegisterPlugin config cannot be nil")
-	}
-	if val.Kind() != reflect.Struct {
-		log.Panicf("RegisterPlugin config must be a struct, got %v", val.Kind())
-	}
-	for i := 0; i < val.NumField(); i++ {
-		field := val.Type().Field(i)
-		if !field.IsExported() {
-			continue
-		}
-
-		validatorTag := field.Tag.Get("validate")
-
-		jsonTag := field.Tag.Get("json")
-		fieldName := strings.Split(jsonTag, ",")[0]
-
-		if fieldName == "" || fieldName == "-" {
-			continue
-		}
-
-		vt := field.Type
-		var dataType Type
-		switch vt.Kind() {
-		case reflect.String:
-			dataType = TypeString
-		case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			dataType = TypeUnsignedInteger
-		case reflect.Int64:
-			if field.Type.Name() == "Duration" {
-				dataType = TypeDurationNs
-				break
-			}
-			fallthrough
-		case reflect.Bool:
-			dataType = TypeBoolean
-		default:
-			log.Panicf("unhandled type for field %q: %q", val.Type().Field(i).Name, field.Type.Name())
-		}
-
-		config[fieldName] = Parameter{
-			DataType: dataType,
-			Required: checkRequired.MatchString(validatorTag),
-		}
-	}
-	return config
-}
-
+// GetPlugin retrieves a plugin from the registry, creates it, and wraps it with OTel tracing.
 func GetPlugin(connectorID models.ConnectorID, logger logging.Logger, provider string, connectorName string, rawConfig json.RawMessage) (models.Plugin, error) {
 	provider = strings.ToLower(provider)
-	info, ok := pluginsRegistry[provider]
-	if !ok {
+
+	createFunc, _, err := pkgregistry.GetPluginFactory(provider)
+	if err != nil {
 		if _, enterprise := EnterpriseOnlyPlugins[provider]; enterprise {
 			return nil, fmt.Errorf("%s: %w", provider, ErrPluginEnterpriseOnly)
 		}
-		return nil, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+		return nil, err
 	}
 
-	p, err := info.createFunc(connectorID, connectorName, logger, rawConfig)
+	p, err := createFunc(connector.ConnectorID(connectorID), connectorName, logger, rawConfig)
 	if err != nil {
 		return nil, translateError(err)
 	}
 
+	// Wrap with OTel tracing (internal only)
 	return New(connectorID, logger, p), nil
 }
 
+// GetPluginType delegates to pkg/registry.
 func GetPluginType(provider string) (models.PluginType, error) {
-	provider = strings.ToLower(provider)
-	info, ok := pluginsRegistry[provider]
-	if !ok {
-		return 0, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
-	}
-
-	return info.pluginType, nil
+	pt, err := pkgregistry.GetPluginType(provider)
+	return models.PluginType(pt), err
 }
 
+// GetCapabilities delegates to pkg/registry.
 func GetCapabilities(provider string) ([]models.Capability, error) {
-	provider = strings.ToLower(provider)
-	info, ok := pluginsRegistry[provider]
-	if !ok {
-		return nil, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	caps, err := pkgregistry.GetCapabilities(provider)
+	if err != nil {
+		return nil, err
 	}
-
-	return info.capabilities, nil
+	// Convert connector.Capability to models.Capability
+	result := make([]models.Capability, len(caps))
+	for i, c := range caps {
+		result[i] = models.Capability(c)
+	}
+	return result, nil
 }
 
+// GetConfigs delegates to pkg/registry.
 func GetConfigs(debug bool) Configs {
-	confs := make(Configs)
-	for key, info := range pluginsRegistry {
-		// hide dummy PSP outside of debug mode
-		if !debug && key == DummyPSPName {
-			continue
-		}
-		confs[key] = info.config
+	pkgConfigs := pkgregistry.GetConfigs(debug)
+	result := make(Configs)
+	for k, v := range pkgConfigs {
+		result[k] = Config(v)
 	}
-	return confs
+	return result
 }
 
+// GetConfig delegates to pkg/registry.
 func GetConfig(provider string) (Config, error) {
-	provider = strings.ToLower(provider)
-	info, ok := pluginsRegistry[provider]
-	if !ok {
-		return nil, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
-	}
-	return info.config, nil
+	cfg, err := pkgregistry.GetConfig(provider)
+	return Config(cfg), err
 }
 
+// GetPageSize delegates to pkg/registry.
 func GetPageSize(provider string) (uint64, error) {
-	provider = strings.ToLower(provider)
-	info, ok := pluginsRegistry[provider]
-	if !ok {
-		return 0, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
-	}
-	return info.pageSize, nil
+	return pkgregistry.GetPageSize(provider)
 }

--- a/pkg/connector/base_plugin.go
+++ b/pkg/connector/base_plugin.go
@@ -1,0 +1,140 @@
+package connector
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// BasePlugin provides a default implementation of the Plugin interface.
+// All methods return ErrNotImplemented except TrimWebhook which returns
+// the webhook as-is. Connector implementations can embed this struct
+// and override only the methods they need.
+type BasePlugin struct {
+	isScheduledForDeletion atomic.Bool
+}
+
+// NewBasePlugin creates a new BasePlugin instance.
+func NewBasePlugin() Plugin {
+	return &BasePlugin{}
+}
+
+func (bp *BasePlugin) Name() string {
+	return "default"
+}
+
+func (bp *BasePlugin) IsScheduledForDeletion() bool {
+	return bp.isScheduledForDeletion.Load()
+}
+
+func (bp *BasePlugin) ScheduleForDeletion(isScheduledForDeletion bool) {
+	bp.isScheduledForDeletion.Store(isScheduledForDeletion)
+}
+
+func (bp *BasePlugin) Config() PluginInternalConfig {
+	return struct{}{}
+}
+
+func (bp *BasePlugin) Install(ctx context.Context, req InstallRequest) (InstallResponse, error) {
+	return InstallResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) Uninstall(ctx context.Context, req UninstallRequest) (UninstallResponse, error) {
+	return UninstallResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) FetchNextAccounts(ctx context.Context, req FetchNextAccountsRequest) (FetchNextAccountsResponse, error) {
+	return FetchNextAccountsResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) FetchNextBalances(ctx context.Context, req FetchNextBalancesRequest) (FetchNextBalancesResponse, error) {
+	return FetchNextBalancesResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) FetchNextExternalAccounts(ctx context.Context, req FetchNextExternalAccountsRequest) (FetchNextExternalAccountsResponse, error) {
+	return FetchNextExternalAccountsResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) FetchNextPayments(ctx context.Context, req FetchNextPaymentsRequest) (FetchNextPaymentsResponse, error) {
+	return FetchNextPaymentsResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) FetchNextOthers(ctx context.Context, req FetchNextOthersRequest) (FetchNextOthersResponse, error) {
+	return FetchNextOthersResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreateBankAccount(ctx context.Context, req CreateBankAccountRequest) (CreateBankAccountResponse, error) {
+	return CreateBankAccountResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreateTransfer(ctx context.Context, req CreateTransferRequest) (CreateTransferResponse, error) {
+	return CreateTransferResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) ReverseTransfer(ctx context.Context, req ReverseTransferRequest) (ReverseTransferResponse, error) {
+	return ReverseTransferResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) PollTransferStatus(ctx context.Context, req PollTransferStatusRequest) (PollTransferStatusResponse, error) {
+	return PollTransferStatusResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreatePayout(ctx context.Context, req CreatePayoutRequest) (CreatePayoutResponse, error) {
+	return CreatePayoutResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) ReversePayout(ctx context.Context, req ReversePayoutRequest) (ReversePayoutResponse, error) {
+	return ReversePayoutResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) PollPayoutStatus(ctx context.Context, req PollPayoutStatusRequest) (PollPayoutStatusResponse, error) {
+	return PollPayoutStatusResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreateWebhooks(ctx context.Context, req CreateWebhooksRequest) (CreateWebhooksResponse, error) {
+	return CreateWebhooksResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) TrimWebhook(ctx context.Context, req TrimWebhookRequest) (TrimWebhookResponse, error) {
+	// Base implementation is to return the webhook as is
+	return TrimWebhookResponse{
+		Webhooks: []PSPWebhook{req.Webhook},
+	}, nil
+}
+
+func (bp *BasePlugin) VerifyWebhook(ctx context.Context, req VerifyWebhookRequest) (VerifyWebhookResponse, error) {
+	return VerifyWebhookResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) TranslateWebhook(ctx context.Context, req TranslateWebhookRequest) (TranslateWebhookResponse, error) {
+	return TranslateWebhookResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreateUser(ctx context.Context, req CreateUserRequest) (CreateUserResponse, error) {
+	return CreateUserResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CreateUserLink(ctx context.Context, req CreateUserLinkRequest) (CreateUserLinkResponse, error) {
+	return CreateUserLinkResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CompleteUserLink(ctx context.Context, req CompleteUserLinkRequest) (CompleteUserLinkResponse, error) {
+	return CompleteUserLinkResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) UpdateUserLink(ctx context.Context, req UpdateUserLinkRequest) (UpdateUserLinkResponse, error) {
+	return UpdateUserLinkResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) CompleteUpdateUserLink(ctx context.Context, req CompleteUpdateUserLinkRequest) (CompleteUpdateUserLinkResponse, error) {
+	return CompleteUpdateUserLinkResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) DeleteUserConnection(ctx context.Context, req DeleteUserConnectionRequest) (DeleteUserConnectionResponse, error) {
+	return DeleteUserConnectionResponse{}, ErrNotImplemented
+}
+
+func (bp *BasePlugin) DeleteUser(ctx context.Context, req DeleteUserRequest) (DeleteUserResponse, error) {
+	return DeleteUserResponse{}, ErrNotImplemented
+}
+
+var _ Plugin = &BasePlugin{}

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -1,0 +1,41 @@
+package connector
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	MinimumPollingPeriod = 20 * time.Minute
+	DefaultPollingPeriod = 30 * time.Minute
+)
+
+// PollingPeriod represents a duration used for polling intervals in connectors.
+type PollingPeriod time.Duration
+
+// Duration returns the underlying time.Duration value.
+func (p PollingPeriod) Duration() time.Duration { return time.Duration(p) }
+
+// MarshalJSON implements the json.Marshaler interface.
+func (p PollingPeriod) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(p).String())
+}
+
+// NewPollingPeriod creates a new PollingPeriod from a raw string value,
+// applying minimum and default constraints.
+func NewPollingPeriod(raw string, def, min time.Duration) (PollingPeriod, error) {
+	if raw == "" {
+		if def < min {
+			return PollingPeriod(min), nil
+		}
+		return PollingPeriod(def), nil
+	}
+	v, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, err
+	}
+	if v < min {
+		v = min
+	}
+	return PollingPeriod(v), nil
+}

--- a/pkg/connector/doc.go
+++ b/pkg/connector/doc.go
@@ -1,0 +1,20 @@
+// Package connector provides the public interface for Payment Service Provider connectors.
+//
+// This package re-exports types from internal/models that external connector
+// implementations need. It serves as a stable public API while keeping the
+// canonical type definitions internal.
+//
+// External connector developers should import this package:
+//
+//	import "github.com/formancehq/payments/pkg/connector"
+//
+// Example usage:
+//
+//	func (p *MyConnector) FetchNextAccounts(ctx context.Context, req connector.FetchNextAccountsRequest) (connector.FetchNextAccountsResponse, error) {
+//	    return connector.FetchNextAccountsResponse{
+//	        Accounts: []connector.PSPAccount{
+//	            {Reference: "acc-123", CreatedAt: time.Now(), Raw: json.RawMessage(`{}`)},
+//	        },
+//	    }, nil
+//	}
+package connector

--- a/pkg/connector/enums.go
+++ b/pkg/connector/enums.go
@@ -1,0 +1,127 @@
+package connector
+
+import (
+	"github.com/formancehq/payments/internal/models"
+)
+
+// Payment type enum.
+type PaymentType = models.PaymentType
+
+const (
+	PAYMENT_TYPE_UNKNOWN  = models.PAYMENT_TYPE_UNKNOWN
+	PAYMENT_TYPE_PAYIN    = models.PAYMENT_TYPE_PAYIN
+	PAYMENT_TYPE_PAYOUT   = models.PAYMENT_TYPE_PAYOUT
+	PAYMENT_TYPE_TRANSFER = models.PAYMENT_TYPE_TRANSFER
+	PAYMENT_TYPE_OTHER    = models.PAYMENT_TYPE_OTHER
+)
+
+var (
+	PaymentTypeFromString     = models.PaymentTypeFromString
+	MustPaymentTypeFromString = models.MustPaymentTypeFromString
+)
+
+// Payment status enum.
+type PaymentStatus = models.PaymentStatus
+
+const (
+	PAYMENT_STATUS_UNKNOWN           = models.PAYMENT_STATUS_UNKNOWN
+	PAYMENT_STATUS_PENDING           = models.PAYMENT_STATUS_PENDING
+	PAYMENT_STATUS_SUCCEEDED         = models.PAYMENT_STATUS_SUCCEEDED
+	PAYMENT_STATUS_CANCELLED         = models.PAYMENT_STATUS_CANCELLED
+	PAYMENT_STATUS_FAILED            = models.PAYMENT_STATUS_FAILED
+	PAYMENT_STATUS_EXPIRED           = models.PAYMENT_STATUS_EXPIRED
+	PAYMENT_STATUS_REFUNDED          = models.PAYMENT_STATUS_REFUNDED
+	PAYMENT_STATUS_REFUNDED_FAILURE  = models.PAYMENT_STATUS_REFUNDED_FAILURE
+	PAYMENT_STATUS_REFUND_REVERSED   = models.PAYMENT_STATUS_REFUND_REVERSED
+	PAYMENT_STATUS_DISPUTE           = models.PAYMENT_STATUS_DISPUTE
+	PAYMENT_STATUS_DISPUTE_WON       = models.PAYMENT_STATUS_DISPUTE_WON
+	PAYMENT_STATUS_DISPUTE_LOST      = models.PAYMENT_STATUS_DISPUTE_LOST
+	PAYMENT_STATUS_AMOUNT_ADJUSTMENT = models.PAYMENT_STATUS_AMOUNT_ADJUSTMENT
+	PAYMENT_STATUS_AUTHORISATION     = models.PAYMENT_STATUS_AUTHORISATION
+	PAYMENT_STATUS_CAPTURE           = models.PAYMENT_STATUS_CAPTURE
+	PAYMENT_STATUS_CAPTURE_FAILED    = models.PAYMENT_STATUS_CAPTURE_FAILED
+	PAYMENT_STATUS_OTHER             = models.PAYMENT_STATUS_OTHER
+)
+
+var (
+	PaymentStatusFromString     = models.PaymentStatusFromString
+	MustPaymentStatusFromString = models.MustPaymentStatusFromString
+)
+
+// Payment scheme enum.
+type PaymentScheme = models.PaymentScheme
+
+const (
+	PAYMENT_SCHEME_UNKNOWN         = models.PAYMENT_SCHEME_UNKNOWN
+	PAYMENT_SCHEME_CARD_VISA       = models.PAYMENT_SCHEME_CARD_VISA
+	PAYMENT_SCHEME_CARD_MASTERCARD = models.PAYMENT_SCHEME_CARD_MASTERCARD
+	PAYMENT_SCHEME_CARD_AMEX       = models.PAYMENT_SCHEME_CARD_AMEX
+	PAYMENT_SCHEME_CARD_DINERS     = models.PAYMENT_SCHEME_CARD_DINERS
+	PAYMENT_SCHEME_CARD_DISCOVER   = models.PAYMENT_SCHEME_CARD_DISCOVER
+	PAYMENT_SCHEME_CARD_JCB        = models.PAYMENT_SCHEME_CARD_JCB
+	PAYMENT_SCHEME_CARD_UNION_PAY  = models.PAYMENT_SCHEME_CARD_UNION_PAY
+	PAYMENT_SCHEME_CARD_ALIPAY     = models.PAYMENT_SCHEME_CARD_ALIPAY
+	PAYMENT_SCHEME_CARD_CUP        = models.PAYMENT_SCHEME_CARD_CUP
+	PAYMENT_SCHEME_SEPA_DEBIT      = models.PAYMENT_SCHEME_SEPA_DEBIT
+	PAYMENT_SCHEME_SEPA_CREDIT     = models.PAYMENT_SCHEME_SEPA_CREDIT
+	PAYMENT_SCHEME_SEPA            = models.PAYMENT_SCHEME_SEPA
+	PAYMENT_SCHEME_GOOGLE_PAY      = models.PAYMENT_SCHEME_GOOGLE_PAY
+	PAYMENT_SCHEME_APPLE_PAY       = models.PAYMENT_SCHEME_APPLE_PAY
+	PAYMENT_SCHEME_DOKU            = models.PAYMENT_SCHEME_DOKU
+	PAYMENT_SCHEME_DRAGON_PAY      = models.PAYMENT_SCHEME_DRAGON_PAY
+	PAYMENT_SCHEME_MAESTRO         = models.PAYMENT_SCHEME_MAESTRO
+	PAYMENT_SCHEME_MOL_PAY         = models.PAYMENT_SCHEME_MOL_PAY
+	PAYMENT_SCHEME_A2A             = models.PAYMENT_SCHEME_A2A
+	PAYMENT_SCHEME_ACH_DEBIT       = models.PAYMENT_SCHEME_ACH_DEBIT
+	PAYMENT_SCHEME_ACH             = models.PAYMENT_SCHEME_ACH
+	PAYMENT_SCHEME_RTP             = models.PAYMENT_SCHEME_RTP
+	PAYMENT_SCHEME_OTHER           = models.PAYMENT_SCHEME_OTHER
+)
+
+var (
+	PaymentSchemeFromString     = models.PaymentSchemeFromString
+	MustPaymentSchemeFromString = models.MustPaymentSchemeFromString
+)
+
+// Capability enum.
+type Capability = models.Capability
+
+const (
+	CAPABILITY_FETCH_UNKNOWN                   = models.CAPABILITY_FETCH_UNKNOWN
+	CAPABILITY_FETCH_ACCOUNTS                  = models.CAPABILITY_FETCH_ACCOUNTS
+	CAPABILITY_FETCH_BALANCES                  = models.CAPABILITY_FETCH_BALANCES
+	CAPABILITY_FETCH_EXTERNAL_ACCOUNTS         = models.CAPABILITY_FETCH_EXTERNAL_ACCOUNTS
+	CAPABILITY_FETCH_PAYMENTS                  = models.CAPABILITY_FETCH_PAYMENTS
+	CAPABILITY_FETCH_OTHERS                    = models.CAPABILITY_FETCH_OTHERS
+	CAPABILITY_CREATE_WEBHOOKS                 = models.CAPABILITY_CREATE_WEBHOOKS
+	CAPABILITY_TRANSLATE_WEBHOOKS              = models.CAPABILITY_TRANSLATE_WEBHOOKS
+	CAPABILITY_CREATE_BANK_ACCOUNT             = models.CAPABILITY_CREATE_BANK_ACCOUNT
+	CAPABILITY_CREATE_TRANSFER                 = models.CAPABILITY_CREATE_TRANSFER
+	CAPABILITY_CREATE_PAYOUT                   = models.CAPABILITY_CREATE_PAYOUT
+	CAPABILITY_ALLOW_FORMANCE_ACCOUNT_CREATION = models.CAPABILITY_ALLOW_FORMANCE_ACCOUNT_CREATION
+	CAPABILITY_ALLOW_FORMANCE_PAYMENT_CREATION = models.CAPABILITY_ALLOW_FORMANCE_PAYMENT_CREATION
+)
+
+// Open banking enums.
+type (
+	OpenBankingDataToFetch             = models.OpenBankingDataToFetch
+	ConnectionDisconnectedErrorType    = models.ConnectionDisconnectedErrorType
+	OpenBankingConnectionAttemptStatus = models.OpenBankingConnectionAttemptStatus
+	ConnectionStatus                   = models.ConnectionStatus
+)
+
+const (
+	OpenBankingDataToFetchPayments            = models.OpenBankingDataToFetchPayments
+	OpenBankingDataToFetchAccountsAndBalances = models.OpenBankingDataToFetchAccountsAndBalances
+
+	ConnectionDisconnectedErrorTypeTemporaryError   = models.ConnectionDisconnectedErrorTypeTemporaryError
+	ConnectionDisconnectedErrorTypeNonRecoverable   = models.ConnectionDisconnectedErrorTypeNonRecoverable
+	ConnectionDisconnectedErrorTypeUserActionNeeded = models.ConnectionDisconnectedErrorTypeUserActionNeeded
+
+	OpenBankingConnectionAttemptStatusPending   = models.OpenBankingConnectionAttemptStatusPending
+	OpenBankingConnectionAttemptStatusCompleted = models.OpenBankingConnectionAttemptStatusCompleted
+	OpenBankingConnectionAttemptStatusExited    = models.OpenBankingConnectionAttemptStatusExited
+
+	ConnectionStatusActive = models.ConnectionStatusActive
+	ConnectionStatusError  = models.ConnectionStatusError
+)

--- a/pkg/connector/errors.go
+++ b/pkg/connector/errors.go
@@ -1,0 +1,39 @@
+package connector
+
+import (
+	"errors"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+// Plugin implementation errors.
+// These are the canonical definitions used by connector plugins.
+var (
+	ErrNotImplemented       = errors.New("not implemented")
+	ErrNotYetInstalled      = errors.New("not yet installed")
+	ErrInvalidClientRequest = errors.New("invalid client request")
+	ErrUpstreamRatelimit    = errors.New("rate limited by upstream server")
+	ErrCurrencyNotSupported = errors.New("currency not supported")
+)
+
+// Common errors that connectors can return.
+// These are aliases to internal/models for backward compatibility.
+var (
+	ErrInvalidConfig               = models.ErrInvalidConfig
+	ErrFailedAccountCreation       = models.ErrFailedAccountCreation
+	ErrMissingFromPayloadInRequest = models.ErrMissingFromPayloadInRequest
+	ErrMissingAccountInRequest     = models.ErrMissingAccountInRequest
+	ErrInvalidRequest              = models.ErrInvalidRequest
+	ErrValidation                  = models.ErrValidation
+	ErrWebhookVerification         = models.ErrWebhookVerification
+	ErrMissingPageSize             = models.ErrMissingPageSize
+	ErrExceededMaxPageSize         = models.ErrExceededMaxPageSize
+	ErrMissingConnectorMetadata    = models.ErrMissingConnectorMetadata
+	ErrMissingConnectorField       = models.ErrMissingConnectorField
+)
+
+// ConnectorValidationError represents a validation error for a specific field.
+type ConnectorValidationError = models.ConnectorValidationError
+
+// NewConnectorValidationError creates a new ConnectorValidationError.
+var NewConnectorValidationError = models.NewConnectorValidationError

--- a/pkg/connector/errors_util.go
+++ b/pkg/connector/errors_util.go
@@ -1,0 +1,61 @@
+package connector
+
+import "fmt"
+
+type wrappedError struct {
+	err error
+}
+
+// NewWrappedError creates a new error that wraps the cause error with the new error.
+// It should be used when you want to have the end cause of an error and not all
+// the stack trace, for example when you want to store the transfer/payout creation
+// error.
+func NewWrappedError(cause error, newError error) error {
+	return &wrappedError{
+		err: fmt.Errorf("%w: %w", cause, newError),
+	}
+}
+
+func (e *wrappedError) Error() string {
+	return e.err.Error()
+}
+
+// This method is needed for all errors to be recognized by the errors.Is function
+func (e *wrappedError) Unwrap() []error {
+	return e.err.(interface{ Unwrap() []error }).Unwrap()
+}
+
+// Cause unwraps the error to the root cause
+func Cause(err error) error {
+	for {
+		switch v := err.(type) {
+		case interface{ Unwrap() error }:
+			next := v.Unwrap()
+			if next == nil {
+				return err
+			}
+			err = next
+		case interface{ Unwrap() []error }:
+			nexts := v.Unwrap()
+			if len(nexts) == 0 {
+				return err
+			}
+			// we assume that the cause error is always the first one
+			err = nexts[0]
+		default:
+			return err
+		}
+	}
+}
+
+// RetryableError is a marker interface for errors that should be retried
+type RetryableError interface {
+	error
+	Retryable()
+}
+
+// NonRetryableError is a marker interface for errors that should not be retried
+type NonRetryableError interface {
+	error
+	NonRetryable()
+}

--- a/pkg/connector/httpwrapper/client.go
+++ b/pkg/connector/httpwrapper/client.go
@@ -1,0 +1,123 @@
+// Package httpwrapper provides a convenience HTTP client wrapper for connector implementations.
+package httpwrapper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/payments/pkg/connector"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/oauth2"
+)
+
+var (
+	// ErrStatusCodeUnexpected is returned when an unexpected HTTP status code is received.
+	ErrStatusCodeUnexpected = errors.New("unexpected status code")
+	// ErrStatusCodeClientError is returned for 4xx HTTP status codes.
+	ErrStatusCodeClientError = fmt.Errorf("%w: http client error", ErrStatusCodeUnexpected)
+	// ErrStatusCodeServerError is returned for 5xx HTTP status codes.
+	ErrStatusCodeServerError = fmt.Errorf("%w: http server error", ErrStatusCodeUnexpected)
+	// ErrStatusCodeTooManyRequests is returned for HTTP 429 status code.
+	ErrStatusCodeTooManyRequests = fmt.Errorf("%w: http too many requests error", ErrStatusCodeUnexpected)
+
+	defaultHttpErrorCheckerFn = func(statusCode int) error {
+		if statusCode == http.StatusTooManyRequests {
+			return ErrStatusCodeTooManyRequests
+		}
+
+		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+			return ErrStatusCodeClientError
+		} else if statusCode >= http.StatusInternalServerError {
+			return ErrStatusCodeServerError
+		}
+		return nil
+	}
+)
+
+// Client is a convenience wrapper that encapsulates common code related to interacting with HTTP endpoints.
+type Client interface {
+	// Do performs an HTTP request while handling errors and unmarshaling success and error responses into the provided interfaces.
+	// expectedBody and errorBody should be pointers to structs.
+	Do(ctx context.Context, req *http.Request, expectedBody, errorBody any) (statusCode int, err error)
+}
+
+type client struct {
+	httpClient *http.Client
+
+	httpErrorCheckerFn func(statusCode int) error
+}
+
+// NewClient creates a new HTTP client wrapper with the given configuration.
+func NewClient(config *Config) Client {
+	if config.Timeout == 0 {
+		config.Timeout = connector.DefaultConnectorClientTimeout
+	}
+	if config.Transport != nil {
+		config.Transport = otelhttp.NewTransport(config.Transport)
+	} else {
+		config.Transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
+	httpClient := &http.Client{
+		Timeout:   config.Timeout,
+		Transport: config.Transport,
+	}
+	if config.OAuthConfig != nil {
+		// pass a pre-configured http client to oauth lib via the context
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+		httpClient = config.OAuthConfig.Client(ctx)
+	}
+
+	if config.HttpErrorCheckerFn == nil {
+		config.HttpErrorCheckerFn = defaultHttpErrorCheckerFn
+	}
+
+	return &client{
+		httpErrorCheckerFn: config.HttpErrorCheckerFn,
+		httpClient:         httpClient,
+	}
+}
+
+func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorBody any) (int, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
+	// the caller doesn't care about the response body so we return early
+	if resp.Body == nil || (reqErr == nil && expectedBody == nil) || (reqErr != nil && errorBody == nil) {
+		return resp.StatusCode, reqErr
+	}
+
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			logging.FromContext(ctx).Errorf("failed to close response body: %w", err)
+		}
+	}()
+
+	// TODO: reading everything into memory might not be optimal if we expect long responses
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if reqErr != nil {
+		if err = json.Unmarshal(rawBody, errorBody); err != nil {
+			return resp.StatusCode, fmt.Errorf("failed to unmarshal error response (%w) with status %d: %w", err, resp.StatusCode, reqErr)
+		}
+		return resp.StatusCode, reqErr
+	}
+
+	// TODO: assuming json bodies for now, but may need to handle other body types
+	if err = json.Unmarshal(rawBody, expectedBody); err != nil {
+		return resp.StatusCode, fmt.Errorf("failed to unmarshal response with status %d: %w", resp.StatusCode, err)
+	}
+	return resp.StatusCode, nil
+}

--- a/pkg/connector/httpwrapper/config.go
+++ b/pkg/connector/httpwrapper/config.go
@@ -1,0 +1,24 @@
+package httpwrapper
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// Config holds the configuration for an HTTP client wrapper.
+type Config struct {
+	// HttpErrorCheckerFn is a custom function to check for HTTP errors.
+	// If nil, a default checker is used that returns errors for 4xx and 5xx status codes.
+	HttpErrorCheckerFn func(code int) error
+
+	// Timeout is the request timeout. If zero, DefaultConnectorClientTimeout is used.
+	Timeout time.Duration
+
+	// Transport is the HTTP transport to use. If nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+
+	// OAuthConfig is optional OAuth2 client credentials configuration.
+	OAuthConfig *clientcredentials.Config
+}

--- a/pkg/connector/metrics/client.go
+++ b/pkg/connector/metrics/client.go
@@ -1,0 +1,14 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewHTTPClient creates a new HTTP client with metrics instrumentation.
+func NewHTTPClient(connectorName string, timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: NewTransport(connectorName, TransportOpts{}),
+	}
+}

--- a/pkg/connector/metrics/metrics.go
+++ b/pkg/connector/metrics/metrics.go
@@ -1,0 +1,111 @@
+// Package metrics provides OpenTelemetry metrics for connector PSP calls.
+package metrics
+
+import (
+	"sync"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	registry   MetricsRegistry
+	registryMu sync.RWMutex
+)
+
+// GetMetricsRegistry returns the global metrics registry.
+// If no registry has been registered, it returns a no-op implementation.
+func GetMetricsRegistry() MetricsRegistry {
+	registryMu.RLock()
+	currentRegistry := registry
+	registryMu.RUnlock()
+	if currentRegistry != nil {
+		return currentRegistry
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if registry == nil {
+		registry = NewNoOpMetricsRegistry()
+	}
+
+	return registry
+}
+
+// MetricsRegistry provides access to connector metrics.
+type MetricsRegistry interface {
+	// ConnectorPSPCalls returns the counter for PSP API calls.
+	ConnectorPSPCalls() metric.Int64Counter
+	// ConnectorPSPCallLatencies returns the histogram for PSP API call latencies.
+	ConnectorPSPCallLatencies() metric.Int64Histogram
+}
+
+type metricsRegistry struct {
+	connectorPSPCalls         metric.Int64Counter
+	connectorPSPCallLatencies metric.Int64Histogram
+}
+
+// RegisterMetricsRegistry creates and registers a new metrics registry with the given meter provider.
+func RegisterMetricsRegistry(meterProvider metric.MeterProvider) (MetricsRegistry, error) {
+	meter := meterProvider.Meter("payments")
+
+	connectorPSPCalls, err := meter.Int64Counter(
+		"payments_connectors_psp_calls",
+		metric.WithUnit("1"),
+		metric.WithDescription("payments connectors psp calls"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	connectorPSPCallLatencies, err := meter.Int64Histogram(
+		"payments_connectors_psp_calls_latencies",
+		metric.WithUnit("ms"),
+		metric.WithDescription("payments connectors psp calls latencies"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &metricsRegistry{
+		connectorPSPCalls:         connectorPSPCalls,
+		connectorPSPCallLatencies: connectorPSPCallLatencies,
+	}
+
+	registryMu.Lock()
+	registry = r
+	registryMu.Unlock()
+
+	return r, nil
+}
+
+func (m *metricsRegistry) ConnectorPSPCalls() metric.Int64Counter {
+	return m.connectorPSPCalls
+}
+
+func (m *metricsRegistry) ConnectorPSPCallLatencies() metric.Int64Histogram {
+	return m.connectorPSPCallLatencies
+}
+
+// NoopMetricsRegistry is a no-op implementation of MetricsRegistry.
+type NoopMetricsRegistry struct{}
+
+// NewNoOpMetricsRegistry creates a new no-op metrics registry.
+func NewNoOpMetricsRegistry() *NoopMetricsRegistry {
+	return &NoopMetricsRegistry{}
+}
+
+func (m *NoopMetricsRegistry) ConnectorPSPCalls() metric.Int64Counter {
+	counter, _ := noop.NewMeterProvider().Meter("payments").Int64Counter("payments_connectors_psp_calls")
+	return counter
+}
+
+func (m *NoopMetricsRegistry) ConnectorPSPCallLatencies() metric.Int64Histogram {
+	histogram, _ := noop.NewMeterProvider().Meter("payments").Int64Histogram("payments_connectors_psp_calls_latencies")
+	return histogram
+}
+
+var (
+	_ MetricsRegistry = (*metricsRegistry)(nil)
+	_ MetricsRegistry = (*NoopMetricsRegistry)(nil)
+)

--- a/pkg/connector/metrics/transport.go
+++ b/pkg/connector/metrics/transport.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// MetricOpContextKey is the type for the metric operation context key.
+type MetricOpContextKey string
+
+// MetricOperationContextKey is the context key used to store the operation name for metrics.
+const MetricOperationContextKey MetricOpContextKey = "_metric_operation_context_key"
+
+// OperationContext returns a new context with the operation name set for metrics.
+func OperationContext(ctx context.Context, operation string) context.Context {
+	return context.WithValue(ctx, MetricOperationContextKey, operation)
+}
+
+// TransportOpts holds options for creating a metrics transport.
+type TransportOpts struct {
+	// Transport is the underlying HTTP transport. If nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+	// CommonMetricAttributesFn returns common attributes to add to all metrics.
+	CommonMetricAttributesFn func() []attribute.KeyValue
+}
+
+// Transport is an http.RoundTripper that records metrics for each request.
+type Transport struct {
+	connectorName          string
+	parent                 http.RoundTripper
+	commonMetricAttributes []attribute.KeyValue
+}
+
+// NewTransport creates a new metrics transport for the given connector.
+func NewTransport(connectorName string, opts TransportOpts) http.RoundTripper {
+	if opts.Transport == nil {
+		opts.Transport = http.DefaultTransport
+	}
+
+	if opts.CommonMetricAttributesFn == nil {
+		opts.CommonMetricAttributesFn = func() []attribute.KeyValue { return []attribute.KeyValue{} }
+	}
+
+	return &Transport{
+		connectorName:          connectorName,
+		parent:                 opts.Transport,
+		commonMetricAttributes: opts.CommonMetricAttributesFn(),
+	}
+}
+
+// RoundTrip implements http.RoundTripper and records metrics for the request.
+func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	res, err := r.parent.RoundTrip(req)
+	registry := GetMetricsRegistry()
+
+	attrs := r.commonMetricAttributes
+	attrs = append(attrs, attribute.String("connector", r.connectorName))
+	attrs = append(attrs, attribute.String("endpoint", req.URL.Path))
+	if val := req.Context().Value(MetricOperationContextKey); val != nil {
+		if name, ok := val.(string); ok {
+			attrs = append(attrs, attribute.String("operation", name))
+		}
+	}
+
+	if res != nil {
+		attrs = append(attrs, attribute.Int("status", res.StatusCode))
+	} else {
+		// if request could not be executed
+		attrs = append(attrs, attribute.Int("status", 0))
+	}
+	opts := metric.WithAttributes(attrs...)
+
+	registry.ConnectorPSPCalls().Add(req.Context(), 1, opts)
+	registry.ConnectorPSPCallLatencies().Record(req.Context(), time.Since(start).Milliseconds(), opts)
+	return res, err
+}

--- a/pkg/connector/pagination.go
+++ b/pkg/connector/pagination.go
@@ -1,0 +1,29 @@
+package connector
+
+// ShouldFetchMore determines if we need more objects to fetch and if we have
+// more objects to fetch.
+// This function should be used only if the following requirements are met:
+// - When fetching some objects, you need to append all of them to a slice
+func ShouldFetchMore[T any, C any](total []T, currentBatch []C, pageSize int) (needMore bool, hasMore bool) {
+	switch {
+	case len(total) > pageSize:
+		// We fetched more than we should, the total will be trimmed, we don't
+		// need more
+		needMore = false
+		// Since the total will be trimmed it means we will have to refetch the
+		// objects trimmed, so we have more
+		hasMore = true
+	case len(total) == pageSize:
+		// We don't need more, we fetched exactly what we needed
+		needMore = false
+		// hasMore depends on the currentBatch, if the currentBatch is full
+		// then we have more
+		hasMore = len(currentBatch) >= pageSize
+	default:
+		// Here, total is < pageSize, so we need more objects
+		needMore = true
+		// If the currentBatch is full, we have more
+		hasMore = len(currentBatch) >= pageSize
+	}
+	return
+}

--- a/pkg/connector/plugin.go
+++ b/pkg/connector/plugin.go
@@ -1,0 +1,138 @@
+package connector
+
+import (
+	"time"
+
+	"github.com/formancehq/payments/internal/models"
+)
+
+// DefaultConnectorClientTimeout is the default timeout for connector HTTP clients.
+const DefaultConnectorClientTimeout = models.DefaultConnectorClientTimeout
+
+// Activity timeout constants.
+const (
+	ActivityStartToCloseTimeoutMinutesDefault = models.ActivityStartToCloseTimeoutMinutesDefault
+	ActivityStartToCloseTimeoutMinutesLong    = models.ActivityStartToCloseTimeoutMinutesLong
+)
+
+// PluginType represents the type of plugin.
+type PluginType = models.PluginType
+
+const (
+	PluginTypePSP         = models.PluginTypePSP
+	PluginTypeOpenBanking = models.PluginTypeOpenBanking
+	PluginTypeBoth        = models.PluginTypeBoth
+)
+
+// PluginInternalConfig is a generic interface for connector-specific configuration.
+type PluginInternalConfig = models.PluginInternalConfig
+
+// Plugin is the main interface that all connectors must implement.
+type Plugin = models.Plugin
+
+// PSPPlugin interface for PSP-specific operations.
+type PSPPlugin = models.PSPPlugin
+
+// OpenBankingPlugin interface for open banking operations.
+type OpenBankingPlugin = models.OpenBankingPlugin
+
+// ConnectorID identifies a connector instance.
+type ConnectorID = models.ConnectorID
+
+// Install/Uninstall types.
+type (
+	InstallRequest   = models.InstallRequest
+	InstallResponse  = models.InstallResponse
+	UninstallRequest = models.UninstallRequest
+	UninstallResponse = models.UninstallResponse
+)
+
+// Webhook types.
+type (
+	CreateWebhooksRequest    = models.CreateWebhooksRequest
+	CreateWebhooksResponse   = models.CreateWebhooksResponse
+	TrimWebhookRequest       = models.TrimWebhookRequest
+	TrimWebhookResponse      = models.TrimWebhookResponse
+	VerifyWebhookRequest     = models.VerifyWebhookRequest
+	VerifyWebhookResponse    = models.VerifyWebhookResponse
+	TranslateWebhookRequest  = models.TranslateWebhookRequest
+	TranslateWebhookResponse = models.TranslateWebhookResponse
+	WebhookResponse          = models.WebhookResponse
+	WebhookConfig            = models.WebhookConfig
+)
+
+// PSP fetch request/response types.
+type (
+	FetchNextAccountsRequest          = models.FetchNextAccountsRequest
+	FetchNextAccountsResponse         = models.FetchNextAccountsResponse
+	FetchNextExternalAccountsRequest  = models.FetchNextExternalAccountsRequest
+	FetchNextExternalAccountsResponse = models.FetchNextExternalAccountsResponse
+	FetchNextPaymentsRequest          = models.FetchNextPaymentsRequest
+	FetchNextPaymentsResponse         = models.FetchNextPaymentsResponse
+	FetchNextOthersRequest            = models.FetchNextOthersRequest
+	FetchNextOthersResponse           = models.FetchNextOthersResponse
+	FetchNextBalancesRequest          = models.FetchNextBalancesRequest
+	FetchNextBalancesResponse         = models.FetchNextBalancesResponse
+)
+
+// Bank account types.
+type (
+	CreateBankAccountRequest  = models.CreateBankAccountRequest
+	CreateBankAccountResponse = models.CreateBankAccountResponse
+	BankAccount               = models.BankAccount
+)
+
+// Transfer types.
+type (
+	CreateTransferRequest      = models.CreateTransferRequest
+	CreateTransferResponse     = models.CreateTransferResponse
+	ReverseTransferRequest     = models.ReverseTransferRequest
+	ReverseTransferResponse    = models.ReverseTransferResponse
+	PollTransferStatusRequest  = models.PollTransferStatusRequest
+	PollTransferStatusResponse = models.PollTransferStatusResponse
+)
+
+// Payout types.
+type (
+	CreatePayoutRequest      = models.CreatePayoutRequest
+	CreatePayoutResponse     = models.CreatePayoutResponse
+	ReversePayoutRequest     = models.ReversePayoutRequest
+	ReversePayoutResponse    = models.ReversePayoutResponse
+	PollPayoutStatusRequest  = models.PollPayoutStatusRequest
+	PollPayoutStatusResponse = models.PollPayoutStatusResponse
+)
+
+// Open banking user types.
+type (
+	CreateUserRequest              = models.CreateUserRequest
+	CreateUserResponse             = models.CreateUserResponse
+	CreateUserLinkRequest          = models.CreateUserLinkRequest
+	CreateUserLinkResponse         = models.CreateUserLinkResponse
+	UpdateUserLinkRequest          = models.UpdateUserLinkRequest
+	UpdateUserLinkResponse         = models.UpdateUserLinkResponse
+	CompleteUserLinkRequest        = models.CompleteUserLinkRequest
+	CompleteUserLinkResponse       = models.CompleteUserLinkResponse
+	CompleteUpdateUserLinkRequest  = models.CompleteUpdateUserLinkRequest
+	CompleteUpdateUserLinkResponse = models.CompleteUpdateUserLinkResponse
+	UserLinkSuccessResponse        = models.UserLinkSuccessResponse
+	UserLinkErrorResponse          = models.UserLinkErrorResponse
+	DeleteUserConnectionRequest    = models.DeleteUserConnectionRequest
+	DeleteUserConnectionResponse   = models.DeleteUserConnectionResponse
+	DeleteUserRequest              = models.DeleteUserRequest
+	DeleteUserResponse             = models.DeleteUserResponse
+	HTTPCallInformation            = models.HTTPCallInformation
+	CallbackState                       = models.CallbackState
+	OpenBankingForwardedUserFromPayload = models.OpenBankingForwardedUserFromPayload
+	OpenBankingConnectionAttempt        = models.OpenBankingConnectionAttempt
+	OpenBankingForwardedUser            = models.OpenBankingForwardedUser
+	OpenBankingConnection               = models.OpenBankingConnection
+)
+
+// Open banking constants.
+const NoRedirectQueryParamID = models.NoRedirectQueryParamID
+
+// Open banking callback helpers.
+var CallbackStateFromString = models.CallbackStateFromString
+
+// Ensure DefaultConnectorClientTimeout has the expected value at compile time.
+var _ time.Duration = DefaultConnectorClientTimeout

--- a/pkg/connector/tasks.go
+++ b/pkg/connector/tasks.go
@@ -1,0 +1,29 @@
+package connector
+
+import (
+	"github.com/formancehq/payments/internal/models"
+)
+
+// Task type enum.
+type TaskType = models.TaskType
+
+const (
+	TASK_FETCH_OTHERS            = models.TASK_FETCH_OTHERS
+	TASK_FETCH_ACCOUNTS          = models.TASK_FETCH_ACCOUNTS
+	TASK_FETCH_BALANCES          = models.TASK_FETCH_BALANCES
+	TASK_FETCH_EXTERNAL_ACCOUNTS = models.TASK_FETCH_EXTERNAL_ACCOUNTS
+	TASK_FETCH_PAYMENTS          = models.TASK_FETCH_PAYMENTS
+	TASK_CREATE_WEBHOOKS         = models.TASK_CREATE_WEBHOOKS
+)
+
+// Task tree types.
+type (
+	TaskTreeFetchOther            = models.TaskTreeFetchOther
+	TaskTreeFetchAccounts         = models.TaskTreeFetchAccounts
+	TaskTreeFetchBalances         = models.TaskTreeFetchBalances
+	TaskTreeFetchExternalAccounts = models.TaskTreeFetchExternalAccounts
+	TaskTreeFetchPayments         = models.TaskTreeFetchPayments
+	TaskTreeCreateWebhooks        = models.TaskTreeCreateWebhooks
+	ConnectorTaskTree             = models.ConnectorTaskTree
+	ConnectorTasksTree            = models.ConnectorTasksTree
+)

--- a/pkg/connector/types.go
+++ b/pkg/connector/types.go
@@ -1,0 +1,111 @@
+package connector
+
+import (
+	"github.com/formancehq/payments/internal/models"
+)
+
+// Core PSP types - these are the data structures connectors produce and consume.
+type (
+	// PSPAccount represents an account as returned by a Payment Service Provider.
+	PSPAccount = models.PSPAccount
+
+	// PSPPayment represents a payment as returned by a Payment Service Provider.
+	PSPPayment = models.PSPPayment
+
+	// PSPPaymentsToDelete represents a payment that should be deleted.
+	PSPPaymentsToDelete = models.PSPPaymentsToDelete
+
+	// PSPPaymentsToCancel represents a payment that should be cancelled.
+	PSPPaymentsToCancel = models.PSPPaymentsToCancel
+
+	// PSPBalance represents a balance as returned by a Payment Service Provider.
+	PSPBalance = models.PSPBalance
+
+	// PSPOther represents other data returned by a connector.
+	PSPOther = models.PSPOther
+
+	// PSPPaymentInitiation represents a payment initiation request.
+	PSPPaymentInitiation = models.PSPPaymentInitiation
+
+	// PSPPaymentInitiationReversal represents a payment initiation reversal.
+	PSPPaymentInitiationReversal = models.PSPPaymentInitiationReversal
+
+	// PSPPaymentServiceUser represents a payment service user.
+	PSPPaymentServiceUser = models.PSPPaymentServiceUser
+
+	// PSPWebhookConfig represents a webhook configuration from a PSP.
+	PSPWebhookConfig = models.PSPWebhookConfig
+
+	// PSPWebhook represents a webhook payload from a PSP.
+	PSPWebhook = models.PSPWebhook
+
+	// PSPOpenBankingAccount represents an open banking account.
+	PSPOpenBankingAccount = models.PSPOpenBankingAccount
+
+	// PSPOpenBankingPayment represents an open banking payment.
+	PSPOpenBankingPayment = models.PSPOpenBankingPayment
+
+	// PSPOpenBankingConnection represents an open banking connection from PSP.
+	PSPOpenBankingConnection = models.PSPOpenBankingConnection
+)
+
+// Supporting types used by PSP types.
+type (
+	// Address represents a physical address.
+	Address = models.Address
+
+	// ContactDetails represents contact information.
+	ContactDetails = models.ContactDetails
+
+	// Token represents an authentication token.
+	Token = models.Token
+
+	// BasicAuth represents basic authentication credentials.
+	BasicAuth = models.BasicAuth
+)
+
+// Metadata helpers - re-exported from internal/models.
+var ExtractNamespacedMetadata = models.ExtractNamespacedMetadata
+
+// Bank account metadata keys - re-exported from internal/models.
+const (
+	BankAccountOwnerAddressLine1MetadataKey = models.BankAccountOwnerAddressLine1MetadataKey
+	BankAccountOwnerAddressLine2MetadataKey = models.BankAccountOwnerAddressLine2MetadataKey
+	BankAccountOwnerStreetNameMetadataKey   = models.BankAccountOwnerStreetNameMetadataKey
+	BankAccountOwnerStreetNumberMetadataKey = models.BankAccountOwnerStreetNumberMetadataKey
+	BankAccountOwnerCityMetadataKey         = models.BankAccountOwnerCityMetadataKey
+	BankAccountOwnerRegionMetadataKey       = models.BankAccountOwnerRegionMetadataKey
+	BankAccountOwnerPostalCodeMetadataKey   = models.BankAccountOwnerPostalCodeMetadataKey
+	BankAccountOwnerEmailMetadataKey        = models.BankAccountOwnerEmailMetadataKey
+	BankAccountOwnerPhoneNumberMetadataKey  = models.BankAccountOwnerPhoneNumberMetadataKey
+
+	AccountIBANMetadataKey               = models.AccountIBANMetadataKey
+	AccountAccountNumberMetadataKey      = models.AccountAccountNumberMetadataKey
+	AccountBankAccountNameMetadataKey    = models.AccountBankAccountNameMetadataKey
+	AccountBankAccountCountryMetadataKey = models.AccountBankAccountCountryMetadataKey
+	AccountSwiftBicCodeMetadataKey       = models.AccountSwiftBicCodeMetadataKey
+)
+
+// Open banking event types.
+type (
+	// PSPDataReadyToFetch indicates that data is ready to be fetched.
+	PSPDataReadyToFetch = models.PSPDataReadyToFetch
+
+	// PSPDataToDelete indicates data that should be deleted.
+	PSPDataToDelete = models.PSPDataToDelete
+
+	// PSPUserDisconnected indicates a user has been disconnected.
+	PSPUserDisconnected = models.PSPUserDisconnected
+
+	// PSPUserConnectionPendingDisconnect indicates a connection is pending disconnection.
+	PSPUserConnectionPendingDisconnect = models.PSPUserConnectionPendingDisconnect
+
+	// PSPUserConnectionDisconnected indicates a user connection has been disconnected.
+	PSPUserConnectionDisconnected = models.PSPUserConnectionDisconnected
+
+	// PSPUserConnectionReconnected indicates a user connection has been reconnected.
+	PSPUserConnectionReconnected = models.PSPUserConnectionReconnected
+
+	// PSPUserLinkSessionFinished indicates a user link session has finished.
+	PSPUserLinkSessionFinished = models.PSPUserLinkSessionFinished
+)

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -1,0 +1,38 @@
+package registry
+
+// Type represents the data type of a configuration parameter.
+type Type string
+
+const (
+	TypeLongString      Type = "long string"
+	TypeString          Type = "string"
+	TypeDurationNs      Type = "duration ns"
+	TypeUnsignedInteger Type = "unsigned integer"
+	TypeBoolean         Type = "boolean"
+)
+
+// Configs maps provider names to their configuration schemas.
+type Configs map[string]Config
+
+// Config maps parameter names to their definitions.
+type Config map[string]Parameter
+
+// Parameter defines a configuration parameter for a connector.
+type Parameter struct {
+	DataType     Type   `json:"dataType"`
+	Required     bool   `json:"required"`
+	DefaultValue string `json:"defaultValue"`
+}
+
+// defaultParameters are the common parameters that all connectors have.
+var defaultParameters = map[string]Parameter{
+	"pollingPeriod": {
+		DataType:     TypeDurationNs,
+		Required:     false,
+		DefaultValue: "30m",
+	},
+	"name": {
+		DataType: TypeString,
+		Required: true,
+	},
+}

--- a/pkg/registry/doc.go
+++ b/pkg/registry/doc.go
@@ -1,0 +1,30 @@
+// Package registry provides the plugin registration API for payment connectors.
+//
+// This package enables connectors to be developed in separate git repositories
+// by providing a public API for registering connector plugins.
+//
+// # Usage
+//
+// Connectors register themselves using the RegisterPlugin function, typically
+// in an init() function:
+//
+//	package myconnector
+//
+//	import (
+//	    "github.com/formancehq/payments/pkg/connector"
+//	    "github.com/formancehq/payments/pkg/registry"
+//	)
+//
+//	func init() {
+//	    registry.RegisterPlugin("myconnector", connector.PluginTypePSP,
+//	        func(id connector.ConnectorID, name string, logger logging.Logger, cfg json.RawMessage) (connector.Plugin, error) {
+//	            return New(name, logger, cfg)
+//	        },
+//	        capabilities, Config{}, PAGE_SIZE,
+//	    )
+//	}
+//
+// To include the connector in a build, add a blank import to the connector loader:
+//
+//	_ "github.com/myorg/myconnector"
+package registry

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,185 @@
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/payments/pkg/connector"
+)
+
+// DummyPSPName is the name of the dummy PSP used for testing.
+const DummyPSPName = "dummypay"
+
+// PluginCreateFunction is the factory function signature for creating plugins.
+type PluginCreateFunction func(
+	connector.ConnectorID,
+	string,
+	logging.Logger,
+	json.RawMessage,
+) (connector.Plugin, error)
+
+// PluginInformation holds the metadata and factory for a registered plugin.
+type PluginInformation struct {
+	pluginType   connector.PluginType
+	capabilities []connector.Capability
+	createFunc   PluginCreateFunction
+	config       Config
+	pageSize     uint64
+}
+
+var (
+	pluginsRegistry = make(map[string]PluginInformation)
+
+	// ErrPluginNotFound is returned when a plugin is not found in the registry.
+	ErrPluginNotFound = errors.New("plugin not found")
+
+	checkRequired = regexp.MustCompile("required")
+)
+
+// RegisterPlugin registers a connector plugin with the global registry.
+// This is typically called from an init() function in the connector package.
+func RegisterPlugin(
+	provider string,
+	pluginType connector.PluginType,
+	createFunc PluginCreateFunction,
+	capabilities []connector.Capability,
+	conf any,
+	pageSize uint64,
+) {
+	pluginsRegistry[provider] = PluginInformation{
+		pluginType:   pluginType,
+		capabilities: capabilities,
+		createFunc:   createFunc,
+		config:       setupConfig(conf),
+		pageSize:     pageSize,
+	}
+}
+
+func setupConfig(conf any) Config {
+	config := make(Config)
+	for paramName, param := range defaultParameters {
+		if _, ok := config[paramName]; !ok {
+			config[paramName] = param
+		}
+	}
+
+	val := reflect.ValueOf(conf)
+	if val.Kind() == reflect.Invalid {
+		log.Panicf("RegisterPlugin config cannot be nil")
+	}
+	if val.Kind() != reflect.Struct {
+		log.Panicf("RegisterPlugin config must be a struct, got %v", val.Kind())
+	}
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Type().Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		validatorTag := field.Tag.Get("validate")
+
+		jsonTag := field.Tag.Get("json")
+		fieldName := strings.Split(jsonTag, ",")[0]
+
+		if fieldName == "" || fieldName == "-" {
+			continue
+		}
+
+		vt := field.Type
+		var dataType Type
+		switch vt.Kind() {
+		case reflect.String:
+			dataType = TypeString
+		case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			dataType = TypeUnsignedInteger
+		case reflect.Int64:
+			// Handle time.Duration and custom duration types like PollingPeriod
+			typeName := field.Type.Name()
+			if typeName == "Duration" || typeName == "PollingPeriod" {
+				dataType = TypeDurationNs
+				break
+			}
+			fallthrough
+		case reflect.Bool:
+			dataType = TypeBoolean
+		default:
+			log.Panicf("unhandled type for field %q: %q", val.Type().Field(i).Name, field.Type.Name())
+		}
+
+		config[fieldName] = Parameter{
+			DataType: dataType,
+			Required: checkRequired.MatchString(validatorTag),
+		}
+	}
+	return config
+}
+
+// GetPluginFactory returns the factory function and metadata for a plugin.
+// This is used by internal code to create and wrap plugins.
+func GetPluginFactory(provider string) (PluginCreateFunction, PluginInformation, error) {
+	provider = strings.ToLower(provider)
+	info, ok := pluginsRegistry[provider]
+	if !ok {
+		return nil, PluginInformation{}, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	}
+	return info.createFunc, info, nil
+}
+
+// GetPluginType returns the plugin type for a provider.
+func GetPluginType(provider string) (connector.PluginType, error) {
+	provider = strings.ToLower(provider)
+	info, ok := pluginsRegistry[provider]
+	if !ok {
+		return 0, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	}
+	return info.pluginType, nil
+}
+
+// GetCapabilities returns the capabilities for a provider.
+func GetCapabilities(provider string) ([]connector.Capability, error) {
+	provider = strings.ToLower(provider)
+	info, ok := pluginsRegistry[provider]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	}
+	return info.capabilities, nil
+}
+
+// GetConfigs returns the configuration schemas for all registered providers.
+func GetConfigs(debug bool) Configs {
+	confs := make(Configs)
+	for key, info := range pluginsRegistry {
+		// hide dummy PSP outside of debug mode
+		if !debug && key == DummyPSPName {
+			continue
+		}
+		confs[key] = info.config
+	}
+	return confs
+}
+
+// GetConfig returns the configuration schema for a provider.
+func GetConfig(provider string) (Config, error) {
+	provider = strings.ToLower(provider)
+	info, ok := pluginsRegistry[provider]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	}
+	return info.config, nil
+}
+
+// GetPageSize returns the default page size for a provider.
+func GetPageSize(provider string) (uint64, error) {
+	provider = strings.ToLower(provider)
+	info, ok := pluginsRegistry[provider]
+	if !ok {
+		return 0, fmt.Errorf("%s: %w", provider, ErrPluginNotFound)
+	}
+	return info.pageSize, nil
+}


### PR DESCRIPTION
## Summary
- Add `pkg/connector/` — the public SDK layer (types, base plugin, httpwrapper, metrics, errors, pagination) that re-exports internal/models types as a stable API for external connector development
- Add `pkg/registry/` — plugin registration system allowing connectors to self-register via `init()`
- Update `internal/connectors/` plumbing (httpwrapper, metrics, errors, registry) to delegate to `pkg/` types

**No connectors are moved in this PR** — all remain in `internal/connectors/plugins/public/`. This lays the foundation for the subsequent migration PR.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/connectors/plugins/registry/` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)