### PR TITLE
fix(EN-880): ensure we always setup temporal search attributes whiche…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       CONFIG_ENCRYPTION_KEY: mysuperencryptionkey
       TEMPORAL_ADDRESS: temporal:7233
       PLUGIN_MAGIC_COOKIE: mysupercookie
-      TEMPORAL_INIT_SEARCH_ATTRIBUTES: false
+      TEMPORAL_INIT_SEARCH_ATTRIBUTES: true
       STACK_URL: http://gateway:8092
       STACK_PUBLIC_URL: ${STACK_PUBLIC_URL:-http://localhost:8080}
 


### PR DESCRIPTION
…ver pod starts first


In prod/staging, the Temporal clusters are pre-configured; it's not the app that enables it.