### PR TITLE
chore(deps): backport go-libs migrator index name fix to release/v3.3

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ compile-plugins:
 
 [group('openapi')]
 validate-openapi:
-  @go run github.com/getkin/kin-openapi/cmd/validate@latest openapi.yaml
+  @go run github.com/getkin/kin-openapi/cmd/validate@v0.135.0 openapi.yaml
 
 [group('openapi')]
 compile-connector-configs:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/adyen/adyen-go-api-library/v7 v7.3.1
 	github.com/bombsimon/logrusr/v3 v3.1.0
 	github.com/emvi/iso-639-1 v1.1.1
-	github.com/formancehq/go-libs/v3 v3.6.1
+	github.com/formancehq/go-libs/v3 v3.6.2
 	github.com/formancehq/payments/genericclient/v3 v3.0.0-00010101000000-000000000000
 	github.com/formancehq/payments/pkg/client v0.0.0-00010101000000-000000000000
 	github.com/get-momo/atlar-v1-go-client v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/formancehq/go-libs/v3 v3.6.1 h1:4PxUrsiFDiwzdW/sgOM3rSYjyve+lpr8S7UFonsfwhs=
-github.com/formancehq/go-libs/v3 v3.6.1/go.mod h1:zWgFos2lhuunwk6YqXscMEokOKvEeH6Et5VjTyaF9mM=
+github.com/formancehq/go-libs/v3 v3.6.2 h1:xFg93JENE5TVZA3UM5JVqaWLW7v7S1me69zG4u7VnUw=
+github.com/formancehq/go-libs/v3 v3.6.2/go.mod h1:zWgFos2lhuunwk6YqXscMEokOKvEeH6Et5VjTyaF9mM=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=


### PR DESCRIPTION
## Summary

Backport of the go-libs migrator index name fix to payments `release/v3.3`. Bumps `github.com/formancehq/go-libs/v3` from `v3.6.1` to `v3.6.2`.

Pulls in formancehq/go-libs#596 (backport of #594 to `release/v3.6`) which fixes a hardcoded `idx_version_id` name collision between migrators sharing a schema. The bug crashes services with `SQLSTATE 42P10` at startup. Affected DBs self-heal on next deploy — no manual SQL required.

Companion to #701 (main), #703 (release/v3.1), #704 (release/v3.2).

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)