### PR TITLE
fix(coinbaseprime): avoid refetching payments on every account fetch cycle

### DIFF
--- a/ee/plugins/coinbaseprime/payments.go
+++ b/ee/plugins/coinbaseprime/payments.go
@@ -24,12 +24,8 @@ const (
 	transferTypeCounterpartyID  TransferEndpointType = "COUNTERPARTY_ID"
 )
 
-type paymentsState struct {
-	Cursor string `json:"cursor"`
-}
-
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
-	var oldState paymentsState
+	var oldState incrementalState
 	if req.State != nil {
 		if err := json.Unmarshal(req.State, &oldState); err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -53,7 +49,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		payments = append(payments, *payment)
 	}
 
-	newState := paymentsState{Cursor: response.Pagination.NextCursor}
+	newState := incrementalState{Cursor: advanceCursor(oldState.Cursor, response.Pagination.NextCursor)}
 	payload, err := json.Marshal(newState)
 	if err != nil {
 		return models.FetchNextPaymentsResponse{}, err

--- a/ee/plugins/coinbaseprime/state.go
+++ b/ee/plugins/coinbaseprime/state.go
@@ -1,0 +1,31 @@
+package coinbaseprime
+
+// incrementalState persists the opaque Coinbase Prime pagination cursor
+// between fetch cycles. On each call the plugin sends Cursor as the
+// `cursor` query param; Coinbase returns records strictly after it.
+//
+// First-run state is the zero value (empty Cursor) — the client omits the
+// query param and Coinbase returns the oldest records first under the
+// pinned `sort_direction=ASC`.
+//
+// The cursor is treated as opaque: no assumption about its format or
+// lifetime is made. It is persisted verbatim and updated only when
+// Coinbase returns a non-empty `next_cursor`. Coinbase returns an empty
+// next_cursor at end-of-pagination; we keep the previous cursor in that
+// case so the marker does not reset to the start of history. The cost is
+// re-fetching the last page each cycle — the framework dedupes emitted
+// records, so this is cheap and safe.
+type incrementalState struct {
+	Cursor string `json:"cursor"`
+}
+
+// advanceCursor returns the cursor value to persist after a page
+// response. If Coinbase returned a non-empty next_cursor, use it;
+// otherwise keep the previous cursor so end-of-pagination does not wipe
+// the marker.
+func advanceCursor(oldCursor, nextCursor string) string {
+	if nextCursor != "" {
+		return nextCursor
+	}
+	return oldCursor
+}

--- a/ee/plugins/coinbaseprime/state_test.go
+++ b/ee/plugins/coinbaseprime/state_test.go
@@ -1,0 +1,34 @@
+package coinbaseprime
+
+import "testing"
+
+func TestAdvanceCursor_UsesNextWhenNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := advanceCursor("old", "next-cursor")
+	if got != "next-cursor" {
+		t.Errorf("want next-cursor, got %q", got)
+	}
+}
+
+func TestAdvanceCursor_KeepsOldWhenNextEmpty(t *testing.T) {
+	t.Parallel()
+
+	// End-of-pagination: Coinbase returns empty next_cursor. The plugin
+	// must keep the previous cursor rather than resetting to the start of
+	// history.
+	got := advanceCursor("old", "")
+	if got != "old" {
+		t.Errorf("want old, got %q", got)
+	}
+}
+
+func TestAdvanceCursor_FirstRun(t *testing.T) {
+	t.Parallel()
+
+	// First-ever call: both oldCursor and nextCursor empty → stay empty.
+	got := advanceCursor("", "")
+	if got != "" {
+		t.Errorf("want empty cursor, got %q", got)
+	}
+}

--- a/ee/plugins/coinbaseprime/workflow.go
+++ b/ee/plugins/coinbaseprime/workflow.go
@@ -15,13 +15,13 @@ func workflow() models.ConnectorTasksTree {
 					Periodically: true,
 					NextTasks:    []models.ConnectorTaskTree{},
 				},
-				{
-					TaskType:     models.TASK_FETCH_PAYMENTS,
-					Name:         "fetch_payments",
-					Periodically: true,
-					NextTasks:    []models.ConnectorTaskTree{},
-				},
 			},
+		},
+		{
+			TaskType:     models.TASK_FETCH_PAYMENTS,
+			Name:         "fetch_payments",
+			Periodically: true,
+			NextTasks:    []models.ConnectorTaskTree{},
 		},
 	}
 }


### PR DESCRIPTION
Backport of the fetch-workflow bug fix from PR [#657](https://github.com/formancehq/payments/issues/657) (ea23a01) to release/v3.2.

Root causes:

TASK_FETCH_PAYMENTS was nested as a child of TASK_FETCH_ACCOUNTS in the workflow tree, so payments were re-triggered from scratch on every account sync cycle.
paymentsState stored the raw next_cursor from Coinbase directly. When Coinbase returns an empty next_cursor at end-of-pagination, the cursor was wiped — causing the next run to refetch all transactions from the beginning.
Changes:

Move TASK_FETCH_PAYMENTS to a top-level sibling task so it runs on its own independent schedule
Introduce incrementalState + advanceCursor in state.go: keep the previous cursor when next_cursor is empty so the pagination marker is never reset
Unit tests for advanceCursor