### PR TITLE
feat(openapi): mark sensitive connector config fields as format: password

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -746,14 +746,14 @@ Accept: application/json
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 ```
@@ -922,14 +922,14 @@ Accept: application/json
 ```json
 {
   "data": {
-    "apiKey": "string",
+    "apiKey": "pa$$word",
     "companyID": "string",
     "liveEndpointPrefix": "string",
     "name": "string",
     "pageSize": 25,
     "pollingPeriod": "30m",
     "provider": "Adyen",
-    "webhookPassword": "string",
+    "webhookPassword": "pa$$word",
     "webhookUsername": "string"
   }
 }
@@ -968,14 +968,14 @@ Update connector config
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 ```
@@ -4657,14 +4657,14 @@ None ( Scopes: payments:read )
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 
@@ -4797,14 +4797,14 @@ None ( Scopes: payments:read )
 ```json
 {
   "data": {
-    "apiKey": "string",
+    "apiKey": "pa$$word",
     "companyID": "string",
     "liveEndpointPrefix": "string",
     "name": "string",
     "pageSize": 25,
     "pollingPeriod": "30m",
     "provider": "Adyen",
-    "webhookPassword": "string",
+    "webhookPassword": "pa$$word",
     "webhookUsername": "string"
   }
 }
@@ -4826,14 +4826,14 @@ None ( Scopes: payments:read )
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 
@@ -7887,14 +7887,14 @@ Query and dynamic pools are available from Connectivity v3.1
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 
@@ -8031,14 +8031,14 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "companyID": "string",
   "liveEndpointPrefix": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Adyen",
-  "webhookPassword": "string",
+  "webhookPassword": "pa$$word",
   "webhookUsername": "string"
 }
 
@@ -8048,14 +8048,14 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |companyID|string|true|none|none|
 |liveEndpointPrefix|string|false|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
 |pollingPeriod|string|false|none|none|
 |provider|string|false|none|none|
-|webhookPassword|string|false|none|none|
+|webhookPassword|string(password)|false|none|none|
 |webhookUsername|string|false|none|none|
 
 <h2 id="tocS_V3AtlarConfig">V3AtlarConfig</h2>
@@ -8067,13 +8067,13 @@ xor
 
 ```json
 {
-  "accessKey": "string",
+  "accessKey": "pa$$word",
   "baseUrl": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Atlar",
-  "secret": "string"
+  "secret": "pa$$word"
 }
 
 ```
@@ -8082,13 +8082,13 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|accessKey|string|true|none|none|
+|accessKey|string(password)|true|none|none|
 |baseUrl|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
 |pollingPeriod|string|false|none|none|
 |provider|string|false|none|none|
-|secret|string|true|none|none|
+|secret|string(password)|true|none|none|
 
 <h2 id="tocS_V3BankingbridgeConfig">V3BankingbridgeConfig</h2>
 <!-- backwards compatibility -->
@@ -8137,11 +8137,11 @@ xor
   "endpoint": "string",
   "name": "string",
   "pageSize": 25,
-  "password": "string",
+  "password": "pa$$word",
   "pollingPeriod": "30m",
   "provider": "Bankingcircle",
-  "userCertificate": "string",
-  "userCertificateKey": "string",
+  "userCertificate": "pa$$word",
+  "userCertificateKey": "pa$$word",
   "username": "string"
 }
 
@@ -8155,11 +8155,11 @@ xor
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
-|password|string|true|none|none|
+|password|string(password)|true|none|none|
 |pollingPeriod|string|false|none|none|
 |provider|string|false|none|none|
-|userCertificate|string|true|none|none|
-|userCertificateKey|string|true|none|none|
+|userCertificate|string(password)|true|none|none|
+|userCertificateKey|string(password)|true|none|none|
 |username|string|true|none|none|
 
 <h2 id="tocS_V3CoinbaseprimeConfig">V3CoinbaseprimeConfig</h2>
@@ -8205,7 +8205,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "endpoint": "string",
   "name": "string",
   "pageSize": 25,
@@ -8219,7 +8219,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
@@ -8235,7 +8235,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "endpoint": "string",
   "loginID": "string",
   "name": "string",
@@ -8250,7 +8250,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |endpoint|string|true|none|none|
 |loginID|string|true|none|none|
 |name|string|true|none|none|
@@ -8331,7 +8331,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "endpoint": "string",
   "name": "string",
   "pageSize": 25,
@@ -8345,7 +8345,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
@@ -8393,7 +8393,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "clientID": "string",
   "endpoint": "string",
   "name": "string",
@@ -8408,7 +8408,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |clientID|string|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
@@ -8425,8 +8425,8 @@ xor
 
 ```json
 {
-  "apiKey": "string",
-  "apiSecret": "string",
+  "apiKey": "pa$$word",
+  "apiSecret": "pa$$word",
   "endpoint": "string",
   "name": "string",
   "pageSize": 25,
@@ -8440,8 +8440,8 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
-|apiSecret|string|true|none|none|
+|apiKey|string(password)|true|none|none|
+|apiSecret|string(password)|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
@@ -8457,7 +8457,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "clientID": "string",
   "endpoint": "string",
   "name": "string",
@@ -8472,7 +8472,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |clientID|string|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
@@ -8559,14 +8559,14 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "clientID": "string",
   "endpoint": "string",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
   "provider": "Qonto",
-  "stagingToken": "string"
+  "stagingToken": "pa$$word"
 }
 
 ```
@@ -8575,14 +8575,14 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |clientID|string|true|none|none|
 |endpoint|string|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
 |pollingPeriod|string|false|none|none|
 |provider|string|false|none|none|
-|stagingToken|string|false|none|none|
+|stagingToken|string(password)|false|none|none|
 
 <h2 id="tocS_V3StripeConfig">V3StripeConfig</h2>
 <!-- backwards compatibility -->
@@ -8593,7 +8593,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
@@ -8606,7 +8606,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
 |pollingPeriod|string|false|none|none|
@@ -8653,7 +8653,7 @@ xor
 
 ```json
 {
-  "apiKey": "string",
+  "apiKey": "pa$$word",
   "name": "string",
   "pageSize": 25,
   "pollingPeriod": "30m",
@@ -8667,7 +8667,7 @@ xor
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|apiKey|string|true|none|none|
+|apiKey|string(password)|true|none|none|
 |name|string|true|none|none|
 |pageSize|integer|false|none|none|
 |pollingPeriod|string|false|none|none|

--- a/internal/connectors/plugins/public/adyen/config.go
+++ b/internal/connectors/plugins/public/adyen/config.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Config struct {
-	APIKey             string `json:"apiKey" validate:"required"`
+	APIKey             string `json:"apiKey" validate:"required" format:"password"`
 	CompanyID          string `json:"companyID" validate:"required"`
 	LiveEndpointPrefix string `json:"liveEndpointPrefix" validate:"omitempty,url_encoded"`
 
 	// https://datatracker.ietf.org/doc/html/rfc7617
 	WebhookUsername string `json:"webhookUsername" validate:"omitempty,excludes=:"`
-	WebhookPassword string `json:"webhookPassword" validate:""`
+	WebhookPassword string `json:"webhookPassword" validate:"" format:"password"`
 }
 
 const PAGE_SIZE = 100

--- a/internal/connectors/plugins/public/atlar/config.go
+++ b/internal/connectors/plugins/public/atlar/config.go
@@ -11,8 +11,8 @@ import (
 
 type Config struct {
 	BaseURL       string                     `json:"baseUrl" validate:"required"`
-	AccessKey     string                     `json:"accessKey" validate:"required"`
-	Secret        string                     `json:"secret" validate:"required"`
+	AccessKey     string                     `json:"accessKey" validate:"required" format:"password"`
+	Secret        string                     `json:"secret" validate:"required" format:"password"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }
 

--- a/internal/connectors/plugins/public/bankingcircle/config.go
+++ b/internal/connectors/plugins/public/bankingcircle/config.go
@@ -11,11 +11,11 @@ import (
 
 type Config struct {
 	Username              string                     `json:"username" yaml:"username" validate:"required"`
-	Password              string                     `json:"password" yaml:"password" validate:"required"`
+	Password              string                     `json:"password" yaml:"password" validate:"required" format:"password"`
 	Endpoint              string                     `json:"endpoint" yaml:"endpoint" validate:"required"`
 	AuthorizationEndpoint string                     `json:"authorizationEndpoint" yaml:"authorizationEndpoint" validate:"required"`
-	UserCertificate       string                     `json:"userCertificate" yaml:"userCertificate" validate:"required"`
-	UserCertificateKey    string                     `json:"userCertificateKey" yaml:"userCertificateKey" validate:"required"`
+	UserCertificate       string                     `json:"userCertificate" yaml:"userCertificate" validate:"required" format:"password"`
+	UserCertificateKey    string                     `json:"userCertificateKey" yaml:"userCertificateKey" validate:"required" format:"password"`
 	PollingPeriod         sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }
 

--- a/internal/connectors/plugins/public/column/config.go
+++ b/internal/connectors/plugins/public/column/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required,url"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }

--- a/internal/connectors/plugins/public/currencycloud/config.go
+++ b/internal/connectors/plugins/public/currencycloud/config.go
@@ -10,7 +10,7 @@ import (
 
 type Config struct {
 	LoginID  string `json:"loginID" validate:"required"`
-	APIKey   string `json:"apiKey" validate:"required"`
+	APIKey   string `json:"apiKey" validate:"required" format:"password"`
 	Endpoint string `json:"endpoint" validate:"required"`
 }
 

--- a/internal/connectors/plugins/public/generic/config.go
+++ b/internal/connectors/plugins/public/generic/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }

--- a/internal/connectors/plugins/public/mangopay/config.go
+++ b/internal/connectors/plugins/public/mangopay/config.go
@@ -11,7 +11,7 @@ import (
 
 type Config struct {
 	ClientID      string                     `json:"clientID" validate:"required"`
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }

--- a/internal/connectors/plugins/public/modulr/config.go
+++ b/internal/connectors/plugins/public/modulr/config.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Config struct {
-	APIKey        string                     `json:"apiKey" validate:"required"`
-	APISecret     string                     `json:"apiSecret" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
+	APISecret     string                     `json:"apiSecret" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }

--- a/internal/connectors/plugins/public/moneycorp/config.go
+++ b/internal/connectors/plugins/public/moneycorp/config.go
@@ -11,7 +11,7 @@ import (
 
 type Config struct {
 	ClientID      string                     `json:"clientID" validate:"required"`
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }

--- a/internal/connectors/plugins/public/qonto/config.go
+++ b/internal/connectors/plugins/public/qonto/config.go
@@ -11,9 +11,9 @@ import (
 
 type Config struct {
 	ClientID      string                     `json:"clientID" validate:"required"`
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	Endpoint      string                     `json:"endpoint" validate:"required,url"`
-	StagingToken  string                     `json:"stagingToken" validate:"omitempty"`
+	StagingToken  string                     `json:"stagingToken" validate:"omitempty" format:"password"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }
 

--- a/internal/connectors/plugins/public/stripe/config.go
+++ b/internal/connectors/plugins/public/stripe/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	APIKey        string                     `json:"apiKey" validate:"required"`
+	APIKey        string                     `json:"apiKey" validate:"required" format:"password"`
 	PollingPeriod sharedconfig.PollingPeriod `json:"pollingPeriod"`
 }
 

--- a/internal/connectors/plugins/public/wise/config.go
+++ b/internal/connectors/plugins/public/wise/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Config struct {
-	APIKey           string                     `json:"apiKey" validate:"required"`
+	APIKey           string                     `json:"apiKey" validate:"required" format:"password"`
 	WebhookPublicKey string                     `json:"webhookPublicKey" validate:"required"`
 	PollingPeriod    sharedconfig.PollingPeriod `json:"pollingPeriod"`
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6410,6 +6410,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         companyID:
           type: string
         liveEndpointPrefix:
@@ -6429,6 +6430,7 @@ components:
           default: Adyen
         webhookPassword:
           type: string
+          format: password
         webhookUsername:
           type: string
     V3AtlarConfig:
@@ -6441,6 +6443,7 @@ components:
       properties:
         accessKey:
           type: string
+          format: password
         baseUrl:
           type: string
         name:
@@ -6458,6 +6461,7 @@ components:
           default: Atlar
         secret:
           type: string
+          format: password
     V3BankingbridgeConfig:
       type: object
       required:
@@ -6512,6 +6516,7 @@ components:
           x-speakeasy-deprecation-message: From v3.1, this parameter will be ignored
         password:
           type: string
+          format: password
         pollingPeriod:
           type: string
           default: 30m
@@ -6520,8 +6525,10 @@ components:
           default: Bankingcircle
         userCertificate:
           type: string
+          format: password
         userCertificateKey:
           type: string
+          format: password
         username:
           type: string
     V3CoinbaseprimeConfig:
@@ -6563,6 +6570,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         endpoint:
           type: string
         name:
@@ -6588,6 +6596,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         endpoint:
           type: string
         loginID:
@@ -6665,6 +6674,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         endpoint:
           type: string
         name:
@@ -6717,6 +6727,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         clientID:
           type: string
         endpoint:
@@ -6744,8 +6755,10 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         apiSecret:
           type: string
+          format: password
         endpoint:
           type: string
         name:
@@ -6771,6 +6784,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         clientID:
           type: string
         endpoint:
@@ -6860,6 +6874,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         clientID:
           type: string
         endpoint:
@@ -6879,6 +6894,7 @@ components:
           default: Qonto
         stagingToken:
           type: string
+          format: password
     V3StripeConfig:
       type: object
       required:
@@ -6887,6 +6903,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         name:
           type: string
         pageSize:
@@ -6936,6 +6953,7 @@ components:
       properties:
         apiKey:
           type: string
+          format: password
         name:
           type: string
         pageSize:

--- a/openapi/v3/v3-connectors-config.yaml
+++ b/openapi/v3/v3-connectors-config.yaml
@@ -54,6 +54,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 companyID:
                     type: string
                 liveEndpointPrefix:
@@ -73,6 +74,7 @@ components:
                     default: Adyen
                 webhookPassword:
                     type: string
+                    format: password
                 webhookUsername:
                     type: string
         V3AtlarConfig:
@@ -85,6 +87,7 @@ components:
             properties:
                 accessKey:
                     type: string
+                    format: password
                 baseUrl:
                     type: string
                 name:
@@ -102,6 +105,7 @@ components:
                     default: Atlar
                 secret:
                     type: string
+                    format: password
         V3BankingbridgeConfig:
             type: object
             required:
@@ -156,6 +160,7 @@ components:
                     x-speakeasy-deprecation-message: From v3.1, this parameter will be ignored
                 password:
                     type: string
+                    format: password
                 pollingPeriod:
                     type: string
                     default: 30m
@@ -164,8 +169,10 @@ components:
                     default: Bankingcircle
                 userCertificate:
                     type: string
+                    format: password
                 userCertificateKey:
                     type: string
+                    format: password
                 username:
                     type: string
         V3CoinbaseprimeConfig:
@@ -207,6 +214,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 endpoint:
                     type: string
                 name:
@@ -232,6 +240,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 endpoint:
                     type: string
                 loginID:
@@ -309,6 +318,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 endpoint:
                     type: string
                 name:
@@ -361,6 +371,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 clientID:
                     type: string
                 endpoint:
@@ -388,8 +399,10 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 apiSecret:
                     type: string
+                    format: password
                 endpoint:
                     type: string
                 name:
@@ -415,6 +428,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 clientID:
                     type: string
                 endpoint:
@@ -504,6 +518,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 clientID:
                     type: string
                 endpoint:
@@ -523,6 +538,7 @@ components:
                     default: Qonto
                 stagingToken:
                     type: string
+                    format: password
         V3StripeConfig:
             type: object
             required:
@@ -531,6 +547,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 name:
                     type: string
                 pageSize:
@@ -580,6 +597,7 @@ components:
             properties:
                 apiKey:
                     type: string
+                    format: password
                 name:
                     type: string
                 pageSize:

--- a/pkg/client/.speakeasy/gen.lock
+++ b/pkg/client/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 1fa8a26f-45d9-44b7-8b97-fbeebcdcd8b1
 management:
-  docChecksum: b2a8396780edd89fe9da1e4b470130c6
+  docChecksum: 9051ad3b5f3bdfa73b10fc7f37cff65b
   docVersion: v1
   speakeasyVersion: 1.525.0
   generationVersion: 2.562.2

--- a/tools/compile-configs/definitions.go
+++ b/tools/compile-configs/definitions.go
@@ -35,6 +35,7 @@ type V3Config struct {
 
 type Property struct {
 	Type                         string `yaml:"type"`
+	Format                       string `yaml:"format,omitempty"`
 	Default                      any    `yaml:"default,omitempty"`
 	Deprecated                   bool   `yaml:"deprecated,omitempty"`
 	XSpeakeasyDeprecationMessage string `yaml:"x-speakeasy-deprecation-message,omitempty"`

--- a/tools/compile-configs/main.go
+++ b/tools/compile-configs/main.go
@@ -240,6 +240,10 @@ func readConfig(basePath string, name string, caserName string) (V3Config, error
 						if strings.Contains(fields[1], "required") {
 							required = append(required, name)
 						}
+					case "format":
+						propCopy := properties[name]
+						propCopy.Format = strings.Trim(fields[1], "\"")
+						properties[name] = propCopy
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Add `format: password` to credential-like fields in every connector OpenAPI config so SDKs and docs render them as secrets (e.g. masked inputs, `pa$$word` placeholders).
- Extend `tools/compile-configs` to read a `format:"…"` struct tag (new `Format` property in the generator).
- Regenerate `openapi/v3/v3-connectors-config.yaml`, `openapi.yaml`, and the Speakeasy Go SDK docs.

Affected fields per connector:
- adyen: `apiKey`, `webhookPassword`
- atlar: `accessKey`, `secret`
- bankingcircle: `password`, `userCertificate`, `userCertificateKey`
- column / currencycloud / generic / mangopay / moneycorp / stripe / wise: `apiKey`
- modulr: `apiKey`, `apiSecret`
- qonto: `apiKey`, `stagingToken`

Public identifiers (usernames, login/client IDs, endpoints, base URLs, dummypay directory) and the Wise webhook public key are intentionally left unmarked.

## Test plan
- [x] `just pre-commit` passes (lint 0 issues, generate, openapi, compile-plugins)
- [x] `go build ./internal/connectors/plugins/public/...` succeeds
- [x] Inspect regenerated `openapi/v3/v3-connectors-config.yaml` — `format: password` appears on the expected fields only
- [x] `docs/api/README.md` examples now show `pa$$word` placeholders for password-format fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)