### PR TITLE
feat(httpwrapper): default-on rate-limit hint parsing with safety ceiling

### DIFF
--- a/internal/connectors/engine/activities/errors.go
+++ b/internal/connectors/engine/activities/errors.go
@@ -55,10 +55,18 @@ func (a Activities) temporalPluginErrorCheck(ctx context.Context, err error, isP
 
 	// Potentially retry
 	case errors.Is(err, plugins.ErrUpstreamRatelimit):
+		// Honor the upstream's wait hint when the plugin parsed one
+		// from RFC 9110 Retry-After or draft-ietf-httpapi-ratelimit-headers.
+		// Falls back to the static engine delay when no hint is available
+		// (or when the hint is shorter than the configured floor).
+		// https://docs.temporal.io/encyclopedia/retry-policies#per-error-next-retry-delay
+		nextDelay := a.rateLimitingRetryDelay
+		var rl *plugins.RateLimitedError
+		if errors.As(err, &rl) && rl.RetryAfter > nextDelay {
+			nextDelay = rl.RetryAfter
+		}
 		return temporal.NewApplicationErrorWithOptions(err.Error(), ErrTypeRateLimited, temporal.ApplicationErrorOptions{
-			// temporal already implements a backoff strategy, but let's add an extra delay before the next retry
-			// https://docs.temporal.io/encyclopedia/retry-policies#per-error-next-retry-delay
-			NextRetryDelay: a.rateLimitingRetryDelay,
+			NextRetryDelay: nextDelay,
 		})
 	case errors.Is(err, plugins.ErrUpstreamTimeout):
 		return temporal.NewApplicationErrorWithCause(err.Error(), ErrTypeTimeout, cause)

--- a/internal/connectors/engine/activities/errors_test.go
+++ b/internal/connectors/engine/activities/errors_test.go
@@ -1,0 +1,73 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/formancehq/payments/internal/connectors/plugins"
+	"go.temporal.io/sdk/temporal"
+)
+
+// Engine fallback contract: a plain ErrUpstreamRatelimit (no hint) must
+// still translate to a Temporal RATE_LIMITED ApplicationError with the
+// configured static NextRetryDelay. Pre-existing connectors rely on this.
+func TestTemporalPluginError_RateLimited_FallsBackToStaticDelay(t *testing.T) {
+	a := Activities{rateLimitingRetryDelay: 30 * time.Second}
+	err := a.temporalPluginError(context.Background(), plugins.ErrUpstreamRatelimit)
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *temporal.ApplicationError, got %T", err)
+	}
+	if appErr.Type() != ErrTypeRateLimited {
+		t.Fatalf("type want %q got %q", ErrTypeRateLimited, appErr.Type())
+	}
+	if got := nextRetryDelay(appErr); got != 30*time.Second {
+		t.Fatalf("NextRetryDelay want 30s got %s", got)
+	}
+}
+
+// Honor-the-hint contract: when the plugin surfaces a RateLimitedError
+// with a RetryAfter longer than the engine floor, the per-error
+// NextRetryDelay must use the upstream hint.
+func TestTemporalPluginError_RateLimited_HintBeatsStaticDelay(t *testing.T) {
+	a := Activities{rateLimitingRetryDelay: 5 * time.Second}
+	hint := 90 * time.Second
+	err := a.temporalPluginError(context.Background(), plugins.NewRateLimitedError(hint, nil))
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *temporal.ApplicationError, got %T", err)
+	}
+	if appErr.Type() != ErrTypeRateLimited {
+		t.Fatalf("type want %q got %q", ErrTypeRateLimited, appErr.Type())
+	}
+	if got := nextRetryDelay(appErr); got != hint {
+		t.Fatalf("NextRetryDelay want %s (hint) got %s", hint, got)
+	}
+}
+
+// Floor contract: a hint shorter than the engine's static floor must NOT
+// pull the next-retry-delay below the floor. Operators rely on the floor
+// to throttle a misconfigured PSP that sets a hint of "0s".
+func TestTemporalPluginError_RateLimited_HintBelowFloorClamped(t *testing.T) {
+	a := Activities{rateLimitingRetryDelay: 30 * time.Second}
+	err := a.temporalPluginError(context.Background(), plugins.NewRateLimitedError(2*time.Second, nil))
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *temporal.ApplicationError, got %T", err)
+	}
+	if got := nextRetryDelay(appErr); got != 30*time.Second {
+		t.Fatalf("NextRetryDelay must clamp to floor of 30s, got %s", got)
+	}
+}
+
+// nextRetryDelay extracts the per-error delay Temporal stamped on an
+// ApplicationError. The SDK exposes it directly; this helper centralises
+// the call to keep the assertions readable.
+func nextRetryDelay(appErr *temporal.ApplicationError) time.Duration {
+	return appErr.NextRetryDelay()
+}

--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/models"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
@@ -57,7 +59,8 @@ type Client interface {
 type client struct {
 	httpClient *http.Client
 
-	httpErrorCheckerFn func(statusCode int) error
+	httpErrorCheckerFn    func(statusCode int) error
+	disableRateLimitHints bool
 }
 
 func NewClient(config *Config) Client {
@@ -85,8 +88,9 @@ func NewClient(config *Config) Client {
 	}
 
 	return &client{
-		httpErrorCheckerFn: config.HttpErrorCheckerFn,
-		httpClient:         httpClient,
+		httpErrorCheckerFn:    config.HttpErrorCheckerFn,
+		httpClient:            httpClient,
+		disableRateLimitHints: config.DisableRateLimitHints,
 	}
 }
 
@@ -97,9 +101,14 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 	}
 
 	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
+	rateLimited, retryAfter := false, time.Duration(0)
+	if !c.disableRateLimitHints {
+		rateLimited, retryAfter = classifyRateLimitResponse(resp)
+	}
+
 	// the caller doesn't care about the response body so we return early
 	if resp.Body == nil || (reqErr == nil && expectedBody == nil) || (reqErr != nil && errorBody == nil) {
-		return resp.StatusCode, reqErr
+		return resp.StatusCode, c.maybeWrapRateLimit(reqErr, rateLimited, retryAfter)
 	}
 
 	defer func() {
@@ -116,10 +125,16 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 	}
 
 	if reqErr != nil {
-		if err = json.Unmarshal(rawBody, errorBody); err != nil {
-			return resp.StatusCode, fmt.Errorf("failed to unmarshal error response (%w) with status %d: %w", err, resp.StatusCode, reqErr)
+		// Empty error bodies are common on bare 429s and some 5xx
+		// responses; skip the unmarshal in that case so we don't lose
+		// the rate-limit classification to a "unexpected end of JSON
+		// input" failure.
+		if len(rawBody) > 0 {
+			if err = json.Unmarshal(rawBody, errorBody); err != nil {
+				return resp.StatusCode, fmt.Errorf("failed to unmarshal error response (%w) with status %d: %w", err, resp.StatusCode, reqErr)
+			}
 		}
-		return resp.StatusCode, reqErr
+		return resp.StatusCode, c.maybeWrapRateLimit(reqErr, rateLimited, retryAfter)
 	}
 
 	// TODO: assuming json bodies for now, but may need to handle other body types
@@ -127,4 +142,16 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 		return resp.StatusCode, fmt.Errorf("failed to unmarshal response with status %d: %w", resp.StatusCode, err)
 	}
 	return resp.StatusCode, nil
+}
+
+// maybeWrapRateLimit upgrades a status-driven error into
+// *plugins.RateLimitedError when the response was classified as
+// rate-limited. The wrapping keeps errors.Is(err, ErrUpstreamRatelimit)
+// AND errors.Is(err, ErrStatusCode*) both satisfied, so existing
+// connector code that branches on either sentinel keeps working.
+func (c *client) maybeWrapRateLimit(reqErr error, rateLimited bool, retryAfter time.Duration) error {
+	if !rateLimited || reqErr == nil {
+		return reqErr
+	}
+	return plugins.NewRateLimitedError(retryAfter, reqErr)
 }

--- a/internal/connectors/httpwrapper/config.go
+++ b/internal/connectors/httpwrapper/config.go
@@ -13,4 +13,14 @@ type Config struct {
 	Timeout     time.Duration
 	Transport   http.RoundTripper
 	OAuthConfig *clientcredentials.Config
+
+	// DisableRateLimitHints opts OUT of rate-limit header parsing. By
+	// default the client honours RFC 9110 Retry-After and
+	// draft-ietf-httpapi-ratelimit-headers RateLimit on 429 / 5xx-with-
+	// RateLimit-header responses, surfacing them as
+	// *plugins.RateLimitedError so the engine's temporalPluginErrorCheck
+	// feeds the hint into Temporal's NextRetryDelay (clamped to a
+	// safety ceiling to defend against absurd values per RFC 9110 §8.4).
+	// Set true only if a connector needs to bypass that path entirely.
+	DisableRateLimitHints bool
 }

--- a/internal/connectors/httpwrapper/ratelimit.go
+++ b/internal/connectors/httpwrapper/ratelimit.go
@@ -1,0 +1,162 @@
+package httpwrapper
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MaxRateLimitHint caps the wait we will honour from an upstream
+// server. RFC 9110 §8.4 explicitly warns that Retry-After values can be
+// excessive (accidentally or maliciously); this ceiling preserves
+// Temporal's default retry behaviour as the upper bound and prevents a
+// single misbehaving response from parking a workflow attempt for days.
+const MaxRateLimitHint = time.Hour
+
+// ParseRateLimitHeaders reads the wait hint per RFC 9110 §10.2.3
+// (Retry-After) and draft-ietf-httpapi-ratelimit-headers-10 §4.1.2
+// (RateLimit "t" parameter). Precedence per IETF §6: Retry-After wins,
+// then the smallest "t" across listed policies, then zero. The bool
+// distinguishes "no signal" from "0 seconds, retry now".
+//
+// Honoured by httpwrapper Do() by default; opt out via
+// Config.DisableRateLimitHints. The parsed wait surfaces as
+// *plugins.RateLimitedError, which the engine's temporalPluginErrorCheck
+// feeds into Temporal's per-error NextRetryDelay.
+func ParseRateLimitHeaders(h http.Header, now time.Time) (time.Duration, bool) {
+	hasSignal := false
+
+	if v := strings.TrimSpace(h.Get("Retry-After")); v != "" {
+		hasSignal = true
+		if d, ok := parseRetryAfter(v, now); ok {
+			return d, true
+		}
+	}
+
+	if values := h.Values("RateLimit"); len(values) > 0 {
+		hasSignal = true
+		if d, ok := parseRateLimitField(values); ok {
+			return d, true
+		}
+	}
+
+	return 0, hasSignal
+}
+
+// parseRetryAfter accepts RFC 9110's two shapes: delta-seconds or
+// HTTP-date.
+func parseRetryAfter(v string, now time.Time) (time.Duration, bool) {
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, true
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	for _, layout := range []string{http.TimeFormat, time.RFC1123, time.RFC1123Z, time.RFC850, time.ANSIC} {
+		if t, err := time.Parse(layout, v); err == nil {
+			d := t.Sub(now)
+			if d < 0 {
+				return 0, true
+			}
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+// parseRateLimitField returns the smallest "t" (reset) across listed
+// policies. We don't pull in a full RFC 8941 SF parser because we only
+// need the "t" parameter. Accepted shapes:
+//
+//	RateLimit: "default";r=50;t=30
+//	RateLimit: "permin";r=0;t=12, "perhour";r=900;t=1500
+func parseRateLimitField(values []string) (time.Duration, bool) {
+	var (
+		smallest time.Duration
+		found    bool
+	)
+	for _, raw := range values {
+		for _, policy := range splitTopLevelCommas(raw) {
+			for _, part := range strings.Split(policy, ";") {
+				part = strings.TrimSpace(part)
+				if !strings.HasPrefix(part, "t=") {
+					continue
+				}
+				secs, err := strconv.Atoi(strings.TrimPrefix(part, "t="))
+				if err != nil || secs < 0 {
+					continue
+				}
+				d := time.Duration(secs) * time.Second
+				if !found || d < smallest {
+					smallest = d
+					found = true
+				}
+			}
+		}
+	}
+	return smallest, found
+}
+
+// splitTopLevelCommas splits on commas outside quoted strings — RFC 8941
+// allows escaped quotes inside quoted strings, so a naïve strings.Split
+// would mis-handle inputs like `"a,b";q=1`.
+func splitTopLevelCommas(s string) []string {
+	var (
+		out     []string
+		buf     strings.Builder
+		inQuote bool
+		escape  bool
+	)
+	for _, r := range s {
+		switch {
+		case escape:
+			buf.WriteRune(r)
+			escape = false
+		case r == '\\' && inQuote:
+			buf.WriteRune(r)
+			escape = true
+		case r == '"':
+			buf.WriteRune(r)
+			inQuote = !inQuote
+		case r == ',' && !inQuote:
+			out = append(out, strings.TrimSpace(buf.String()))
+			buf.Reset()
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	if last := strings.TrimSpace(buf.String()); last != "" {
+		out = append(out, last)
+	}
+	return out
+}
+
+// classifyRateLimitResponse flags whether a response should be surfaced
+// as a rate-limit error. Per IETF §6, RateLimit headers can accompany any
+// status code; their presence on a 5xx is the server signalling quota/
+// capacity, not a generic outage. 429 is always classified as rate-limit
+// regardless of headers.
+func classifyRateLimitResponse(resp *http.Response) (rateLimited bool, retryAfter time.Duration) {
+	if resp == nil {
+		return false, 0
+	}
+	wait, hasSignal := ParseRateLimitHeaders(resp.Header, time.Now())
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return true, clampRateLimitHint(wait)
+	case resp.StatusCode >= http.StatusInternalServerError && hasSignal:
+		return true, clampRateLimitHint(wait)
+	}
+	return false, 0
+}
+
+// clampRateLimitHint caps a parsed hint to MaxRateLimitHint. Negative
+// or zero values are passed through untouched (a zero hint means "no
+// wait", which the engine then clamps against its own floor).
+func clampRateLimitHint(d time.Duration) time.Duration {
+	if d > MaxRateLimitHint {
+		return MaxRateLimitHint
+	}
+	return d
+}

--- a/internal/connectors/httpwrapper/ratelimit_test.go
+++ b/internal/connectors/httpwrapper/ratelimit_test.go
@@ -1,0 +1,286 @@
+package httpwrapper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/formancehq/payments/internal/connectors/plugins"
+)
+
+// Exhaustive coverage of the four header shapes the standards allow:
+//   - RFC 9110 Retry-After: delta-seconds (positive, negative, zero)
+//   - RFC 9110 Retry-After: HTTP-date (future, past)
+//   - IETF draft RateLimit: single policy with t
+//   - IETF draft RateLimit: multiple policies (smallest t wins)
+//   - IETF draft RateLimit: list split across multiple headers
+//
+// Precedence (per IETF §6): Retry-After wins when present, else the
+// smallest t across listed policies, else nil.
+func TestParseRateLimitHeaders(t *testing.T) {
+	now := time.Date(2025, 5, 1, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		headers  http.Header
+		wantWait time.Duration
+		wantHas  bool
+	}{
+		{
+			name:     "no headers",
+			headers:  http.Header{},
+			wantWait: 0,
+			wantHas:  false,
+		},
+		{
+			name:     "Retry-After delta-seconds",
+			headers:  http.Header{"Retry-After": []string{"7"}},
+			wantWait: 7 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name:     "Retry-After negative delta normalised to zero",
+			headers:  http.Header{"Retry-After": []string{"-1"}},
+			wantWait: 0,
+			wantHas:  true,
+		},
+		{
+			name:     "Retry-After HTTP-date",
+			headers:  http.Header{"Retry-After": []string{now.Add(45 * time.Second).Format(http.TimeFormat)}},
+			wantWait: 45 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name:     "Retry-After HTTP-date in the past clamps to zero",
+			headers:  http.Header{"Retry-After": []string{now.Add(-30 * time.Second).Format(http.TimeFormat)}},
+			wantWait: 0,
+			wantHas:  true,
+		},
+		{
+			name:     "RateLimit single policy with t",
+			headers:  http.Header{"Ratelimit": []string{`"default";r=0;t=12`}},
+			wantWait: 12 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name:     "RateLimit picks smallest t across multiple policies",
+			headers:  http.Header{"Ratelimit": []string{`"permin";r=0;t=15, "perhour";r=900;t=1500`}},
+			wantWait: 15 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name: "RateLimit split across multiple headers picks smallest",
+			headers: http.Header{"Ratelimit": []string{
+				`"permin";r=0;t=8`,
+				`"perday";r=10000;t=86400`,
+			}},
+			wantWait: 8 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name: "Retry-After wins over RateLimit per IETF §6",
+			headers: http.Header{
+				"Retry-After": []string{"60"},
+				"Ratelimit":   []string{`"default";r=0;t=10`},
+			},
+			wantWait: 60 * time.Second,
+			wantHas:  true,
+		},
+		{
+			name:     "RateLimit without t parameter is ignored but signals presence",
+			headers:  http.Header{"Ratelimit": []string{`"default";r=0`}},
+			wantWait: 0,
+			wantHas:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotWait, gotHas := ParseRateLimitHeaders(tc.headers, now)
+			if gotWait != tc.wantWait {
+				t.Errorf("wait want %s got %s", tc.wantWait, gotWait)
+			}
+			if gotHas != tc.wantHas {
+				t.Errorf("hasSignal want %v got %v", tc.wantHas, gotHas)
+			}
+		})
+	}
+}
+
+// classifyRateLimitResponse contract:
+//   - 429 is rate-limited regardless of headers (some PSPs return bare 429).
+//   - 5xx is rate-limited ONLY when the server attached a RateLimit
+//     header — per IETF §6, those headers can accompany any status code
+//     and their presence on a 5xx is the server explicitly signalling
+//     quota/capacity rather than a generic outage.
+//   - 2xx and 4xx (other than 429) are never rate-limited.
+//   - parsed waits are clamped to MaxRateLimitHint to defend against
+//     absurd Retry-After values (RFC 9110 §8.4 warning).
+func TestClassifyRateLimitResponse(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		headers  http.Header
+		want     bool
+		wantWait time.Duration
+	}{
+		{"429 with no hint", 429, http.Header{}, true, 0},
+		{"429 with Retry-After", 429, http.Header{"Retry-After": []string{"45"}}, true, 45 * time.Second},
+		{"429 with RateLimit", 429, http.Header{"Ratelimit": []string{`"default";r=0;t=30`}}, true, 30 * time.Second},
+		{"429 with absurd Retry-After clamped to ceiling", 429, http.Header{"Retry-After": []string{"86400"}}, true, MaxRateLimitHint},
+		{"503 with RateLimit (capacity signal)", 503, http.Header{"Ratelimit": []string{`"default";r=0;t=120`}}, true, 120 * time.Second},
+		{"503 with absurd RateLimit t clamped to ceiling", 503, http.Header{"Ratelimit": []string{`"default";r=0;t=999999`}}, true, MaxRateLimitHint},
+		{"503 without RateLimit (generic outage)", 503, http.Header{}, false, 0},
+		{"500 without RateLimit", 500, http.Header{}, false, 0},
+		{"502 without RateLimit", 502, http.Header{}, false, 0},
+		{"400 with RateLimit is ignored", 400, http.Header{"Ratelimit": []string{`"default";r=0;t=10`}}, false, 0},
+		{"201 with RateLimit is ignored (success)", 201, http.Header{"Ratelimit": []string{`"default";r=99;t=60`}}, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: tc.status, Header: tc.headers}
+			got, gotWait := classifyRateLimitResponse(resp)
+			if got != tc.want {
+				t.Errorf("rateLimited want %v got %v", tc.want, got)
+			}
+			if gotWait != tc.wantWait {
+				t.Errorf("retryAfter want %s got %s", tc.wantWait, gotWait)
+			}
+		})
+	}
+}
+
+// End-to-end: rate-limit parsing is on by default. Do() upgrades a 429
+// into *plugins.RateLimitedError carrying the parsed hint. Keeps the
+// httpwrapper status sentinel intact via wrap-Cause so callers that
+// branch on either errors.Is(err, ErrStatusCodeTooManyRequests) OR
+// errors.Is(err, plugins.ErrUpstreamRatelimit) keep working.
+func TestDo_Default_Wraps429AsRateLimitedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.Header().Set("RateLimit", `"default";r=0;t=42`)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"type":"https://iana.org/assignments/http-problem-types#quota-exceeded"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	var errBody map[string]any
+	_, err := c.Do(context.Background(), req, nil, &errBody)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Errorf("expected errors.Is(_, ErrUpstreamRatelimit), got %v", err)
+	}
+	if !errors.Is(err, ErrStatusCodeTooManyRequests) {
+		t.Errorf("expected errors.Is(_, ErrStatusCodeTooManyRequests) to still hold for backward compatibility, got %v", err)
+	}
+	var rl *plugins.RateLimitedError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *plugins.RateLimitedError, got %T", err)
+	}
+	if rl.RetryAfter != 42*time.Second {
+		t.Errorf("RetryAfter want 42s got %s", rl.RetryAfter)
+	}
+}
+
+// Explicit opt-out: when DisableRateLimitHints=true, Do() bypasses the
+// rate-limit upgrade and returns the plain status-driven sentinel — the
+// escape hatch for connectors that need to keep the old behaviour.
+func TestDo_DisableRateLimitHints_NoRateLimitedErrorWrapper(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{DisableRateLimitHints: true})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := c.Do(context.Background(), req, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrStatusCodeTooManyRequests) {
+		t.Errorf("expected ErrStatusCodeTooManyRequests, got %v", err)
+	}
+	if errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Errorf("opt-out client must NOT wrap into RateLimitedError; got %v", err)
+	}
+}
+
+// 503 with a RateLimit header (per IETF §6 a quota signal, not a
+// generic outage) classifies as rate-limited under the default config.
+func TestDo_Default_Wraps503WithRateLimitHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("RateLimit", `"capacity";r=0;t=120`)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := c.Do(context.Background(), req, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Fatalf("503 with RateLimit header must classify as rate-limited; got %v", err)
+	}
+	var rl *plugins.RateLimitedError
+	if !errors.As(err, &rl) || rl.RetryAfter != 120*time.Second {
+		t.Fatalf("expected RetryAfter=120s; got %v", err)
+	}
+}
+
+// Plain 5xx without rate-limit headers stays a generic server error
+// (engine applies its standard backoff). Guards against the
+// over-classification trap where every transient outage gets treated
+// as a quota event.
+func TestDo_Default_503WithoutHeaderStaysServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := c.Do(context.Background(), req, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Fatalf("plain 5xx must NOT classify as rate-limited; got %v", err)
+	}
+	if !errors.Is(err, ErrStatusCodeServerError) {
+		t.Fatalf("expected ErrStatusCodeServerError; got %v", err)
+	}
+}
+
+// Absurd Retry-After values must be clamped to MaxRateLimitHint
+// (RFC 9110 §8.4 warning): a misbehaving server can't park a workflow
+// attempt for hours/days by replying with Retry-After: 86400.
+func TestDo_Default_ClampsAbsurdRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "86400")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := c.Do(context.Background(), req, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var rl *plugins.RateLimitedError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *plugins.RateLimitedError, got %T", err)
+	}
+	if rl.RetryAfter != MaxRateLimitHint {
+		t.Errorf("RetryAfter want %s (clamped); got %s", MaxRateLimitHint, rl.RetryAfter)
+	}
+}

--- a/internal/connectors/plugins/errors.go
+++ b/internal/connectors/plugins/errors.go
@@ -2,6 +2,8 @@ package plugins
 
 import (
 	"errors"
+	"fmt"
+	"time"
 )
 
 var (
@@ -13,3 +15,39 @@ var (
 	ErrUpstreamRetryAfter   = errors.New("upstream asked to retry later")
 	ErrCurrencyNotSupported = errors.New("currency not supported")
 )
+
+// RateLimitedError carries an upstream wait hint alongside the
+// ErrUpstreamRatelimit sentinel. Plugins parse it from RFC 9110
+// Retry-After and/or draft-ietf-httpapi-ratelimit-headers RateLimit
+// headers; the engine's temporalPluginErrorCheck feeds RetryAfter into
+// Temporal's per-error NextRetryDelay. Wraps ErrUpstreamRatelimit so
+// existing errors.Is(err, ErrUpstreamRatelimit) call sites stay green.
+type RateLimitedError struct {
+	// RetryAfter: zero means no hint (engine falls back to its static delay).
+	RetryAfter time.Duration
+	// Cause is the underlying transport error, preserved for logging.
+	Cause error
+}
+
+func (e *RateLimitedError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s", ErrUpstreamRatelimit.Error(), e.Cause.Error())
+	}
+	return ErrUpstreamRatelimit.Error()
+}
+
+func (e *RateLimitedError) Unwrap() []error {
+	if e.Cause != nil {
+		return []error{ErrUpstreamRatelimit, e.Cause}
+	}
+	return []error{ErrUpstreamRatelimit}
+}
+
+// NewRateLimitedError treats negative retryAfter as "no hint" so callers
+// can pass a parsed-but-absent header value directly.
+func NewRateLimitedError(retryAfter time.Duration, cause error) *RateLimitedError {
+	if retryAfter < 0 {
+		retryAfter = 0
+	}
+	return &RateLimitedError{RetryAfter: retryAfter, Cause: cause}
+}

--- a/internal/connectors/plugins/errors_test.go
+++ b/internal/connectors/plugins/errors_test.go
@@ -1,0 +1,79 @@
+package plugins_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/formancehq/payments/internal/connectors/plugins"
+)
+
+// Backward-compat invariant: every existing connector that returns
+// plugins.ErrUpstreamRatelimit (with errors.Is at the call-site) must keep
+// working when a wrapped RateLimitedError flows through the same channel.
+func TestRateLimitedErrorIsErrUpstreamRatelimit(t *testing.T) {
+	err := plugins.NewRateLimitedError(5*time.Second, errors.New("429 too many requests"))
+	if !errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Fatalf("RateLimitedError must satisfy errors.Is(_, ErrUpstreamRatelimit) for backward compatibility")
+	}
+}
+
+func TestRateLimitedErrorPreservesCauseInIs(t *testing.T) {
+	cause := fmt.Errorf("connection reset by peer")
+	err := plugins.NewRateLimitedError(0, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("RateLimitedError must keep its Cause reachable via errors.Is")
+	}
+}
+
+func TestRateLimitedErrorAsExposesHint(t *testing.T) {
+	err := error(plugins.NewRateLimitedError(7*time.Second, nil))
+	var typed *plugins.RateLimitedError
+	if !errors.As(err, &typed) {
+		t.Fatalf("errors.As must recover *RateLimitedError")
+	}
+	if typed.RetryAfter != 7*time.Second {
+		t.Fatalf("RetryAfter want 7s, got %s", typed.RetryAfter)
+	}
+}
+
+func TestRateLimitedErrorNegativeHintNormalizedToZero(t *testing.T) {
+	err := plugins.NewRateLimitedError(-1*time.Second, nil)
+	if err.RetryAfter != 0 {
+		t.Fatalf("negative RetryAfter must be normalised to 0, got %s", err.RetryAfter)
+	}
+}
+
+// Error() with a cause: surfaces both the canonical sentinel message and
+// the underlying transport error so log triage has the original context.
+func TestRateLimitedErrorMessageWithCause(t *testing.T) {
+	cause := errors.New("connection reset by peer")
+	got := plugins.NewRateLimitedError(5*time.Second, cause).Error()
+	if !strings.Contains(got, plugins.ErrUpstreamRatelimit.Error()) {
+		t.Errorf("missing rate-limit sentinel in %q", got)
+	}
+	if !strings.Contains(got, "connection reset by peer") {
+		t.Errorf("missing cause in %q", got)
+	}
+}
+
+// Error() without a cause: returns just the sentinel string (no spurious
+// suffix).
+func TestRateLimitedErrorMessageWithoutCause(t *testing.T) {
+	got := plugins.NewRateLimitedError(0, nil).Error()
+	if got != plugins.ErrUpstreamRatelimit.Error() {
+		t.Errorf("Error() with no cause = %q, want %q", got, plugins.ErrUpstreamRatelimit.Error())
+	}
+}
+
+// Unwrap() with no cause: just exposes the canonical sentinel so
+// errors.Is(_, ErrUpstreamRatelimit) keeps working when the plugin
+// surfaces a hint without a wrapped transport error.
+func TestRateLimitedErrorUnwrapNoCauseStillExposesSentinel(t *testing.T) {
+	err := error(plugins.NewRateLimitedError(3*time.Second, nil))
+	if !errors.Is(err, plugins.ErrUpstreamRatelimit) {
+		t.Fatalf("errors.Is(_, ErrUpstreamRatelimit) must hold even without a cause")
+	}
+}

--- a/internal/connectors/plugins/registry/errors.go
+++ b/internal/connectors/plugins/registry/errors.go
@@ -13,6 +13,12 @@ func translateError(err error) error {
 	switch {
 	case errors.Is(err, plugins.ErrNotImplemented):
 		return err
+	// Already a typed RateLimitedError (httpwrapper default-on path):
+	// preserve it as-is so the engine's temporalPluginErrorCheck can
+	// extract RetryAfter via errors.As. Skipping the wrap also avoids
+	// a redundant ErrUpstreamRatelimit in the error chain.
+	case isRateLimited(err):
+		return err
 	case errors.Is(err, models.ErrMissingFromPayloadInRequest),
 		errors.Is(err, models.ErrMissingAccountInRequest),
 		errors.Is(err, models.ErrInvalidRequest),
@@ -43,4 +49,9 @@ func translateError(err error) error {
 	default:
 		return err
 	}
+}
+
+func isRateLimited(err error) bool {
+	var rl *plugins.RateLimitedError
+	return errors.As(err, &rl)
 }


### PR DESCRIPTION
## Summary

Honour RFC 9110 `Retry-After` + IETF draft `RateLimit` headers by default across every connector, clamped to a 1h ceiling (RFC 9110 §8.4) against absurd values. Connectors keep an explicit `Config.DisableRateLimitHints` escape hatch.

Carved out of #711 (Routable connector) so it can land independently and benefit the entire connector fleet. Routable inherits the default-on behaviour automatically once both PRs are in main, in either order.

## What changes

- `internal/connectors/httpwrapper/ratelimit.go` (new): shared parser for Retry-After + RateLimit headers, 1h safety ceiling.
- `internal/connectors/httpwrapper/{config.go, client.go}`: `Do()` wraps 429 / 5xx-with-hint responses as `*plugins.RateLimitedError` by default.
- `internal/connectors/plugins/errors.go`: new `RateLimitedError` type wrapping `ErrUpstreamRatelimit` (backward-compatible — every `errors.Is(err, ErrUpstreamRatelimit)` call site stays green).
- `internal/connectors/plugins/regry/errors.go`: short-circuits typed `RateLimitedError` so it's not redundantly re-wrapped.
- `internal/connectors/engine/activities/errors.go`: feeds `RetryAfter` into Temporal's per-error `NextRetryDelay`, clamped to the configured static floor.

## Behaviour shift

- Every PSP that already sends `Retry-After` (verified per public docs: Plaid, Wise, Qonto) now hands the engine a concrete retry hint instead of falling back to the static `--temporal-rate-limiting-retry-delay` floor.
- Every PSP that sends nothing: no change.
- Misbehaving servers can no longer park a workflow attempt for hours — capped at 1h.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/connectors/httpwrapper/... ./internal/connectors/plugins/... ./internal/connectors/engine/activities/...` (all green, including every existing connector: adyen / atlar / bankingcircle / column / currencycloud / generic / increase / mangopay / modulr / moneycorp / plaid / powens / qonto / stripe / tink / wise)
- [x] `just pc` clean
- [ ] C
## Follow-ups (separate PRs)

Per-connector adapters for custom rate-limit headers not covered by the standards parser:
- Stripe: `Stripe-Rate-Limited-Reason`
- Modulr: `x-ratelimit-{limit,remaining,reset}`
- Mangopay: `x-ratelimit-{,-remaining,-reset}`