### PR TITLE
fix(fireblocks): EN-1011 align asset regex with Ledger and canonicalize asset emission

### DIFF
--- a/ee/plugins/fireblocks/accounts.go
+++ b/ee/plugins/fireblocks/accounts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
 	"github.com/formancehq/payments/internal/models"
 )
 
@@ -41,6 +42,7 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 			Reference: account.ID,
 			CreatedAt: createdAt,
 			Name:      &account.Name,
+			Metadata:  buildAccountMetadata(account),
 			Raw:       raw,
 		})
 	}
@@ -61,4 +63,23 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		NewState: payload,
 		HasMore:  hasMore,
 	}, nil
+}
+
+// buildAccountMetadata surfaces vault-level context that the engine drops
+// otherwise. Booleans are emitted only when true so the map stays small.
+func buildAccountMetadata(a client.VaultAccount) map[string]string {
+	m := map[string]string{}
+	if a.CustomerRefID != "" {
+		m[MetadataPrefix+"customer_ref_id"] = a.CustomerRefID
+	}
+	if a.HiddenOnUI {
+		m[MetadataPrefix+"hidden_on_ui"] = boolStr(true)
+	}
+	if a.AutoFuel {
+		m[MetadataPrefix+"auto_fuel"] = boolStr(true)
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }

--- a/ee/plugins/fireblocks/accounts.go
+++ b/ee/plugins/fireblocks/accounts.go
@@ -65,8 +65,9 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	}, nil
 }
 
-// buildAccountMetadata surfaces vault-level context. Booleans are emitted only
-// when true so the map stays small; nil is returned when nothing applies.
+// buildAccountMetadata surfaces vault-level context. Each key is emitted only
+// when the source field is non-zero (non-empty string, true bool); nil is
+// returned when nothing applies.
 func buildAccountMetadata(a client.VaultAccount) map[string]string {
 	m := map[string]string{}
 	if a.CustomerRefID != "" {

--- a/ee/plugins/fireblocks/accounts.go
+++ b/ee/plugins/fireblocks/accounts.go
@@ -65,18 +65,18 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	}, nil
 }
 
-// buildAccountMetadata surfaces vault-level context that the engine drops
-// otherwise. Booleans are emitted only when true so the map stays small.
+// buildAccountMetadata surfaces vault-level context. Booleans are emitted only
+// when true so the map stays small; nil is returned when nothing applies.
 func buildAccountMetadata(a client.VaultAccount) map[string]string {
 	m := map[string]string{}
 	if a.CustomerRefID != "" {
 		m[MetadataPrefix+"customer_ref_id"] = a.CustomerRefID
 	}
 	if a.HiddenOnUI {
-		m[MetadataPrefix+"hidden_on_ui"] = boolStr(true)
+		m[MetadataPrefix+"hidden_on_ui"] = "true"
 	}
 	if a.AutoFuel {
-		m[MetadataPrefix+"auto_fuel"] = boolStr(true)
+		m[MetadataPrefix+"auto_fuel"] = "true"
 	}
 	if len(m) == 0 {
 		return nil

--- a/ee/plugins/fireblocks/accounts_test.go
+++ b/ee/plugins/fireblocks/accounts_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Fireblocks Plugin Accounts", func() {
 		ctrl.Finish()
 	})
 
-	It("fetches next accounts with cursor", func(ctx SpecContext) {
+	It("fetches next accounts with cursor and surfaces vault metadata", func(ctx SpecContext) {
 		state, err := json.Marshal(accountsState{NextCursor: "cursor-1"})
 		Expect(err).To(BeNil())
 
@@ -36,9 +36,12 @@ var _ = Describe("Fireblocks Plugin Accounts", func() {
 		m.EXPECT().GetVaultAccountsPaged(gomock.Any(), "cursor-1", 2).Return(&client.VaultAccountsPagedResponse{
 			Accounts: []client.VaultAccount{
 				{
-					ID:           "acc-1",
-					Name:         "Treasury",
-					CreationDate: creationDate,
+					ID:            "acc-1",
+					Name:          "Treasury",
+					CustomerRefID: "cust-42",
+					HiddenOnUI:    true,
+					AutoFuel:      true,
+					CreationDate:  creationDate,
 				},
 				{
 					ID:           "acc-2",
@@ -56,10 +59,17 @@ var _ = Describe("Fireblocks Plugin Accounts", func() {
 		Expect(err).To(BeNil())
 		Expect(resp.Accounts).To(HaveLen(2))
 		Expect(resp.HasMore).To(BeTrue())
+
 		Expect(resp.Accounts[0].Reference).To(Equal("acc-1"))
 		Expect(*resp.Accounts[0].Name).To(Equal("Treasury"))
 		Expect(resp.Accounts[0].CreatedAt).To(Equal(time.Unix(1700000000, 0)))
 		Expect(resp.Accounts[0].Raw).ToNot(BeNil())
+		Expect(resp.Accounts[0].Metadata).To(HaveKeyWithValue(MetadataPrefix+"customer_ref_id", "cust-42"))
+		Expect(resp.Accounts[0].Metadata).To(HaveKeyWithValue(MetadataPrefix+"hidden_on_ui", "true"))
+		Expect(resp.Accounts[0].Metadata).To(HaveKeyWithValue(MetadataPrefix+"auto_fuel", "true"))
+
+		// Defaults: no metadata emitted when source fields are empty / false.
+		Expect(resp.Accounts[1].Metadata).To(BeNil())
 
 		var newState accountsState
 		err = json.Unmarshal(resp.NewState, &newState)

--- a/ee/plugins/fireblocks/assets_sync.go
+++ b/ee/plugins/fireblocks/assets_sync.go
@@ -87,8 +87,13 @@ func (p *Plugin) loadAssets(ctx context.Context) error {
 	p.assetsLastSync = time.Now()
 	p.assetsMu.Unlock()
 
-	p.logger.Infof("loaded %d fireblocks assets (%d skipped, %d testnet blockchains)",
-		len(out), skipped, len(testnetByBlockchain))
+	if len(out) == 0 {
+		p.logger.Errorf("loaded 0 fireblocks assets (%d skipped) — Fireblocks may have changed the legacyId surface or the workspace is empty",
+			skipped)
+	} else {
+		p.logger.Infof("loaded %d fireblocks assets (%d skipped, %d testnet blockchains)",
+			len(out), skipped, len(testnetByBlockchain))
+	}
 	return nil
 }
 

--- a/ee/plugins/fireblocks/assets_sync.go
+++ b/ee/plugins/fireblocks/assets_sync.go
@@ -3,28 +3,19 @@ package fireblocks
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
 )
 
-// assetInfo is the per-asset cache entry built from /v1/assets at install /
-// refresh time. The map is keyed by uppercased legacyId.
+// assetInfo is the per-asset cache entry built from /v1/assets at refresh time.
 type assetInfo struct {
-	// Asset is the canonical Formance asset string ("USDT/6", "ETH/18", ...).
-	Asset string
-	// Precision is the decimals count used to scale string amounts.
-	Precision int
-	// BlockchainID is captured separately (in addition to being included in
-	// Metadata) so balance aggregation can join chain ids for collapsed entries.
+	Asset        string // canonical Formance asset, e.g. "USDT/6"
+	Precision    int
 	BlockchainID string
-	// LegacyID is preserved for the same reason — needed by aggregation.
-	LegacyID string
-	// Metadata is the per-asset slice of MetadataPrefix-namespaced kv pairs
-	// to copy onto every PSPBalance / PSPPayment that uses this asset.
-	Metadata map[string]string
+	LegacyID     string
+	Metadata     map[string]string // copied onto every PSPPayment using this asset
 }
 
 func (p *Plugin) ensureAssetsFresh(ctx context.Context) error {
@@ -48,9 +39,7 @@ func (p *Plugin) ensureAssetsFresh(ctx context.Context) error {
 	return p.loadAssets(ctx)
 }
 
-// lookupAsset resolves a Fireblocks legacyId (case-insensitive) against the
-// cached asset map. Callers should treat a `false` second return as "skip
-// this entry with a log" — never as a fatal error.
+// lookupAsset resolves a Fireblocks legacyId (case-insensitive) against the cache.
 func (p *Plugin) lookupAsset(legacyID string) (assetInfo, bool) {
 	p.assetsMu.RLock()
 	defer p.assetsMu.RUnlock()
@@ -86,9 +75,7 @@ func (p *Plugin) loadAssets(ctx context.Context) error {
 			continue
 		}
 		if a.LegacyID == "" {
-			// Without a legacyId vault accounts cannot reference this asset
-			// (vaults use legacyIds, never UUIDs), so caching it would be dead
-			// weight. Fireblocks docs explicitly say "use only the legacy ID".
+			// Vaults reference assets by legacyId only.
 			skipped++
 			continue
 		}
@@ -249,7 +236,3 @@ func buildAssetMetadata(a client.Asset, isTestnet bool) map[string]string {
 
 	return m
 }
-
-// boolStr renders a bool as the strings "true"/"false" used by the metadata
-// payload. Pulled out for symmetry with the int/string conversions below.
-func boolStr(b bool) string { return strconv.FormatBool(b) }

--- a/ee/plugins/fireblocks/assets_sync.go
+++ b/ee/plugins/fireblocks/assets_sync.go
@@ -2,12 +2,34 @@ package fireblocks
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
 )
+
+// assetInfo is the per-asset cache entry built from /v1/assets at install /
+// refresh time. The map is keyed by uppercased legacyId.
+type assetInfo struct {
+	// Asset is the canonical Formance asset string ("USDT/6", "ETH/18", ...).
+	Asset string
+	// Precision is the decimals count used to scale string amounts.
+	Precision int
+	// BlockchainID is captured separately (in addition to being included in
+	// Metadata) so balance aggregation can join chain ids for collapsed entries.
+	BlockchainID string
+	// LegacyID is preserved for the same reason — needed by aggregation.
+	LegacyID string
+	// Metadata is the per-asset slice of MetadataPrefix-namespaced kv pairs
+	// to copy onto every PSPBalance / PSPPayment that uses this asset.
+	Metadata map[string]string
+}
 
 func (p *Plugin) ensureAssetsFresh(ctx context.Context) error {
 	p.assetsMu.RLock()
-	needsRefresh := p.assetDecimals == nil || time.Since(p.assetsLastSync) >= assetRefreshInterval
+	needsRefresh := p.assets == nil || time.Since(p.assetsLastSync) >= assetRefreshInterval
 	p.assetsMu.RUnlock()
 	if !needsRefresh {
 		return nil
@@ -17,7 +39,7 @@ func (p *Plugin) ensureAssetsFresh(ctx context.Context) error {
 	defer p.assetsRefreshMu.Unlock()
 
 	p.assetsMu.RLock()
-	needsRefresh = p.assetDecimals == nil || time.Since(p.assetsLastSync) >= assetRefreshInterval
+	needsRefresh = p.assets == nil || time.Since(p.assetsLastSync) >= assetRefreshInterval
 	p.assetsMu.RUnlock()
 	if !needsRefresh {
 		return nil
@@ -26,69 +48,187 @@ func (p *Plugin) ensureAssetsFresh(ctx context.Context) error {
 	return p.loadAssets(ctx)
 }
 
-func (p *Plugin) getAssetDecimals() map[string]int {
+// lookupAsset resolves a Fireblocks legacyId (case-insensitive) against the
+// cached asset map. Callers should treat a `false` second return as "skip
+// this entry with a log" — never as a fatal error.
+func (p *Plugin) lookupAsset(legacyID string) (assetInfo, bool) {
 	p.assetsMu.RLock()
 	defer p.assetsMu.RUnlock()
-	return p.assetDecimals
+	info, ok := p.assets[strings.ToUpper(legacyID)]
+	return info, ok
 }
 
 func (p *Plugin) loadAssets(ctx context.Context) error {
-	assets, err := p.client.ListAssets(ctx)
+	rawAssets, err := p.client.ListAssets(ctx)
 	if err != nil {
 		return err
 	}
 
-	assetDecimals := make(map[string]int, len(assets))
+	out := make(map[string]assetInfo, len(rawAssets))
 	var skipped int
-	for _, asset := range assets {
-		if asset.LegacyID == "" && asset.ID == "" {
-			p.logger.Infof("skipping asset with empty identifiers")
+	for _, a := range rawAssets {
+		info, ok := buildAssetInfo(a)
+		if !ok {
+			p.logger.Infof("skipping fireblocks asset legacyId=%q id=%q class=%q",
+				a.LegacyID, a.ID, a.AssetClass)
 			skipped++
 			continue
 		}
-
-		identifier := asset.LegacyID
-		if identifier == "" {
-			identifier = asset.ID
-		}
-
-		var decimals int
-		var hasDecimals bool
-
-		if asset.Onchain != nil {
-			decimals = asset.Onchain.Decimals
-			hasDecimals = true
-		} else if asset.Decimals != nil {
-			// For fiat assets without onchain data, use top-level decimals when provided.
-			decimals = *asset.Decimals
-			hasDecimals = true
-		}
-
-		if !hasDecimals {
-			p.logger.Infof("skipping asset %q: no decimals information", identifier)
+		if a.LegacyID == "" {
+			// Without a legacyId vault accounts cannot reference this asset
+			// (vaults use legacyIds, never UUIDs), so caching it would be dead
+			// weight. Fireblocks docs explicitly say "use only the legacy ID".
 			skipped++
 			continue
 		}
-
-		if decimals < 0 {
-			p.logger.Infof("skipping asset %q: invalid decimals %d", identifier, decimals)
-			skipped++
-			continue
-		}
-
-		if asset.LegacyID != "" {
-			assetDecimals[asset.LegacyID] = decimals
-		}
-		if asset.ID != "" {
-			assetDecimals[asset.ID] = decimals
-		}
+		out[strings.ToUpper(a.LegacyID)] = info
 	}
 
 	p.assetsMu.Lock()
-	p.assetDecimals = assetDecimals
+	p.assets = out
 	p.assetsLastSync = time.Now()
 	p.assetsMu.Unlock()
 
-	p.logger.Infof("loaded %d assets from Fireblocks (%d skipped)", len(assetDecimals), skipped)
+	p.logger.Infof("loaded %d fireblocks assets (%d skipped)", len(out), skipped)
 	return nil
 }
+
+// buildAssetInfo turns a Fireblocks Asset into the cached entry. Returns
+// ok=false for assets that must not be ingested (deprecated, NFT/SFT/VIRTUAL,
+// unknown decimals, sanitization yields empty symbol).
+func buildAssetInfo(a client.Asset) (assetInfo, bool) {
+	if a.Metadata != nil && a.Metadata.Deprecated {
+		return assetInfo{}, false
+	}
+
+	switch a.AssetClass {
+	case client.AssetClassNFT, client.AssetClassSFT, client.AssetClassVirtual:
+		return assetInfo{}, false
+	}
+
+	precision, ok := pickPrecision(a)
+	if !ok {
+		return assetInfo{}, false
+	}
+
+	symbol := a.DisplaySymbol
+	if symbol == "" && a.Onchain != nil {
+		symbol = a.Onchain.Symbol
+	}
+	if symbol == "" {
+		// Last-resort fallback so we keep some signal; legacyId is the only
+		// other string guaranteed to identify the asset.
+		symbol = a.LegacyID
+	}
+
+	asset := canonicalAsset(symbol, precision)
+	if asset == "" {
+		return assetInfo{}, false
+	}
+
+	return assetInfo{
+		Asset:        asset,
+		Precision:    precision,
+		BlockchainID: a.BlockchainID,
+		LegacyID:     a.LegacyID,
+		Metadata:     buildAssetMetadata(a),
+	}, true
+}
+
+// pickPrecision selects decimals based on assetClass: FIAT uses the top-level
+// `decimals`, NATIVE/FT/unknown fall through to onchain. Negative or absent
+// values cause a skip.
+func pickPrecision(a client.Asset) (int, bool) {
+	if a.AssetClass == client.AssetClassFiat {
+		if a.Decimals != nil && *a.Decimals >= 0 {
+			return *a.Decimals, true
+		}
+		// Some FIAT assets ship decimals via onchain too; try that next.
+	}
+	if a.Onchain != nil && a.Onchain.Decimals >= 0 {
+		return a.Onchain.Decimals, true
+	}
+	if a.Decimals != nil && *a.Decimals >= 0 {
+		return *a.Decimals, true
+	}
+	return 0, false
+}
+
+// sanitizeSymbol turns an arbitrary Fireblocks displaySymbol into a Ledger-
+// valid base: uppercase ASCII letters/digits only, first char must be a
+// letter, capped at 17 chars. Returns "" if no valid prefix can be derived.
+func sanitizeSymbol(symbol string) string {
+	var b strings.Builder
+	b.Grow(len(symbol))
+	seenLetter := false
+	for _, r := range strings.ToUpper(symbol) {
+		if b.Len() >= 17 {
+			break
+		}
+		switch {
+		case r >= 'A' && r <= 'Z':
+			seenLetter = true
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			if seenLetter {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}
+
+// canonicalAsset assembles "<sanitized>/<precision>" (or just "<sanitized>"
+// when precision is 0), and returns "" when sanitization fails so callers can
+// skip cleanly.
+func canonicalAsset(symbol string, precision int) string {
+	s := sanitizeSymbol(symbol)
+	if s == "" {
+		return ""
+	}
+	if precision == 0 {
+		return s
+	}
+	return fmt.Sprintf("%s/%d", s, precision)
+}
+
+// buildAssetMetadata captures the Fireblocks-side context that's worth
+// surfacing alongside each balance/payment. Optional fields are omitted when
+// empty / default so the map stays small.
+func buildAssetMetadata(a client.Asset) map[string]string {
+	m := map[string]string{}
+	setIfPresent := func(key, value string) {
+		if value != "" {
+			m[MetadataPrefix+key] = value
+		}
+	}
+
+	setIfPresent("legacy_id", a.LegacyID)
+	setIfPresent("asset_uuid", a.ID)
+	setIfPresent("display_name", a.DisplayName)
+	setIfPresent("display_symbol", a.DisplaySymbol)
+	setIfPresent("blockchain_id", a.BlockchainID)
+	setIfPresent("asset_class", a.AssetClass)
+
+	if a.Onchain != nil {
+		setIfPresent("contract_address", a.Onchain.Address)
+		if len(a.Onchain.Standards) > 0 {
+			m[MetadataPrefix+"token_standard"] = strings.Join(a.Onchain.Standards, ",")
+		}
+	}
+
+	if a.Metadata != nil {
+		if a.Metadata.Verified {
+			m[MetadataPrefix+"verified"] = "true"
+		}
+		if len(a.Metadata.Features) > 0 {
+			m[MetadataPrefix+"features"] = strings.Join(a.Metadata.Features, ",")
+		}
+	}
+
+	return m
+}
+
+// boolStr renders a bool as the strings "true"/"false" used by the metadata
+// payload. Pulled out for symmetry with the int/string conversions below.
+func boolStr(b bool) string { return strconv.FormatBool(b) }

--- a/ee/plugins/fireblocks/assets_sync.go
+++ b/ee/plugins/fireblocks/assets_sync.go
@@ -194,21 +194,15 @@ func sanitizeSymbol(symbol string) string {
 
 // canonicalAsset assembles "<sanitized>[_TEST]/<precision>" (or the bare base
 // when precision is 0). isTestnet appends a `_TEST` segment so testnet and
-// mainnet assets never collide downstream; the base is trimmed to keep the
-// whole identifier within Ledger's 17-char limit before the optional suffix.
+// mainnet assets never collide downstream. Ledger's regex permits the base
+// (capped at 17 chars by sanitizeSymbol) and the suffix independently.
 func canonicalAsset(symbol string, precision int, isTestnet bool) string {
 	s := sanitizeSymbol(symbol)
 	if s == "" {
 		return ""
 	}
 	if isTestnet {
-		const testSuffix = "_TEST"
-		// 17 max for "<base>" + 5 for "_TEST" would overflow Ledger's regex;
-		// the suffix takes priority so we trim the base instead.
-		if max := 17 - len(testSuffix); len(s) > max {
-			s = s[:max]
-		}
-		s += testSuffix
+		s += "_TEST"
 	}
 	if precision == 0 {
 		return s

--- a/ee/plugins/fireblocks/assets_sync.go
+++ b/ee/plugins/fireblocks/assets_sync.go
@@ -59,6 +59,17 @@ func (p *Plugin) lookupAsset(legacyID string) (assetInfo, bool) {
 }
 
 func (p *Plugin) loadAssets(ctx context.Context) error {
+	blockchains, err := p.client.ListBlockchains(ctx)
+	if err != nil {
+		return fmt.Errorf("listing blockchains: %w", err)
+	}
+	testnetByBlockchain := make(map[string]bool, len(blockchains))
+	for _, b := range blockchains {
+		if b.Onchain != nil && b.Onchain.Test {
+			testnetByBlockchain[b.ID] = true
+		}
+	}
+
 	rawAssets, err := p.client.ListAssets(ctx)
 	if err != nil {
 		return err
@@ -67,7 +78,7 @@ func (p *Plugin) loadAssets(ctx context.Context) error {
 	out := make(map[string]assetInfo, len(rawAssets))
 	var skipped int
 	for _, a := range rawAssets {
-		info, ok := buildAssetInfo(a)
+		info, ok := buildAssetInfo(a, testnetByBlockchain[a.BlockchainID])
 		if !ok {
 			p.logger.Infof("skipping fireblocks asset legacyId=%q id=%q class=%q",
 				a.LegacyID, a.ID, a.AssetClass)
@@ -89,14 +100,17 @@ func (p *Plugin) loadAssets(ctx context.Context) error {
 	p.assetsLastSync = time.Now()
 	p.assetsMu.Unlock()
 
-	p.logger.Infof("loaded %d fireblocks assets (%d skipped)", len(out), skipped)
+	p.logger.Infof("loaded %d fireblocks assets (%d skipped, %d testnet blockchains)",
+		len(out), skipped, len(testnetByBlockchain))
 	return nil
 }
 
 // buildAssetInfo turns a Fireblocks Asset into the cached entry. Returns
 // ok=false for assets that must not be ingested (deprecated, NFT/SFT/VIRTUAL,
-// unknown decimals, sanitization yields empty symbol).
-func buildAssetInfo(a client.Asset) (assetInfo, bool) {
+// unknown decimals, sanitization yields empty symbol). isTestnet stamps the
+// canonical asset with a `_TEST` suffix so testnet holdings never aggregate
+// with their mainnet equivalents.
+func buildAssetInfo(a client.Asset, isTestnet bool) (assetInfo, bool) {
 	if a.Metadata != nil && a.Metadata.Deprecated {
 		return assetInfo{}, false
 	}
@@ -121,7 +135,7 @@ func buildAssetInfo(a client.Asset) (assetInfo, bool) {
 		symbol = a.LegacyID
 	}
 
-	asset := canonicalAsset(symbol, precision)
+	asset := canonicalAsset(symbol, precision, isTestnet)
 	if asset == "" {
 		return assetInfo{}, false
 	}
@@ -131,7 +145,7 @@ func buildAssetInfo(a client.Asset) (assetInfo, bool) {
 		Precision:    precision,
 		BlockchainID: a.BlockchainID,
 		LegacyID:     a.LegacyID,
-		Metadata:     buildAssetMetadata(a),
+		Metadata:     buildAssetMetadata(a, isTestnet),
 	}, true
 }
 
@@ -178,13 +192,23 @@ func sanitizeSymbol(symbol string) string {
 	return b.String()
 }
 
-// canonicalAsset assembles "<sanitized>/<precision>" (or just "<sanitized>"
-// when precision is 0), and returns "" when sanitization fails so callers can
-// skip cleanly.
-func canonicalAsset(symbol string, precision int) string {
+// canonicalAsset assembles "<sanitized>[_TEST]/<precision>" (or the bare base
+// when precision is 0). isTestnet appends a `_TEST` segment so testnet and
+// mainnet assets never collide downstream; the base is trimmed to keep the
+// whole identifier within Ledger's 17-char limit before the optional suffix.
+func canonicalAsset(symbol string, precision int, isTestnet bool) string {
 	s := sanitizeSymbol(symbol)
 	if s == "" {
 		return ""
+	}
+	if isTestnet {
+		const testSuffix = "_TEST"
+		// 17 max for "<base>" + 5 for "_TEST" would overflow Ledger's regex;
+		// the suffix takes priority so we trim the base instead.
+		if max := 17 - len(testSuffix); len(s) > max {
+			s = s[:max]
+		}
+		s += testSuffix
 	}
 	if precision == 0 {
 		return s
@@ -195,7 +219,7 @@ func canonicalAsset(symbol string, precision int) string {
 // buildAssetMetadata captures the Fireblocks-side context that's worth
 // surfacing alongside each balance/payment. Optional fields are omitted when
 // empty / default so the map stays small.
-func buildAssetMetadata(a client.Asset) map[string]string {
+func buildAssetMetadata(a client.Asset, isTestnet bool) map[string]string {
 	m := map[string]string{}
 	setIfPresent := func(key, value string) {
 		if value != "" {
@@ -224,6 +248,9 @@ func buildAssetMetadata(a client.Asset) map[string]string {
 		if len(a.Metadata.Features) > 0 {
 			m[MetadataPrefix+"features"] = strings.Join(a.Metadata.Features, ",")
 		}
+	}
+	if isTestnet {
+		m[MetadataPrefix+"testnet"] = "true"
 	}
 
 	return m

--- a/ee/plugins/fireblocks/assets_sync_test.go
+++ b/ee/plugins/fireblocks/assets_sync_test.go
@@ -1,0 +1,159 @@
+package fireblocks
+
+import (
+	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Fireblocks assets helpers", func() {
+	Describe("sanitizeSymbol", func() {
+		DescribeTable("returns a Ledger-valid base or empty",
+			func(in, want string) {
+				Expect(sanitizeSymbol(in)).To(Equal(want))
+			},
+			Entry("uppercase passthrough", "USDT", "USDT"),
+			Entry("lowercase uppercased", "xDAI", "XDAI"),
+			Entry("digit-first prefix stripped", "1INCH", "INCH"),
+			Entry("punctuation dropped", "BQ5R MY TOKEN", "BQ5RMYTOKEN"),
+			Entry("hyphens & underscores dropped", "ETH-AETH_SEPOLIA", "ETHAETHSEPOLIA"),
+			Entry("truncated at 17 chars", "ABCDEFGHIJKLMNOPQRSTUV", "ABCDEFGHIJKLMNOPQ"),
+			Entry("only digits yields empty", "123", ""),
+			Entry("empty input", "", ""),
+		)
+	})
+
+	Describe("canonicalAsset", func() {
+		It("appends precision when non-zero", func() {
+			Expect(canonicalAsset("USDT", 6)).To(Equal("USDT/6"))
+		})
+		It("omits suffix when precision is zero", func() {
+			Expect(canonicalAsset("JPY", 0)).To(Equal("JPY"))
+		})
+		It("returns empty when sanitisation fails", func() {
+			Expect(canonicalAsset("...", 2)).To(BeEmpty())
+		})
+	})
+
+	Describe("buildAssetInfo", func() {
+		It("uses onchain.decimals for fungible tokens", func() {
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "USDT_ERC20",
+				DisplaySymbol: "USDT",
+				BlockchainID:  "chain-eth",
+				AssetClass:    client.AssetClassFT,
+				Onchain: &client.AssetOnchain{
+					Symbol:    "USDT",
+					Address:   "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+					Decimals:  6,
+					Standards: []string{"ERC20"},
+				},
+			})
+			Expect(ok).To(BeTrue())
+			Expect(info.Asset).To(Equal("USDT/6"))
+			Expect(info.Precision).To(Equal(6))
+			Expect(info.BlockchainID).To(Equal("chain-eth"))
+			Expect(info.Metadata[MetadataPrefix+"legacy_id"]).To(Equal("USDT_ERC20"))
+			Expect(info.Metadata[MetadataPrefix+"contract_address"]).To(Equal("0xdAC17F958D2ee523a2206206994597C13D831ec7"))
+			Expect(info.Metadata[MetadataPrefix+"token_standard"]).To(Equal("ERC20"))
+			Expect(info.Metadata[MetadataPrefix+"blockchain_id"]).To(Equal("chain-eth"))
+		})
+
+		It("uses top-level decimals for FIAT", func() {
+			d := 2
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "USD",
+				DisplaySymbol: "USD",
+				AssetClass:    client.AssetClassFiat,
+				Decimals:      &d,
+			})
+			Expect(ok).To(BeTrue())
+			Expect(info.Asset).To(Equal("USD/2"))
+		})
+
+		It("falls back to onchain.symbol when displaySymbol is empty", func() {
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:   "USDC_NEW",
+				AssetClass: client.AssetClassFT,
+				Onchain: &client.AssetOnchain{
+					Symbol:   "USDC",
+					Decimals: 6,
+				},
+			})
+			Expect(ok).To(BeTrue())
+			Expect(info.Asset).To(Equal("USDC/6"))
+		})
+
+		It("sanitises a digit-first displaySymbol", func() {
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "1INCH",
+				DisplaySymbol: "1INCH",
+				AssetClass:    client.AssetClassFT,
+				Onchain:       &client.AssetOnchain{Decimals: 18},
+			})
+			Expect(ok).To(BeTrue())
+			Expect(info.Asset).To(Equal("INCH/18"))
+		})
+
+		It("emits verified+features metadata flags", func() {
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "USDC",
+				DisplaySymbol: "USDC",
+				AssetClass:    client.AssetClassFT,
+				Onchain:       &client.AssetOnchain{Decimals: 6},
+				Metadata: &client.AssetSpecMetadata{
+					Verified: true,
+					Features: []string{"STABLECOIN"},
+				},
+			})
+			Expect(ok).To(BeTrue())
+			Expect(info.Metadata[MetadataPrefix+"verified"]).To(Equal("true"))
+			Expect(info.Metadata[MetadataPrefix+"features"]).To(Equal("STABLECOIN"))
+		})
+
+		It("skips deprecated assets", func() {
+			_, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "OLD",
+				DisplaySymbol: "OLD",
+				AssetClass:    client.AssetClassFT,
+				Onchain:       &client.AssetOnchain{Decimals: 18},
+				Metadata:      &client.AssetSpecMetadata{Deprecated: true},
+			})
+			Expect(ok).To(BeFalse())
+		})
+
+		DescribeTable("skips non-fungible / virtual classes",
+			func(class string) {
+				_, ok := buildAssetInfo(client.Asset{
+					LegacyID:      "X",
+					DisplaySymbol: "X",
+					AssetClass:    class,
+					Onchain:       &client.AssetOnchain{Decimals: 0},
+				})
+				Expect(ok).To(BeFalse())
+			},
+			Entry("NFT", client.AssetClassNFT),
+			Entry("SFT", client.AssetClassSFT),
+			Entry("VIRTUAL", client.AssetClassVirtual),
+		)
+
+		It("skips when no decimals can be derived", func() {
+			_, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "X",
+				DisplaySymbol: "X",
+				AssetClass:    client.AssetClassFT,
+			})
+			Expect(ok).To(BeFalse())
+		})
+
+		It("skips when sanitisation yields empty symbol", func() {
+			_, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "123",
+				DisplaySymbol: "123",
+				AssetClass:    client.AssetClassFT,
+				Onchain:       &client.AssetOnchain{Decimals: 0},
+			})
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/ee/plugins/fireblocks/assets_sync_test.go
+++ b/ee/plugins/fireblocks/assets_sync_test.go
@@ -1,9 +1,13 @@
 package fireblocks
 
 import (
+	"time"
+
+	"github.com/formancehq/go-libs/v3/logging"
 	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 )
 
 var _ = Describe("Fireblocks assets helpers", func() {
@@ -177,3 +181,58 @@ var _ = Describe("Fireblocks assets helpers", func() {
 		})
 	})
 })
+
+var _ = Describe("Fireblocks ensureAssetsFresh", func() {
+	var (
+		ctrl *gomock.Controller
+		m    *client.MockClient
+		plg  *Plugin
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		m = client.NewMockClient(ctrl)
+		plg = &Plugin{
+			logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false),
+			client: m,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("is a no-op when the cache is populated within the TTL", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{"USD": {Asset: "USD/2", Precision: 2}}
+		plg.assetsLastSync = time.Now()
+
+		Expect(plg.ensureAssetsFresh(ctx)).To(Succeed())
+	})
+
+	It("loads assets on first call when the cache is empty", func(ctx SpecContext) {
+		m.EXPECT().ListBlockchains(gomock.Any()).Return(nil, nil)
+		m.EXPECT().ListAssets(gomock.Any()).Return([]client.Asset{
+			{LegacyID: "USD", DisplaySymbol: "USD", AssetClass: client.AssetClassFiat, Decimals: pointerInt(2)},
+		}, nil)
+
+		Expect(plg.ensureAssetsFresh(ctx)).To(Succeed())
+		Expect(plg.assets).To(HaveKey("USD"))
+		Expect(plg.assetsLastSync.IsZero()).To(BeFalse())
+	})
+
+	It("refreshes when assetsLastSync is older than the TTL", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{"USD": {Asset: "USD/2", Precision: 2}}
+		plg.assetsLastSync = time.Now().Add(-2 * assetRefreshInterval)
+
+		m.EXPECT().ListBlockchains(gomock.Any()).Return(nil, nil)
+		m.EXPECT().ListAssets(gomock.Any()).Return([]client.Asset{
+			{LegacyID: "EUR", DisplaySymbol: "EUR", AssetClass: client.AssetClassFiat, Decimals: pointerInt(2)},
+		}, nil)
+
+		Expect(plg.ensureAssetsFresh(ctx)).To(Succeed())
+		Expect(plg.assets).To(HaveKey("EUR"))
+		Expect(plg.assets).ToNot(HaveKey("USD"))
+	})
+})
+
+func pointerInt(v int) *int { return &v }

--- a/ee/plugins/fireblocks/assets_sync_test.go
+++ b/ee/plugins/fireblocks/assets_sync_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Fireblocks assets helpers", func() {
 		It("appends _TEST for testnet assets", func() {
 			Expect(canonicalAsset("ETH", 18, true)).To(Equal("ETH_TEST/18"))
 		})
-		It("trims long bases so the _TEST suffix still fits Ledger's 17-char cap", func() {
-			Expect(canonicalAsset("ABCDEFGHIJKLMNOPQ", 18, true)).To(Equal("ABCDEFGHIJKL_TEST/18"))
+		It("preserves the full 17-char base when appending _TEST", func() {
+			Expect(canonicalAsset("ABCDEFGHIJKLMNOPQ", 18, true)).To(Equal("ABCDEFGHIJKLMNOPQ_TEST/18"))
 		})
 	})
 

--- a/ee/plugins/fireblocks/assets_sync_test.go
+++ b/ee/plugins/fireblocks/assets_sync_test.go
@@ -25,13 +25,19 @@ var _ = Describe("Fireblocks assets helpers", func() {
 
 	Describe("canonicalAsset", func() {
 		It("appends precision when non-zero", func() {
-			Expect(canonicalAsset("USDT", 6)).To(Equal("USDT/6"))
+			Expect(canonicalAsset("USDT", 6, false)).To(Equal("USDT/6"))
 		})
 		It("omits suffix when precision is zero", func() {
-			Expect(canonicalAsset("JPY", 0)).To(Equal("JPY"))
+			Expect(canonicalAsset("JPY", 0, false)).To(Equal("JPY"))
 		})
 		It("returns empty when sanitisation fails", func() {
-			Expect(canonicalAsset("...", 2)).To(BeEmpty())
+			Expect(canonicalAsset("...", 2, false)).To(BeEmpty())
+		})
+		It("appends _TEST for testnet assets", func() {
+			Expect(canonicalAsset("ETH", 18, true)).To(Equal("ETH_TEST/18"))
+		})
+		It("trims long bases so the _TEST suffix still fits Ledger's 17-char cap", func() {
+			Expect(canonicalAsset("ABCDEFGHIJKLMNOPQ", 18, true)).To(Equal("ABCDEFGHIJKL_TEST/18"))
 		})
 	})
 
@@ -48,7 +54,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 					Decimals:  6,
 					Standards: []string{"ERC20"},
 				},
-			})
+			}, false)
 			Expect(ok).To(BeTrue())
 			Expect(info.Asset).To(Equal("USDT/6"))
 			Expect(info.Precision).To(Equal(6))
@@ -66,7 +72,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 				DisplaySymbol: "USD",
 				AssetClass:    client.AssetClassFiat,
 				Decimals:      &d,
-			})
+			}, false)
 			Expect(ok).To(BeTrue())
 			Expect(info.Asset).To(Equal("USD/2"))
 		})
@@ -79,7 +85,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 					Symbol:   "USDC",
 					Decimals: 6,
 				},
-			})
+			}, false)
 			Expect(ok).To(BeTrue())
 			Expect(info.Asset).To(Equal("USDC/6"))
 		})
@@ -90,7 +96,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 				DisplaySymbol: "1INCH",
 				AssetClass:    client.AssetClassFT,
 				Onchain:       &client.AssetOnchain{Decimals: 18},
-			})
+			}, false)
 			Expect(ok).To(BeTrue())
 			Expect(info.Asset).To(Equal("INCH/18"))
 		})
@@ -105,10 +111,24 @@ var _ = Describe("Fireblocks assets helpers", func() {
 					Verified: true,
 					Features: []string{"STABLECOIN"},
 				},
-			})
+			}, false)
 			Expect(ok).To(BeTrue())
 			Expect(info.Metadata[MetadataPrefix+"verified"]).To(Equal("true"))
 			Expect(info.Metadata[MetadataPrefix+"features"]).To(Equal("STABLECOIN"))
+			Expect(info.Metadata).ToNot(HaveKey(MetadataPrefix + "testnet"))
+		})
+
+		It("segregates testnet assets and stamps the testnet metadata flag", func() {
+			info, ok := buildAssetInfo(client.Asset{
+				LegacyID:      "ETH_TEST5",
+				DisplaySymbol: "ETH",
+				BlockchainID:  "chain-eth-sepolia",
+				AssetClass:    client.AssetClassNative,
+				Onchain:       &client.AssetOnchain{Decimals: 18},
+			}, true)
+			Expect(ok).To(BeTrue())
+			Expect(info.Asset).To(Equal("ETH_TEST/18"))
+			Expect(info.Metadata).To(HaveKeyWithValue(MetadataPrefix+"testnet", "true"))
 		})
 
 		It("skips deprecated assets", func() {
@@ -118,7 +138,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 				AssetClass:    client.AssetClassFT,
 				Onchain:       &client.AssetOnchain{Decimals: 18},
 				Metadata:      &client.AssetSpecMetadata{Deprecated: true},
-			})
+			}, false)
 			Expect(ok).To(BeFalse())
 		})
 
@@ -129,7 +149,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 					DisplaySymbol: "X",
 					AssetClass:    class,
 					Onchain:       &client.AssetOnchain{Decimals: 0},
-				})
+				}, false)
 				Expect(ok).To(BeFalse())
 			},
 			Entry("NFT", client.AssetClassNFT),
@@ -142,7 +162,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 				LegacyID:      "X",
 				DisplaySymbol: "X",
 				AssetClass:    client.AssetClassFT,
-			})
+			}, false)
 			Expect(ok).To(BeFalse())
 		})
 
@@ -152,7 +172,7 @@ var _ = Describe("Fireblocks assets helpers", func() {
 				DisplaySymbol: "123",
 				AssetClass:    client.AssetClassFT,
 				Onchain:       &client.AssetOnchain{Decimals: 0},
-			})
+			}, false)
 			Expect(ok).To(BeFalse())
 		})
 	})

--- a/ee/plugins/fireblocks/balances.go
+++ b/ee/plugins/fireblocks/balances.go
@@ -46,13 +46,13 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 	for _, a := range vaultAccount.Assets {
 		info, ok := p.lookupAsset(a.ID)
 		if !ok {
-			p.logger.Infof("skipping balance: unknown asset %q on vault %s", a.ID, from.Reference)
+			p.logger.Infof("skipping balance: unknown asset %q on account %s", a.ID, from.Reference)
 			continue
 		}
 
 		amount, err := currency.GetAmountWithPrecisionFromString(a.Available, info.Precision)
 		if err != nil {
-			p.logger.Infof("skipping balance: asset %q on vault %s, unparseable available %q",
+			p.logger.Infof("skipping balance: asset %q on account %s, unparseable available %q",
 				a.ID, from.Reference, a.Available)
 			continue
 		}
@@ -69,7 +69,7 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 	balances := make([]models.PSPBalance, 0, len(agg))
 	for _, entry := range agg {
 		if len(entry.legacyIDs) > 1 {
-			p.logger.Infof("aggregated %d fireblocks legacyIds [%s] into %s on vault %s",
+			p.logger.Infof("aggregated %d fireblocks legacyIds [%s] into %s on account %s",
 				len(entry.legacyIDs), strings.Join(entry.legacyIDs, ","),
 				entry.info.Asset, from.Reference)
 		}
@@ -80,7 +80,7 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 			Asset:            entry.info.Asset,
 		}
 		if err := balance.Validate(); err != nil {
-			p.logger.Infof("dropping invalid balance for vault %s asset %s: %s",
+			p.logger.Infof("dropping invalid balance for account %s asset %s: %s",
 				from.Reference, entry.info.Asset, err)
 			continue
 		}

--- a/ee/plugins/fireblocks/balances.go
+++ b/ee/plugins/fireblocks/balances.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 	"time"
 
@@ -68,8 +69,6 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 	balances := make([]models.PSPBalance, 0, len(agg))
 	for _, entry := range agg {
 		if len(entry.legacyIDs) > 1 {
-			// PSPBalance has no Metadata/Raw field, so the merge is only
-			// observable via this log line plus the summed Amount.
 			p.logger.Infof("aggregated %d fireblocks legacyIds [%s] into %s on vault %s",
 				len(entry.legacyIDs), strings.Join(entry.legacyIDs, ","),
 				entry.info.Asset, from.Reference)
@@ -95,13 +94,8 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 }
 
 func appendUnique(s []string, v string) []string {
-	if v == "" {
+	if v == "" || slices.Contains(s, v) {
 		return s
-	}
-	for _, existing := range s {
-		if existing == v {
-			return s
-		}
 	}
 	return append(s, v)
 }

--- a/ee/plugins/fireblocks/balances.go
+++ b/ee/plugins/fireblocks/balances.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"strings"
 	"time"
 
 	"github.com/formancehq/go-libs/v3/currency"
 	"github.com/formancehq/payments/internal/models"
 	errorsutils "github.com/formancehq/payments/internal/utils/errors"
 )
+
+// aggregatedBalance accumulates same-canonical-asset VaultAssets within a
+// single vault. Multiple Fireblocks legacyIds (e.g. USDT_ERC20 + USDT_TRX)
+// collapse onto one canonical asset (USDT/6); we sum their `Available` and
+// keep the source legacyIds for the aggregation log line.
+type aggregatedBalance struct {
+	info      assetInfo
+	amount    *big.Int
+	legacyIDs []string
+}
 
 func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBalancesRequest) (models.FetchNextBalancesResponse, error) {
 	var from models.PSPAccount
@@ -23,38 +35,73 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 		return models.FetchNextBalancesResponse{}, err
 	}
 
-	// Fetch fresh balance data from the API
 	vaultAccount, err := p.client.GetVaultAccount(ctx, from.Reference)
 	if err != nil {
 		return models.FetchNextBalancesResponse{}, fmt.Errorf("failed to get vault account %s: %w", from.Reference, err)
 	}
 
 	now := time.Now()
-	assetDecimals := p.getAssetDecimals()
-	var balances []models.PSPBalance
-	for _, asset := range vaultAccount.Assets {
-		precision, err := currency.GetPrecision(assetDecimals, asset.ID)
-		if err != nil {
-			p.logger.Infof("skipping balance for unknown asset %q on account %s", asset.ID, from.Reference)
+	agg := map[string]*aggregatedBalance{}
+	for _, a := range vaultAccount.Assets {
+		info, ok := p.lookupAsset(a.ID)
+		if !ok {
+			p.logger.Infof("skipping balance: unknown asset %q on vault %s", a.ID, from.Reference)
 			continue
 		}
 
-		amount, err := currency.GetAmountWithPrecisionFromString(asset.Available, precision)
+		amount, err := currency.GetAmountWithPrecisionFromString(a.Available, info.Precision)
 		if err != nil {
-			p.logger.Infof("skipping balance for asset %q on account %s: failed to parse amount %q", asset.ID, from.Reference, asset.Available)
+			p.logger.Infof("skipping balance: asset %q on vault %s, unparseable available %q",
+				a.ID, from.Reference, a.Available)
 			continue
 		}
 
-		balances = append(balances, models.PSPBalance{
+		entry, exists := agg[info.Asset]
+		if !exists {
+			entry = &aggregatedBalance{info: info, amount: new(big.Int)}
+			agg[info.Asset] = entry
+		}
+		entry.amount.Add(entry.amount, amount)
+		entry.legacyIDs = appendUnique(entry.legacyIDs, info.LegacyID)
+	}
+
+	balances := make([]models.PSPBalance, 0, len(agg))
+	for _, entry := range agg {
+		if len(entry.legacyIDs) > 1 {
+			// PSPBalance has no Metadata/Raw field, so the merge is only
+			// observable via this log line plus the summed Amount.
+			p.logger.Infof("aggregated %d fireblocks legacyIds [%s] into %s on vault %s",
+				len(entry.legacyIDs), strings.Join(entry.legacyIDs, ","),
+				entry.info.Asset, from.Reference)
+		}
+		balance := models.PSPBalance{
 			AccountReference: from.Reference,
 			CreatedAt:        now,
-			Amount:           amount,
-			Asset:            currency.FormatAsset(assetDecimals, asset.ID),
-		})
+			Amount:           entry.amount,
+			Asset:            entry.info.Asset,
+		}
+		if err := balance.Validate(); err != nil {
+			p.logger.Infof("dropping invalid balance for vault %s asset %s: %s",
+				from.Reference, entry.info.Asset, err)
+			continue
+		}
+		balances = append(balances, balance)
 	}
 
 	return models.FetchNextBalancesResponse{
 		Balances: balances,
 		HasMore:  false,
 	}, nil
+}
+
+func appendUnique(s []string, v string) []string {
+	if v == "" {
+		return s
+	}
+	for _, existing := range s {
+		if existing == v {
+			return s
+		}
+	}
+	return append(s, v)
 }

--- a/ee/plugins/fireblocks/balances_test.go
+++ b/ee/plugins/fireblocks/balances_test.go
@@ -98,6 +98,57 @@ var _ = Describe("Fireblocks Plugin Balances", func() {
 		Expect(resp.Balances[0].Amount).To(Equal(big.NewInt(150500000)))
 	})
 
+	It("aggregates three same-symbol chains within a vault", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{
+			"USDT_ERC20": {Asset: "USDT/6", Precision: 6, LegacyID: "USDT_ERC20", BlockchainID: "chain-eth"},
+			"USDT_TRX":   {Asset: "USDT/6", Precision: 6, LegacyID: "USDT_TRX", BlockchainID: "chain-trx"},
+			"USDT_BSC":   {Asset: "USDT/6", Precision: 6, LegacyID: "USDT_BSC", BlockchainID: "chain-bsc"},
+		}
+
+		from, err := json.Marshal(models.PSPAccount{Reference: "acc-1"})
+		Expect(err).To(BeNil())
+
+		m.EXPECT().GetVaultAccount(gomock.Any(), "acc-1").Return(&client.VaultAccount{
+			ID: "acc-1",
+			Assets: []client.VaultAsset{
+				{ID: "USDT_ERC20", Available: "100"},
+				{ID: "USDT_TRX", Available: "50.5"},
+				{ID: "USDT_BSC", Available: "25.25"},
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextBalances(ctx, models.FetchNextBalancesRequest{FromPayload: from})
+		Expect(err).To(BeNil())
+		Expect(resp.Balances).To(HaveLen(1))
+		Expect(resp.Balances[0].Asset).To(Equal("USDT/6"))
+		// 100_000_000 + 50_500_000 + 25_250_000 = 175_750_000 (6 decimals)
+		Expect(resp.Balances[0].Amount).To(Equal(big.NewInt(175750000)))
+	})
+
+	It("aggregates duplicate vault asset rows of the same legacyId", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{
+			"BTC": {Asset: "BTC/8", Precision: 8, LegacyID: "BTC"},
+		}
+
+		from, err := json.Marshal(models.PSPAccount{Reference: "acc-1"})
+		Expect(err).To(BeNil())
+
+		m.EXPECT().GetVaultAccount(gomock.Any(), "acc-1").Return(&client.VaultAccount{
+			ID: "acc-1",
+			Assets: []client.VaultAsset{
+				{ID: "BTC", Available: "0.1"},
+				{ID: "BTC", Available: "0.2"},
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextBalances(ctx, models.FetchNextBalancesRequest{FromPayload: from})
+		Expect(err).To(BeNil())
+		Expect(resp.Balances).To(HaveLen(1))
+		Expect(resp.Balances[0].Asset).To(Equal("BTC/8"))
+		// 10_000_000 + 20_000_000 = 30_000_000 (8 decimals)
+		Expect(resp.Balances[0].Amount).To(Equal(big.NewInt(30000000)))
+	})
+
 	It("matches legacyIds case-insensitively (xDAI-style)", func(ctx SpecContext) {
 		plg.assets = map[string]assetInfo{
 			"XDAI": {Asset: "XDAI/18", Precision: 18, LegacyID: "xDAI"},

--- a/ee/plugins/fireblocks/balances_test.go
+++ b/ee/plugins/fireblocks/balances_test.go
@@ -24,9 +24,11 @@ var _ = Describe("Fireblocks Plugin Balances", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{
-			logger:         logging.NewDefaultLogger(GinkgoWriter, true, false, false),
-			client:         m,
-			assetDecimals:  map[string]int{"USD": 2},
+			logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false),
+			client: m,
+			assets: map[string]assetInfo{
+				"USD": {Asset: "USD/2", Precision: 2, LegacyID: "USD"},
+			},
 			assetsLastSync: time.Now(),
 		}
 	})

--- a/ee/plugins/fireblocks/balances_test.go
+++ b/ee/plugins/fireblocks/balances_test.go
@@ -69,6 +69,32 @@ var _ = Describe("Fireblocks Plugin Balances", func() {
 		Expect(resp.Balances[0].CreatedAt.IsZero()).To(BeFalse())
 	})
 
+	It("keeps same-symbol different-precision assets in separate balance rows", func(ctx SpecContext) {
+		// Aggregation key is the canonical "<symbol>/<precision>" string; WBTC at
+		// 8 decimals and WBTC at 18 decimals must not share a bucket.
+		plg.assets = map[string]assetInfo{
+			"WBTC8":  {Asset: "WBTC/8", Precision: 8, LegacyID: "WBTC8"},
+			"WBTC18": {Asset: "WBTC/18", Precision: 18, LegacyID: "WBTC18"},
+		}
+
+		from, err := json.Marshal(models.PSPAccount{Reference: "acc-1"})
+		Expect(err).To(BeNil())
+
+		m.EXPECT().GetVaultAccount(gomock.Any(), "acc-1").Return(&client.VaultAccount{
+			ID: "acc-1",
+			Assets: []client.VaultAsset{
+				{ID: "WBTC8", Available: "1"},
+				{ID: "WBTC18", Available: "1"},
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextBalances(ctx, models.FetchNextBalancesRequest{FromPayload: from})
+		Expect(err).To(BeNil())
+		Expect(resp.Balances).To(HaveLen(2))
+		Expect([]string{resp.Balances[0].Asset, resp.Balances[1].Asset}).
+			To(ConsistOf("WBTC/8", "WBTC/18"))
+	})
+
 	It("aggregates same-canonical-asset entries across chains", func(ctx SpecContext) {
 		// Two distinct Fireblocks legacyIds (USDT_ERC20 / USDT_TRX) both
 		// canonicalise to USDT/6 — the plugin must sum them within a vault.

--- a/ee/plugins/fireblocks/balances_test.go
+++ b/ee/plugins/fireblocks/balances_test.go
@@ -68,4 +68,54 @@ var _ = Describe("Fireblocks Plugin Balances", func() {
 		Expect(resp.Balances[0].Asset).To(Equal("USD/2"))
 		Expect(resp.Balances[0].CreatedAt.IsZero()).To(BeFalse())
 	})
+
+	It("aggregates same-canonical-asset entries across chains", func(ctx SpecContext) {
+		// Two distinct Fireblocks legacyIds (USDT_ERC20 / USDT_TRX) both
+		// canonicalise to USDT/6 — the plugin must sum them within a vault.
+		plg.assets = map[string]assetInfo{
+			"USDT_ERC20": {Asset: "USDT/6", Precision: 6, LegacyID: "USDT_ERC20", BlockchainID: "chain-eth"},
+			"USDT_TRX":   {Asset: "USDT/6", Precision: 6, LegacyID: "USDT_TRX", BlockchainID: "chain-trx"},
+		}
+
+		from, err := json.Marshal(models.PSPAccount{Reference: "acc-1"})
+		Expect(err).To(BeNil())
+
+		m.EXPECT().GetVaultAccount(gomock.Any(), "acc-1").Return(&client.VaultAccount{
+			ID: "acc-1",
+			Assets: []client.VaultAsset{
+				{ID: "USDT_ERC20", Available: "100"},
+				{ID: "USDT_TRX", Available: "50.5"},
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextBalances(ctx, models.FetchNextBalancesRequest{
+			FromPayload: from,
+		})
+		Expect(err).To(BeNil())
+		Expect(resp.Balances).To(HaveLen(1))
+		Expect(resp.Balances[0].Asset).To(Equal("USDT/6"))
+		// 100_000_000 + 50_500_000 = 150_500_000 (6 decimals)
+		Expect(resp.Balances[0].Amount).To(Equal(big.NewInt(150500000)))
+	})
+
+	It("matches legacyIds case-insensitively (xDAI-style)", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{
+			"XDAI": {Asset: "XDAI/18", Precision: 18, LegacyID: "xDAI"},
+		}
+
+		from, err := json.Marshal(models.PSPAccount{Reference: "acc-1"})
+		Expect(err).To(BeNil())
+
+		m.EXPECT().GetVaultAccount(gomock.Any(), "acc-1").Return(&client.VaultAccount{
+			ID:     "acc-1",
+			Assets: []client.VaultAsset{{ID: "xDAI", Available: "1"}},
+		}, nil)
+
+		resp, err := plg.FetchNextBalances(ctx, models.FetchNextBalancesRequest{
+			FromPayload: from,
+		})
+		Expect(err).To(BeNil())
+		Expect(resp.Balances).To(HaveLen(1))
+		Expect(resp.Balances[0].Asset).To(Equal("XDAI/18"))
+	})
 })

--- a/ee/plugins/fireblocks/client/accounts.go
+++ b/ee/plugins/fireblocks/client/accounts.go
@@ -44,6 +44,14 @@ type fireblocksError struct {
 	Code    int    `json:"code"`
 }
 
+// wrap formats a client error, surfacing the upstream Fireblocks message when set.
+func (e fireblocksError) wrap(prefix string, base error) error {
+	if e.Message != "" {
+		return fmt.Errorf("%s: %w (fireblocks: %s)", prefix, base, e.Message)
+	}
+	return fmt.Errorf("%s: %w", prefix, base)
+}
+
 func (c *client) GetVaultAccountsPaged(ctx context.Context, cursor string, limit int) (*VaultAccountsPagedResponse, error) {
 	endpoint := fmt.Sprintf("%s/v1/vault/accounts_paged?limit=%d", c.baseURL, limit)
 	if cursor != "" {
@@ -59,7 +67,7 @@ func (c *client) GetVaultAccountsPaged(ctx context.Context, cursor string, limit
 	var errResponse fireblocksError
 	_, err = c.httpClient.Do(ctx, req, &response, &errResponse)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vault accounts: %w", err)
+		return nil, errResponse.wrap("failed to get vault accounts", err)
 	}
 
 	return &response, nil
@@ -77,7 +85,7 @@ func (c *client) GetVaultAccount(ctx context.Context, vaultAccountID string) (*V
 	var errResponse fireblocksError
 	_, err = c.httpClient.Do(ctx, req, &response, &errResponse)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vault account: %w", err)
+		return nil, errResponse.wrap("failed to get vault account", err)
 	}
 
 	return &response, nil

--- a/ee/plugins/fireblocks/client/assets.go
+++ b/ee/plugins/fireblocks/client/assets.go
@@ -72,7 +72,7 @@ func (c *client) ListAssets(ctx context.Context) ([]Asset, error) {
 		var errResponse fireblocksError
 		_, err = c.httpClient.Do(ctx, req, &response, &errResponse)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list assets: %w", err)
+			return nil, errResponse.wrap("failed to list assets", err)
 		}
 
 		allAssets = append(allAssets, response.Data...)

--- a/ee/plugins/fireblocks/client/assets.go
+++ b/ee/plugins/fireblocks/client/assets.go
@@ -8,16 +8,41 @@ import (
 )
 
 type Asset struct {
-	ID       string        `json:"id"`
-	LegacyID string        `json:"legacyId"`
-	Decimals *int          `json:"decimals"` // For fiat assets (when provided)
-	Onchain  *AssetOnchain `json:"onchain"`  // For crypto assets
+	ID            string             `json:"id"`
+	LegacyID      string             `json:"legacyId"`
+	DisplayName   string             `json:"displayName"`
+	DisplaySymbol string             `json:"displaySymbol"`
+	BlockchainID  string             `json:"blockchainId"`
+	AssetClass    string             `json:"assetClass"`
+	Decimals      *int               `json:"decimals"` // populated for FIAT assets
+	Onchain       *AssetOnchain      `json:"onchain"`  // populated for NATIVE/FT assets
+	Metadata      *AssetSpecMetadata `json:"metadata"`
 }
 
 type AssetOnchain struct {
-	Decimals int    `json:"decimals"`
-	Symbol   string `json:"symbol"`
+	Symbol    string   `json:"symbol"`
+	Name      string   `json:"name"`
+	Address   string   `json:"address"`
+	Decimals  int      `json:"decimals"`
+	Standards []string `json:"standards"`
 }
+
+type AssetSpecMetadata struct {
+	Scope      string   `json:"scope"`
+	Verified   bool     `json:"verified"`
+	Deprecated bool     `json:"deprecated"`
+	Features   []string `json:"features"`
+}
+
+// Asset classes returned by /v1/assets; we only ingest fungible/native/fiat.
+const (
+	AssetClassNative  = "NATIVE"
+	AssetClassFT      = "FT"
+	AssetClassFiat    = "FIAT"
+	AssetClassNFT     = "NFT"
+	AssetClassSFT     = "SFT"
+	AssetClassVirtual = "VIRTUAL"
+)
 
 type AssetsPaging struct {
 	Next string `json:"next"`

--- a/ee/plugins/fireblocks/client/blockchains.go
+++ b/ee/plugins/fireblocks/client/blockchains.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 )
 
-// Blockchain mirrors the subset of /v1/blockchains we need to detect
-// testnet assets. The `onchain.test` boolean is Fireblocks' authoritative
-// signal — far more reliable than parsing legacyId suffixes.
+// Blockchain mirrors the subset of /v1/blockchains we need to detect testnet
+// assets via the authoritative `onchain.test` boolean.
 type Blockchain struct {
 	ID            string              `json:"id"`
 	LegacyID      string              `json:"legacyId"`

--- a/ee/plugins/fireblocks/client/blockchains.go
+++ b/ee/plugins/fireblocks/client/blockchains.go
@@ -53,7 +53,7 @@ func (c *client) ListBlockchains(ctx context.Context) ([]Blockchain, error) {
 		var resp BlockchainsResponse
 		var errResp fireblocksError
 		if _, err := c.httpClient.Do(ctx, req, &resp, &errResp); err != nil {
-			return nil, fmt.Errorf("failed to list blockchains: %w", err)
+			return nil, errResp.wrap("failed to list blockchains", err)
 		}
 
 		all = append(all, resp.Data...)

--- a/ee/plugins/fireblocks/client/blockchains.go
+++ b/ee/plugins/fireblocks/client/blockchains.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Blockchain mirrors the subset of /v1/blockchains we need to detect
+// testnet assets. The `onchain.test` boolean is Fireblocks' authoritative
+// signal — far more reliable than parsing legacyId suffixes.
+type Blockchain struct {
+	ID            string              `json:"id"`
+	LegacyID      string              `json:"legacyId"`
+	DisplayName   string              `json:"displayName"`
+	NativeAssetID string              `json:"nativeAssetId"`
+	Onchain       *BlockchainOnchain  `json:"onchain"`
+	Metadata      *BlockchainMetadata `json:"metadata"`
+}
+
+type BlockchainOnchain struct {
+	Protocol    string `json:"protocol"`
+	ChainID     string `json:"chainId"`
+	Test        bool   `json:"test"`
+	SigningAlgo string `json:"signingAlgo"`
+}
+
+type BlockchainMetadata struct {
+	Scope      string `json:"scope"`
+	Deprecated bool   `json:"deprecated"`
+}
+
+type BlockchainsResponse struct {
+	Data []Blockchain `json:"data"`
+	Next string       `json:"next"`
+}
+
+func (c *client) ListBlockchains(ctx context.Context) ([]Blockchain, error) {
+	var all []Blockchain
+	var cursor string
+
+	for {
+		endpoint := fmt.Sprintf("%s/v1/blockchains?pageSize=500", c.baseURL)
+		if cursor != "" {
+			endpoint = fmt.Sprintf("%s&pageCursor=%s", endpoint, url.QueryEscape(cursor))
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		var resp BlockchainsResponse
+		var errResp fireblocksError
+		if _, err := c.httpClient.Do(ctx, req, &resp, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to list blockchains: %w", err)
+		}
+
+		all = append(all, resp.Data...)
+		if resp.Next == "" {
+			break
+		}
+		cursor = resp.Next
+	}
+
+	return all, nil
+}

--- a/ee/plugins/fireblocks/client/blockchains_test.go
+++ b/ee/plugins/fireblocks/client/blockchains_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+)
+
+func TestListBlockchainsPaginatesUsingCursor(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	var capturedQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQueries = append(capturedQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		switch calls.Add(1) {
+		case 1:
+			_ = json.NewEncoder(w).Encode(BlockchainsResponse{
+				Data: []Blockchain{
+					{ID: "chain-1", LegacyID: "ETH", Onchain: &BlockchainOnchain{Test: false}},
+					{ID: "chain-2", LegacyID: "ETH_TEST5", Onchain: &BlockchainOnchain{Test: true}},
+				},
+				Next: "cursor-2",
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(BlockchainsResponse{
+				Data: []Blockchain{{ID: "chain-3", LegacyID: "BTC"}},
+				Next: "",
+			})
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	chains, err := c.ListBlockchains(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(chains); got != 3 {
+		t.Fatalf("expected 3 blockchains across 2 pages, got %d", got)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 HTTP calls, got %d", calls.Load())
+	}
+	if !strings.Contains(capturedQueries[0], "pageSize=500") || strings.Contains(capturedQueries[0], "pageCursor=") {
+		t.Fatalf("first request should have pageSize and no cursor, got %q", capturedQueries[0])
+	}
+	if !strings.Contains(capturedQueries[1], "pageCursor=cursor-2") {
+		t.Fatalf("second request should carry pageCursor=cursor-2, got %q", capturedQueries[1])
+	}
+}
+
+func TestListBlockchainsWrapsServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom","code":500}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	_, err := c.ListBlockchains(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, httpwrapper.ErrStatusCodeServerError) {
+		t.Fatalf("expected wrapped server-error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to list blockchains") {
+		t.Fatalf("expected wrapping prefix, got %v", err)
+	}
+}

--- a/ee/plugins/fireblocks/client/client.go
+++ b/ee/plugins/fireblocks/client/client.go
@@ -13,6 +13,7 @@ import (
 //go:generate mockgen -source client.go -destination client_generated.go -package client . Client
 type Client interface {
 	ListAssets(ctx context.Context) ([]Asset, error)
+	ListBlockchains(ctx context.Context) ([]Blockchain, error)
 	GetVaultAccountsPaged(ctx context.Context, cursor string, limit int) (*VaultAccountsPagedResponse, error)
 	GetVaultAccount(ctx context.Context, vaultAccountID string) (*VaultAccount, error)
 	ListTransactions(ctx context.Context, createdAfter int64, limit int) ([]Transaction, error)

--- a/ee/plugins/fireblocks/client/client_generated.go
+++ b/ee/plugins/fireblocks/client/client_generated.go
@@ -85,6 +85,21 @@ func (mr *MockClientMockRecorder) ListAssets(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssets", reflect.TypeOf((*MockClient)(nil).ListAssets), ctx)
 }
 
+// ListBlockchains mocks base method.
+func (m *MockClient) ListBlockchains(ctx context.Context) ([]Blockchain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBlockchains", ctx)
+	ret0, _ := ret[0].([]Blockchain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBlockchains indicates an expected call of ListBlockchains.
+func (mr *MockClientMockRecorder) ListBlockchains(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBlockchains", reflect.TypeOf((*MockClient)(nil).ListBlockchains), ctx)
+}
+
 // ListTransactions mocks base method.
 func (m *MockClient) ListTransactions(ctx context.Context, createdAfter int64, limit int) ([]Transaction, error) {
 	m.ctrl.T.Helper()

--- a/ee/plugins/fireblocks/client/client_testing_test.go
+++ b/ee/plugins/fireblocks/client/client_testing_test.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+)
+
+// newTestClient builds a Fireblocks client pointed at baseURL using a freshly
+// generated RSA key. The httptest server does not validate the JWT, so any
+// well-formed key works.
+func newTestClient(t *testing.T, baseURL string) Client {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return New("fireblocks-test", "test-api-key", key, baseURL)
+}

--- a/ee/plugins/fireblocks/client/transactions.go
+++ b/ee/plugins/fireblocks/client/transactions.go
@@ -44,10 +44,15 @@ type FeeInfo struct {
 }
 
 func (c *client) ListTransactions(ctx context.Context, createdAfter int64, limit int) ([]Transaction, error) {
-	endpoint := fmt.Sprintf("%s/v1/transactions?limit=%d&orderBy=createdAt&sort=ASC", c.baseURL, limit)
-	if createdAfter > 0 {
-		endpoint = fmt.Sprintf("%s&after=%d", endpoint, createdAfter)
+	// Fireblocks defaults `after` to "last 90 days" when omitted, which silently
+	// drops older transactions on the initial sync. Always pin to a positive
+	// timestamp (1 ms past epoch on the first call) so we get the full history
+	// and let our own cursor advance from there.
+	if createdAfter <= 0 {
+		createdAfter = 1
 	}
+	endpoint := fmt.Sprintf("%s/v1/transactions?limit=%d&orderBy=createdAt&sort=ASC&after=%d",
+		c.baseURL, limit, createdAfter)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/ee/plugins/fireblocks/client/transactions.go
+++ b/ee/plugins/fireblocks/client/transactions.go
@@ -44,10 +44,8 @@ type FeeInfo struct {
 }
 
 func (c *client) ListTransactions(ctx context.Context, createdAfter int64, limit int) ([]Transaction, error) {
-	// Fireblocks defaults `after` to "last 90 days" when omitted, which silently
-	// drops older transactions on the initial sync. Always pin to a positive
-	// timestamp (1 ms past epoch on the first call) so we get the full history
-	// and let our own cursor advance from there.
+	// Fireblocks defaults `after` to "last 90 days" when omitted; pin to 1 ms
+	// past epoch on the first call so we fetch the full history.
 	if createdAfter <= 0 {
 		createdAfter = 1
 	}

--- a/ee/plugins/fireblocks/client/transactions.go
+++ b/ee/plugins/fireblocks/client/transactions.go
@@ -61,7 +61,7 @@ func (c *client) ListTransactions(ctx context.Context, createdAfter int64, limit
 	var errResponse fireblocksError
 	_, err = c.httpClient.Do(ctx, req, &response, &errResponse)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list transactions: %w", err)
+		return nil, errResponse.wrap("failed to list transactions", err)
 	}
 
 	return response, nil

--- a/ee/plugins/fireblocks/client/transactions_test.go
+++ b/ee/plugins/fireblocks/client/transactions_test.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/formancehq/payments/internal/connectors/httpwrapper"
+)
+
+func TestListTransactionsPinsAfterOneOnFirstSync(t *testing.T) {
+	t.Parallel()
+
+	var capturedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	if _, err := c.ListTransactions(context.Background(), 0, 50); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// after=1 bypasses Fireblocks' "last 90 days" default.
+	if !strings.Contains(capturedQuery, "after=1") {
+		t.Fatalf("expected after=1 on initial sync, got %q", capturedQuery)
+	}
+	for _, want := range []string{"limit=50", "orderBy=createdAt", "sort=ASC"} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Fatalf("expected query to contain %q, got %q", want, capturedQuery)
+		}
+	}
+}
+
+func TestListTransactionsForwardsStateCursor(t *testing.T) {
+	t.Parallel()
+
+	var capturedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	if _, err := c.ListTransactions(context.Background(), 1234567890, 50); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(capturedQuery, "after=1234567890") {
+		t.Fatalf("expected after=1234567890, got %q", capturedQuery)
+	}
+}
+
+func TestListTransactionsRoundTripsTransactions(t *testing.T) {
+	t.Parallel()
+
+	body := []Transaction{
+		{ID: "tx-1", AssetID: "BTC", Operation: "TRANSFER", Status: "COMPLETED", CreatedAt: 1700000000000},
+		{ID: "tx-2", AssetID: "ETH", Operation: "TRANSFER", Status: "PENDING_SIGNATURE", CreatedAt: 1700000001000},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	txs, err := c.ListTransactions(context.Background(), 0, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(txs); got != 2 {
+		t.Fatalf("expected 2 transactions, got %d", got)
+	}
+	if txs[0].ID != "tx-1" || txs[1].ID != "tx-2" {
+		t.Fatalf("unexpected ids: %+v", txs)
+	}
+}
+
+func TestListTransactionsWrapsServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"message":"boom","code":500}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	_, err := c.ListTransactions(context.Background(), 0, 50)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, httpwrapper.ErrStatusCodeServerError) {
+		t.Fatalf("expected wrapped server-error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to list transactions") {
+		t.Fatalf("expected wrapping prefix, got %v", err)
+	}
+}

--- a/ee/plugins/fireblocks/payments.go
+++ b/ee/plugins/fireblocks/payments.go
@@ -3,6 +3,7 @@ package fireblocks
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"strings"
 	"time"
 
@@ -153,14 +154,11 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 }
 
 // buildPaymentMetadata seeds the payment metadata with the per-asset slice
-// from the cache, then layers transaction-level details under MetadataPrefix.
-// Returns a fresh map (never nil) so downstream destination_ids writes can
-// happen unconditionally.
+// from the cache and layers tx-level details under MetadataPrefix. Always
+// returns a non-nil map so downstream writes can happen unconditionally.
 func buildPaymentMetadata(tx client.Transaction, info assetInfo) map[string]string {
 	out := make(map[string]string, len(info.Metadata)+4)
-	for k, v := range info.Metadata {
-		out[k] = v
-	}
+	maps.Copy(out, info.Metadata)
 	if tx.TxHash != "" {
 		out[MetadataPrefix+"tx_hash"] = tx.TxHash
 	}

--- a/ee/plugins/fireblocks/payments.go
+++ b/ee/plugins/fireblocks/payments.go
@@ -44,7 +44,6 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	payments := make([]models.PSPPayment, 0, len(transactions))
-	assetDecimals := p.getAssetDecimals()
 	newState := paymentsState{
 		LastCreatedAt: oldState.LastCreatedAt,
 		LastTxID:      oldState.LastTxID,
@@ -75,15 +74,16 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			continue
 		}
 
-		precision, err := currency.GetPrecision(assetDecimals, tx.AssetID)
-		if err != nil {
+		info, ok := p.lookupAsset(tx.AssetID)
+		if !ok {
 			p.logger.Errorf("skipping transaction %s: unknown asset %q", tx.ID, tx.AssetID)
 			continue
 		}
 
-		amount, err := currency.GetAmountWithPrecisionFromString(tx.AmountInfo.Amount, precision)
+		amount, err := currency.GetAmountWithPrecisionFromString(tx.AmountInfo.Amount, info.Precision)
 		if err != nil {
-			p.logger.Errorf("skipping transaction %s: failed to parse amount %q for asset %q", tx.ID, tx.AmountInfo.Amount, tx.AssetID)
+			p.logger.Errorf("skipping transaction %s: unparseable amount %q for asset %q",
+				tx.ID, tx.AmountInfo.Amount, tx.AssetID)
 			continue
 		}
 
@@ -97,10 +97,11 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			CreatedAt: time.UnixMilli(tx.CreatedAt),
 			Type:      matchPaymentType(tx),
 			Amount:    amount,
-			Asset:     currency.FormatAsset(assetDecimals, tx.AssetID),
+			Asset:     info.Asset,
 			Scheme:    models.PAYMENT_SCHEME_OTHER,
 			Status:    matchPaymentStatus(tx.Status),
 			Raw:       raw,
+			Metadata:  buildPaymentMetadata(tx, info),
 		}
 
 		if tx.Source.ID != "" && isPeerType(tx.Source.Type, peerTypeVaultAccount) {
@@ -108,7 +109,6 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			payment.SourceAccountReference = &sourceRef
 		}
 
-		metadata := map[string]string{}
 		if len(tx.Destinations) > 0 {
 			if len(tx.Destinations) == 1 && tx.Destinations[0].ID != "" {
 				if isPeerType(tx.Destinations[0].Type, peerTypeVaultAccount) {
@@ -123,7 +123,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 					}
 				}
 				if len(ids) > 0 {
-					metadata["destinationIds"] = strings.Join(ids, ",")
+					payment.Metadata[MetadataPrefix+"destination_ids"] = strings.Join(ids, ",")
 				}
 			}
 		} else if tx.Destination.ID != "" && isPeerType(tx.Destination.Type, peerTypeVaultAccount) {
@@ -131,22 +131,10 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			payment.DestinationAccountReference = &destRef
 		}
 
-		if tx.TxHash != "" {
-			metadata["txHash"] = tx.TxHash
+		if err := payment.Validate(); err != nil {
+			p.logger.Infof("dropping invalid payment %s: %s", tx.ID, err)
+			continue
 		}
-		if tx.FeeInfo.NetworkFee != "" {
-			metadata["networkFee"] = tx.FeeInfo.NetworkFee
-		}
-		if tx.Note != "" {
-			metadata["note"] = tx.Note
-		}
-		if tx.SubStatus != "" {
-			metadata["subStatus"] = tx.SubStatus
-		}
-		if len(metadata) > 0 {
-			payment.Metadata = metadata
-		}
-
 		payments = append(payments, payment)
 	}
 
@@ -162,6 +150,30 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		NewState: payload,
 		HasMore:  hasMore,
 	}, nil
+}
+
+// buildPaymentMetadata seeds the payment metadata with the per-asset slice
+// from the cache, then layers transaction-level details under MetadataPrefix.
+// Returns a fresh map (never nil) so downstream destination_ids writes can
+// happen unconditionally.
+func buildPaymentMetadata(tx client.Transaction, info assetInfo) map[string]string {
+	out := make(map[string]string, len(info.Metadata)+4)
+	for k, v := range info.Metadata {
+		out[k] = v
+	}
+	if tx.TxHash != "" {
+		out[MetadataPrefix+"tx_hash"] = tx.TxHash
+	}
+	if tx.FeeInfo.NetworkFee != "" {
+		out[MetadataPrefix+"network_fee"] = tx.FeeInfo.NetworkFee
+	}
+	if tx.Note != "" {
+		out[MetadataPrefix+"note"] = tx.Note
+	}
+	if tx.SubStatus != "" {
+		out[MetadataPrefix+"sub_status"] = tx.SubStatus
+	}
+	return out
 }
 
 // isPeerType checks if a peer type string matches the expected PeerType (case-insensitive).

--- a/ee/plugins/fireblocks/payments_test.go
+++ b/ee/plugins/fireblocks/payments_test.go
@@ -224,6 +224,53 @@ var _ = Describe("Fireblocks Plugin Payments", func() {
 		Expect(*resp.Payments[0].DestinationAccountReference).To(Equal("vault-1"))
 	})
 
+	It("copies cached asset metadata onto each payment", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{
+			"USDT_ERC20": {
+				Asset:        "USDT/6",
+				Precision:    6,
+				LegacyID:     "USDT_ERC20",
+				BlockchainID: "chain-eth",
+				Metadata: map[string]string{
+					MetadataPrefix + "legacy_id":        "USDT_ERC20",
+					MetadataPrefix + "display_symbol":   "USDT",
+					MetadataPrefix + "contract_address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+					MetadataPrefix + "token_standard":   "ERC20",
+					MetadataPrefix + "blockchain_id":    "chain-eth",
+				},
+			},
+		}
+
+		m.EXPECT().ListTransactions(gomock.Any(), int64(0), 1).Return([]client.Transaction{
+			{
+				ID:         "tx-1",
+				AssetID:    "USDT_ERC20",
+				AmountInfo: client.AmountInfo{Amount: "1"},
+				Operation:  "TRANSFER",
+				Status:     "COMPLETED",
+				CreatedAt:  7000,
+				TxHash:     "0xhash",
+				FeeInfo:    client.FeeInfo{NetworkFee: "0.0002"},
+				Note:       "treasury rebalance",
+				SubStatus:  "CONFIRMED_ON_BLOCKCHAIN",
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{PageSize: 1})
+		Expect(err).To(BeNil())
+		Expect(resp.Payments).To(HaveLen(1))
+		md := resp.Payments[0].Metadata
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"legacy_id", "USDT_ERC20"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"contract_address", "0xdAC17F958D2ee523a2206206994597C13D831ec7"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"token_standard", "ERC20"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"blockchain_id", "chain-eth"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"tx_hash", "0xhash"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"network_fee", "0.0002"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"note", "treasury rebalance"))
+		Expect(md).To(HaveKeyWithValue(MetadataPrefix+"sub_status", "CONFIRMED_ON_BLOCKCHAIN"))
+		Expect(resp.Payments[0].Asset).To(Equal("USDT/6"))
+	})
+
 	It("advances state even when transactions are skipped", func(ctx SpecContext) {
 		state, err := json.Marshal(paymentsState{LastCreatedAt: 2000, LastTxID: "z"})
 		Expect(err).To(BeNil())

--- a/ee/plugins/fireblocks/payments_test.go
+++ b/ee/plugins/fireblocks/payments_test.go
@@ -24,9 +24,12 @@ var _ = Describe("Fireblocks Plugin Payments", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
 		plg = &Plugin{
-			logger:         logging.NewDefaultLogger(GinkgoWriter, true, false, false),
-			client:         m,
-			assetDecimals:  map[string]int{"BTC": 8, "USD": 2},
+			logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false),
+			client: m,
+			assets: map[string]assetInfo{
+				"BTC": {Asset: "BTC/8", Precision: 8, LegacyID: "BTC"},
+				"USD": {Asset: "USD/2", Precision: 2, LegacyID: "USD"},
+			},
 			assetsLastSync: time.Now(),
 		}
 	})
@@ -93,8 +96,8 @@ var _ = Describe("Fireblocks Plugin Payments", func() {
 		Expect(first.Status).To(Equal(models.PAYMENT_STATUS_SUCCEEDED))
 		Expect(*first.SourceAccountReference).To(Equal("src"))
 		Expect(*first.DestinationAccountReference).To(Equal("dst"))
-		Expect(first.Metadata["txHash"]).To(Equal("hash"))
-		Expect(first.Metadata["networkFee"]).To(Equal("0.01"))
+		Expect(first.Metadata[MetadataPrefix+"tx_hash"]).To(Equal("hash"))
+		Expect(first.Metadata[MetadataPrefix+"network_fee"]).To(Equal("0.01"))
 
 	second := resp.Payments[1]
 	Expect(second.Reference).To(Equal("c"))

--- a/ee/plugins/fireblocks/payments_test.go
+++ b/ee/plugins/fireblocks/payments_test.go
@@ -271,6 +271,58 @@ var _ = Describe("Fireblocks Plugin Payments", func() {
 		Expect(resp.Payments[0].Asset).To(Equal("USDT/6"))
 	})
 
+	It("emits non-nil metadata even when the cached asset has no metadata slice", func(ctx SpecContext) {
+		plg.assets = map[string]assetInfo{
+			"BTC": {Asset: "BTC/8", Precision: 8, LegacyID: "BTC"}, // no Metadata
+		}
+
+		m.EXPECT().ListTransactions(gomock.Any(), int64(0), 1).Return([]client.Transaction{
+			{
+				ID:         "tx-empty-md",
+				AssetID:    "BTC",
+				AmountInfo: client.AmountInfo{Amount: "1"},
+				Operation:  "TRANSFER",
+				Status:     "COMPLETED",
+				CreatedAt:  8000,
+				Source:     client.TransferPeer{ID: "vault-1", Type: "VAULT_ACCOUNT"},
+				Destinations: []client.TransferPeer{
+					{ID: "ext-1", Type: "EXTERNAL_WALLET"},
+					{ID: "vault-2", Type: "VAULT_ACCOUNT"},
+				},
+			},
+		}, nil)
+
+		resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{PageSize: 1})
+		Expect(err).To(BeNil())
+		Expect(resp.Payments).To(HaveLen(1))
+		Expect(resp.Payments[0].Metadata).ToNot(BeNil())
+		Expect(resp.Payments[0].Metadata).To(HaveKeyWithValue(MetadataPrefix+"destination_ids", "ext-1,vault-2"))
+	})
+
+	DescribeTable("matchPaymentStatus maps Fireblocks statuses",
+		func(fbStatus string, want models.PaymentStatus) {
+			Expect(matchPaymentStatus(fbStatus)).To(Equal(want))
+		},
+		Entry("COMPLETED", "COMPLETED", models.PAYMENT_STATUS_SUCCEEDED),
+		Entry("SUBMITTED", "SUBMITTED", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_AML_SCREENING", "PENDING_AML_SCREENING", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_ENRICHMENT", "PENDING_ENRICHMENT", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_AUTHORIZATION", "PENDING_AUTHORIZATION", models.PAYMENT_STATUS_PENDING),
+		Entry("QUEUED", "QUEUED", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_SIGNATURE", "PENDING_SIGNATURE", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_3RD_PARTY_MANUAL_APPROVAL", "PENDING_3RD_PARTY_MANUAL_APPROVAL", models.PAYMENT_STATUS_PENDING),
+		Entry("PENDING_3RD_PARTY", "PENDING_3RD_PARTY", models.PAYMENT_STATUS_PENDING),
+		Entry("CONFIRMING", "CONFIRMING", models.PAYMENT_STATUS_PENDING),
+		Entry("BROADCASTING", "BROADCASTING", models.PAYMENT_STATUS_PENDING),
+		Entry("CANCELLING", "CANCELLING", models.PAYMENT_STATUS_CANCELLED),
+		Entry("CANCELLED", "CANCELLED", models.PAYMENT_STATUS_CANCELLED),
+		Entry("FAILED", "FAILED", models.PAYMENT_STATUS_FAILED),
+		Entry("BLOCKED", "BLOCKED", models.PAYMENT_STATUS_FAILED),
+		Entry("REJECTED", "REJECTED", models.PAYMENT_STATUS_FAILED),
+		Entry("unknown falls through to OTHER", "SOMETHING_NEW", models.PaymentStatus(models.PAYMENT_STATUS_OTHER)),
+		Entry("empty string falls through to OTHER", "", models.PaymentStatus(models.PAYMENT_STATUS_OTHER)),
+	)
+
 	It("advances state even when transactions are skipped", func(ctx SpecContext) {
 		state, err := json.Marshal(paymentsState{LastCreatedAt: 2000, LastTxID: "z"})
 		Expect(err).To(BeNil())

--- a/ee/plugins/fireblocks/plugin.go
+++ b/ee/plugins/fireblocks/plugin.go
@@ -14,10 +14,7 @@ import (
 )
 
 const (
-	ProviderName = "fireblocks"
-	// MetadataPrefix namespaces every Fireblocks-specific key written to
-	// PSPAccount / PSPBalance / PSPPayment metadata, matching the
-	// `com.<provider>.spec/` convention used by sibling EE connectors.
+	ProviderName   = "fireblocks"
 	MetadataPrefix = "com.fireblocks.spec/"
 
 	assetRefreshInterval = 24 * time.Hour
@@ -41,9 +38,7 @@ type Plugin struct {
 	assetsMu        sync.RWMutex
 	assetsRefreshMu sync.Mutex
 	assetsLastSync  time.Time
-	// assets maps the uppercased Fireblocks legacyId to its canonical
-	// Formance asset form plus per-asset metadata. Populated by loadAssets.
-	assets map[string]assetInfo
+	assets          map[string]assetInfo // keyed by uppercased legacyId
 }
 
 func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {

--- a/ee/plugins/fireblocks/plugin.go
+++ b/ee/plugins/fireblocks/plugin.go
@@ -7,14 +7,21 @@ import (
 	"time"
 
 	"github.com/formancehq/go-libs/v3/logging"
-	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/ee/plugins/fireblocks/client"
+	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
 	"github.com/formancehq/payments/internal/models"
 )
 
-const ProviderName = "fireblocks"
-const assetRefreshInterval = 24 * time.Hour
+const (
+	ProviderName = "fireblocks"
+	// MetadataPrefix namespaces every Fireblocks-specific key written to
+	// PSPAccount / PSPBalance / PSPPayment metadata, matching the
+	// `com.<provider>.spec/` convention used by sibling EE connectors.
+	MetadataPrefix = "com.fireblocks.spec/"
+
+	assetRefreshInterval = 24 * time.Hour
+)
 
 func init() {
 	registry.RegisterPlugin(ProviderName, models.PluginTypePSP, func(_ models.ConnectorID, name string, logger logging.Logger, rm json.RawMessage) (models.Plugin, error) {
@@ -34,7 +41,9 @@ type Plugin struct {
 	assetsMu        sync.RWMutex
 	assetsRefreshMu sync.Mutex
 	assetsLastSync  time.Time
-	assetDecimals   map[string]int
+	// assets maps the uppercased Fireblocks legacyId to its canonical
+	// Formance asset form plus per-asset metadata. Populated by loadAssets.
+	assets map[string]assetInfo
 }
 
 func New(name string, logger logging.Logger, rawConfig json.RawMessage) (*Plugin, error) {

--- a/ee/plugins/fireblocks/plugin_test.go
+++ b/ee/plugins/fireblocks/plugin_test.go
@@ -98,26 +98,24 @@ var _ = Describe("Fireblocks Plugin", func() {
 			ctrl.Finish()
 		})
 
-		It("loads asset decimals and returns workflow", func(ctx SpecContext) {
+		It("loads assets keyed by uppercased legacyId and returns workflow", func(ctx SpecContext) {
 			decimals2 := 2
 			decimals0 := 0
 			m.EXPECT().ListAssets(gomock.Any()).Return([]client.Asset{
-				{LegacyID: "", Decimals: &decimals2},                               // skipped: empty identifiers
-				{LegacyID: "BTC_TEST", Onchain: &client.AssetOnchain{Decimals: 8}}, // included with underscore
-				{LegacyID: "USD", Decimals: &decimals2},                            // included
-				{ID: "asset-id-only", Decimals: &decimals2},                        // included via ID fallback
-				{LegacyID: "JPY", Decimals: &decimals0},                            // included with 0 decimals
-				{LegacyID: "NEG", Onchain: &client.AssetOnchain{Decimals: -1}},     // skipped: negative decimals
+				{LegacyID: "", DisplaySymbol: "X", AssetClass: client.AssetClassFiat, Decimals: &decimals2}, // skipped: no legacyId
+				{LegacyID: "BTC", DisplaySymbol: "BTC", AssetClass: client.AssetClassNative, Onchain: &client.AssetOnchain{Decimals: 8}},
+				{LegacyID: "USD", DisplaySymbol: "USD", AssetClass: client.AssetClassFiat, Decimals: &decimals2},
+				{LegacyID: "JPY", DisplaySymbol: "JPY", AssetClass: client.AssetClassFiat, Decimals: &decimals0},
+				{LegacyID: "NEG", DisplaySymbol: "NEG", AssetClass: client.AssetClassNative, Onchain: &client.AssetOnchain{Decimals: -1}}, // skipped: negative
 			}, nil)
 
 			res, err := plg.Install(ctx, models.InstallRequest{})
 			Expect(err).To(BeNil())
 			Expect(res.Workflow).To(Equal(workflow()))
-			Expect(plg.assetDecimals).To(HaveLen(4))
-			Expect(plg.assetDecimals["BTC_TEST"]).To(Equal(8))
-			Expect(plg.assetDecimals["USD"]).To(Equal(2))
-			Expect(plg.assetDecimals["asset-id-only"]).To(Equal(2))
-			Expect(plg.assetDecimals["JPY"]).To(Equal(0))
+			Expect(plg.assets).To(HaveLen(3))
+			Expect(plg.assets["BTC"].Asset).To(Equal("BTC/8"))
+			Expect(plg.assets["USD"].Asset).To(Equal("USD/2"))
+			Expect(plg.assets["JPY"].Asset).To(Equal("JPY"))
 		})
 	})
 })

--- a/ee/plugins/fireblocks/plugin_test.go
+++ b/ee/plugins/fireblocks/plugin_test.go
@@ -101,21 +101,28 @@ var _ = Describe("Fireblocks Plugin", func() {
 		It("loads assets keyed by uppercased legacyId and returns workflow", func(ctx SpecContext) {
 			decimals2 := 2
 			decimals0 := 0
+			m.EXPECT().ListBlockchains(gomock.Any()).Return([]client.Blockchain{
+				{ID: "chain-eth", Onchain: &client.BlockchainOnchain{Test: false}},
+				{ID: "chain-eth-sepolia", Onchain: &client.BlockchainOnchain{Test: true}},
+			}, nil)
 			m.EXPECT().ListAssets(gomock.Any()).Return([]client.Asset{
 				{LegacyID: "", DisplaySymbol: "X", AssetClass: client.AssetClassFiat, Decimals: &decimals2}, // skipped: no legacyId
-				{LegacyID: "BTC", DisplaySymbol: "BTC", AssetClass: client.AssetClassNative, Onchain: &client.AssetOnchain{Decimals: 8}},
+				{LegacyID: "BTC", DisplaySymbol: "BTC", AssetClass: client.AssetClassNative, BlockchainID: "chain-eth", Onchain: &client.AssetOnchain{Decimals: 8}},
 				{LegacyID: "USD", DisplaySymbol: "USD", AssetClass: client.AssetClassFiat, Decimals: &decimals2},
 				{LegacyID: "JPY", DisplaySymbol: "JPY", AssetClass: client.AssetClassFiat, Decimals: &decimals0},
+				{LegacyID: "ETH_TEST5", DisplaySymbol: "ETH", AssetClass: client.AssetClassNative, BlockchainID: "chain-eth-sepolia", Onchain: &client.AssetOnchain{Decimals: 18}},
 				{LegacyID: "NEG", DisplaySymbol: "NEG", AssetClass: client.AssetClassNative, Onchain: &client.AssetOnchain{Decimals: -1}}, // skipped: negative
 			}, nil)
 
 			res, err := plg.Install(ctx, models.InstallRequest{})
 			Expect(err).To(BeNil())
 			Expect(res.Workflow).To(Equal(workflow()))
-			Expect(plg.assets).To(HaveLen(3))
+			Expect(plg.assets).To(HaveLen(4))
 			Expect(plg.assets["BTC"].Asset).To(Equal("BTC/8"))
 			Expect(plg.assets["USD"].Asset).To(Equal("USD/2"))
 			Expect(plg.assets["JPY"].Asset).To(Equal("JPY"))
+			Expect(plg.assets["ETH_TEST5"].Asset).To(Equal("ETH_TEST/18"))
+			Expect(plg.assets["ETH_TEST5"].Metadata).To(HaveKeyWithValue(MetadataPrefix+"testnet", "true"))
 		})
 	})
 })

--- a/internal/utils/assets/assets.go
+++ b/internal/utils/assets/assets.go
@@ -4,11 +4,7 @@ import (
 	"regexp"
 )
 
-// Pattern mirrors the canonical asset format enforced by Formance Ledger
-// (see github.com/formancehq/ledger/pkg/assets): an uppercase symbol of up
-// to 17 chars optionally followed by a single `_LETTERS` segment and an
-// optional `/<precision>` suffix. Keeping the two regexes in sync prevents
-// Payments from emitting assets that Ledger would later reject.
+// Pattern mirrors Ledger's canonical asset regex (formancehq/ledger/pkg/assets).
 const Pattern = `[A-Z][A-Z0-9]{0,16}(_[A-Z]{1,16})?(\/\d{1,6})?`
 
 var Regexp = regexp.MustCompile("^" + Pattern + "$")

--- a/internal/utils/assets/assets.go
+++ b/internal/utils/assets/assets.go
@@ -4,13 +4,15 @@ import (
 	"regexp"
 )
 
-// Pattern allows uppercase letters, digits, and underscores for asset identifiers
-// (underscores are common in crypto assets like BTC_TEST, ETH_TEST5, etc.)
-// (Hyphen "-" has been found in some crypto like ETH-AETH_SEPOLIA)
-const Pattern = `[A-Z][A-Z0-9_-]{0,16}(\/\d{1,6})?`
+// Pattern mirrors the canonical asset format enforced by Formance Ledger
+// (see github.com/formancehq/ledger/pkg/assets): an uppercase symbol of up
+// to 17 chars optionally followed by a single `_LETTERS` segment and an
+// optional `/<precision>` suffix. Keeping the two regexes in sync prevents
+// Payments from emitting assets that Ledger would later reject.
+const Pattern = `[A-Z][A-Z0-9]{0,16}(_[A-Z]{1,16})?(\/\d{1,6})?`
 
 var Regexp = regexp.MustCompile("^" + Pattern + "$")
 
 func IsValid(v string) bool {
-	return Regexp.Match([]byte(v))
+	return Regexp.MatchString(v)
 }

--- a/internal/utils/assets/assets_test.go
+++ b/internal/utils/assets/assets_test.go
@@ -6,9 +6,13 @@ func TestIsValid_ValidAssets(t *testing.T) {
 	cases := []string{
 		"A",
 		"BTC",
-		"ETH_TEST",
-		"ETH-AETH_SEPOLIA",
+		"USD",
 		"USD/2",
+		"USD/1234",
+		"EUR/00",
+		"USD123",
+		"EUR_COL",
+		"EUR_COL/12",
 	}
 	for _, c := range cases {
 		c := c
@@ -30,6 +34,12 @@ func TestIsValid_InvalidAssets(t *testing.T) {
 		"USD/ABC",            // non-digit version
 		"USD/1234567",        // version too long (7 digits)
 		"A12345678901234567", // 18 chars before slash
+		"ETH_TEST5",          // digit in suffix segment
+		"ETH-AETH_SEPOLIA",   // hyphen not allowed
+		"MATIC_POLYGON_MUMBAI", // multiple underscore segments
+		"EUR_",               // empty suffix segment
+		"_C",                 // leading underscore
+		"A_/2",               // empty suffix segment before /
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
Closes EN-1011.

Rolls the Payments asset regex back to Ledger's canonical pattern (`[A-Z][A-Z0-9]{0,16}(_[A-Z]{1,16})?(/\d{1,6})?`) so what we emit is what Ledger accepts, and reworks the Fireblocks connector to play by those rules: canonical asset is now derived from `displaySymbol` (sanitised for digit-first / lowercase / oversize cases), same-symbol holdings within a vault aggregate, and mainnet vs testnet are disambiguated via Fireblocks' authoritative `Blockchain.onchain.test` flag (`ETH/18` vs `ETH_TEST/18`). The rich Fireblocks context (`blockchain_id`, `contract_address`, `token_standard`, `display_symbol`, `verified`, `features`, `testnet`, plus vault `customer_ref_id`/`hidden_on_ui`/`auto_fuel`) is surfaced under the `com.fireblocks.spec/` metadata namespace. Per-entry validation now drops invalid balances/payments with a log instead of nuking the whole batch.

Also fixes the initial-sync gap where `/v1/transactions` silently truncates to the last 90 days when `after` is omitted — we now always send `after`, pinned to `1` on the first call. 