### PR TITLE
chore: Split module download into separate cacheable step

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -16,9 +16,15 @@ runs:
     - name: Load dependencies
       shell: bash
       run: nix develop --install
+    - name: Go environment
+      id: go-env
+      shell: bash
+      run: |
+        echo "GOCACHE=$(nix develop --impure --command go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "GOMODCACHE=$(nix develop --impure --command go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - uses: namespacelabs/nscloud-cache-action@v1
       if: inputs.nscloud-cache != 'false'
       with:
         path: |
-          ~/.cache/go-build
-          /tmp/go/pkg/mod/
+          ${{ steps.go-env.outputs.GOCACHE }}
+          ${{ steps.go-env.outputs.GOMODCACHE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,6 @@ jobs:
   GoReleaser:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || contains(github.event.pull_request.labels.*.name, 'deploy-staging') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
-    timeout-minutes: 5
     needs:
       - Dirty
     steps:
@@ -92,8 +91,12 @@ jobs:
           registry: ghcr.io
           username: "NumaryBot"
           password: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+      - uses: namespacelabs/nscloud-setup-buildx-action@v0
+      - name: Download Go modules
+        shell: bash
+        run: nix develop --impure --command go mod download
       - run: >
-          nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes" 
+          nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes"
           develop --impure --command just release-ci
         env:
           GITHUB_TOKEN: ${{ secrets.NUMARY_GITHUB_TOKEN }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,6 +23,10 @@ jobs:
           registry: ghcr.io
           username: "NumaryBot"
           password: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+      - uses: namespacelabs/nscloud-setup-buildx-action@v0
+      - name: Download Go modules
+        shell: bash
+        run: nix develop --impure --command go mod download
       - run: >
           nix --extra-experimental-features "nix-command" --extra-experimental-features "flakes"
           develop --impure --command just release


### PR DESCRIPTION
Failures do not appear to be related to timeouts:

https://github.com/formancehq/payments/actions/runs/26573587345/job/78287113938

Here's another approach that moves the load deps step after the cache step. Also adding the go mod install as a separate step to both the GoReleaser workflows.