### PR TITLE
fix: Ensure administrators can still configure default and minimum polling periods for connectors

### DIFF
--- a/ee/plugins/bitstamp/config.go
+++ b/ee/plugins/bitstamp/config.go
@@ -35,8 +35,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/ee/plugins/bitstamp/plugin_test.go
+++ b/ee/plugins/bitstamp/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/ee/plugins/bitstamp/client"
 	"github.com/formancehq/payments/internal/connectors/plugins"
+	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +19,10 @@ func TestPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Bitstamp Plugin Suite")
 }
+
+var _ = BeforeSuite(func() {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
+})
 
 var _ = Describe("Bitstamp Plugin", func() {
 	var (

--- a/ee/plugins/coinbaseprime/config.go
+++ b/ee/plugins/coinbaseprime/config.go
@@ -34,8 +34,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/ee/plugins/coinbaseprime/plugin_test.go
+++ b/ee/plugins/coinbaseprime/plugin_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/ee/plugins/coinbaseprime/client"
 	"github.com/formancehq/payments/internal/connectors/plugins"
+	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +20,10 @@ func TestPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Coinbase Plugin Suite")
 }
+
+var _ = BeforeSuite(func() {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
+})
 
 var _ = Describe("Coinbase Plugin", func() {
 	var (

--- a/ee/plugins/fireblocks/config.go
+++ b/ee/plugins/fireblocks/config.go
@@ -79,8 +79,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/ee/plugins/routable/config.go
+++ b/ee/plugins/routable/config.go
@@ -43,7 +43,7 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())
 	}
 
-	pp, err := sharedconfig.NewPollingPeriod(raw.PollingPeriod, sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	pp, err := sharedconfig.NewPollingPeriod(raw.PollingPeriod, sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())
 	}

--- a/ee/plugins/routable/config_test.go
+++ b/ee/plugins/routable/config_test.go
@@ -3,9 +3,13 @@ package routable
 import (
 	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 )
 
 func TestConfigDefaults(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	cfg, err := unmarshalAndValidateConfig(json.RawMessage(`{"apiKey":"k"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/connectors/configurer.go
+++ b/internal/connectors/configurer.go
@@ -14,6 +14,9 @@ type Configurer struct {
 }
 
 func NewConfigurer(pollingPeriodDefault, pollingPeriodMinimum time.Duration) (*Configurer, error) {
+	if pollingPeriodDefault <= 0 || pollingPeriodMinimum <= 0 {
+		return nil, fmt.Errorf("connector polling period default and minimum must be bigger than zero")
+	}
 	if pollingPeriodDefault < pollingPeriodMinimum {
 		return nil, fmt.Errorf("default connector polling period may not be lower than minimum")
 	}

--- a/internal/connectors/configurer_test.go
+++ b/internal/connectors/configurer_test.go
@@ -13,15 +13,34 @@ import (
 func TestNewConfigurer(t *testing.T) {
 	t.Parallel()
 
-	defaultPeriod := 13 * time.Minute
-	minimumPeriod := 5 * time.Minute
+	tests := []struct {
+		name        string
+		def         time.Duration
+		min         time.Duration
+		expectError bool
+	}{
+		{"valid", 13 * time.Minute, 5 * time.Minute, false},
+		{"default below minimum", 4 * time.Minute, 5 * time.Minute, true},
+		{"zero default", 0, 5 * time.Minute, true},
+		{"zero minimum", 13 * time.Minute, 0, true},
+		{"both zero", 0, 0, true},
+		{"negative default", -1 * time.Minute, 5 * time.Minute, true},
+		{"negative minimum", 13 * time.Minute, -1 * time.Minute, true},
+		{"both negative", -1 * time.Minute, -2 * time.Minute, true},
+	}
 
-	configurer, err := connectors.NewConfigurer(defaultPeriod, minimumPeriod)
-	require.NoError(t, err)
-	assert.Equal(t, defaultPeriod, configurer.DefaultConfig().PollingPeriod)
-
-	_, err = connectors.NewConfigurer(minimumPeriod-time.Second, minimumPeriod)
-	require.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			configurer, err := connectors.NewConfigurer(tt.def, tt.min)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.def, configurer.DefaultConfig().PollingPeriod)
+			}
+		})
+	}
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/internal/connectors/manager.go
+++ b/internal/connectors/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	pluginserrors "github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
+	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/pkg/errors"
 )
@@ -68,6 +69,7 @@ func NewManager(
 		// start it misconfigured
 		log.Panicf("invalid connector polling period configuration: %v", err)
 	}
+	sharedconfig.SetPollingPeriodDefaults(pollingPeriodDefault, pollingPeriodMinimum)
 	return &manager{
 		logger:               logger,
 		configurer:           configurer,

--- a/internal/connectors/plugins/public/atlar/config.go
+++ b/internal/connectors/plugins/public/atlar/config.go
@@ -31,8 +31,8 @@ func unmarshalAndValidateConfig(payload []byte) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/atlar/config_test.go
+++ b/internal/connectors/plugins/public/atlar/config_test.go
@@ -2,6 +2,7 @@ package atlar
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/atlar/config_test.go
+++ b/internal/connectors/plugins/public/atlar/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/bankingcircle/config.go
+++ b/internal/connectors/plugins/public/bankingcircle/config.go
@@ -37,8 +37,8 @@ func unmarshalAndValidateConfig(payload []byte) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/bankingcircle/config_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/config_test.go
@@ -2,6 +2,7 @@ package bankingcircle
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/bankingcircle/config_test.go
+++ b/internal/connectors/plugins/public/bankingcircle/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/column/config.go
+++ b/internal/connectors/plugins/public/column/config.go
@@ -29,8 +29,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/column/config_test.go
+++ b/internal/connectors/plugins/public/column/config_test.go
@@ -2,6 +2,7 @@ package column
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/column/config_test.go
+++ b/internal/connectors/plugins/public/column/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/generic/config.go
+++ b/internal/connectors/plugins/public/generic/config.go
@@ -29,8 +29,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/generic/config_test.go
+++ b/internal/connectors/plugins/public/generic/config_test.go
@@ -2,6 +2,7 @@ package generic
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/generic/config_test.go
+++ b/internal/connectors/plugins/public/generic/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/increase/config.go
+++ b/internal/connectors/plugins/public/increase/config.go
@@ -31,8 +31,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/increase/config_test.go
+++ b/internal/connectors/plugins/public/increase/config_test.go
@@ -2,6 +2,7 @@ package increase
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/increase/config_test.go
+++ b/internal/connectors/plugins/public/increase/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/mangopay/config.go
+++ b/internal/connectors/plugins/public/mangopay/config.go
@@ -31,8 +31,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/mangopay/config_test.go
+++ b/internal/connectors/plugins/public/mangopay/config_test.go
@@ -2,6 +2,7 @@ package mangopay
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/mangopay/config_test.go
+++ b/internal/connectors/plugins/public/mangopay/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/modulr/config.go
+++ b/internal/connectors/plugins/public/modulr/config.go
@@ -31,8 +31,8 @@ func unmarshalAndValidateConfig(payload []byte) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/modulr/config_test.go
+++ b/internal/connectors/plugins/public/modulr/config_test.go
@@ -2,6 +2,7 @@ package modulr
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/modulr/config_test.go
+++ b/internal/connectors/plugins/public/modulr/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/moneycorp/config.go
+++ b/internal/connectors/plugins/public/moneycorp/config.go
@@ -31,8 +31,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/moneycorp/config_test.go
+++ b/internal/connectors/plugins/public/moneycorp/config_test.go
@@ -2,6 +2,7 @@ package moneycorp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/moneycorp/config_test.go
+++ b/internal/connectors/plugins/public/moneycorp/config_test.go
@@ -11,8 +11,8 @@ import (
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/public/qonto/config.go
+++ b/internal/connectors/plugins/public/qonto/config.go
@@ -33,8 +33,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/qonto/config_test.go
+++ b/internal/connectors/plugins/public/qonto/config_test.go
@@ -2,6 +2,8 @@ package qonto
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/go-playground/validator/v10"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
@@ -22,6 +24,7 @@ var _ = Describe("unmarshalAndValidateConfig", func() {
 	)
 
 	BeforeEach(func() {
+		sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 		var err error
 		defaultPollingPeriod, err = sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 		Expect(err).To(BeNil())

--- a/internal/connectors/plugins/public/qonto/config_test.go
+++ b/internal/connectors/plugins/public/qonto/config_test.go
@@ -23,9 +23,9 @@ var _ = Describe("unmarshalAndValidateConfig", func() {
 
 	BeforeEach(func() {
 		var err error
-		defaultPollingPeriod, err = sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+		defaultPollingPeriod, err = sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 		Expect(err).To(BeNil())
-		longPollingPeriod, err = sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+		longPollingPeriod, err = sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 		Expect(err).To(BeNil())
 	})
 

--- a/internal/connectors/plugins/public/stripe/config.go
+++ b/internal/connectors/plugins/public/stripe/config.go
@@ -28,8 +28,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/stripe/plugin_test.go
+++ b/internal/connectors/plugins/public/stripe/plugin_test.go
@@ -3,10 +3,12 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
+	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/formancehq/payments/internal/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +20,10 @@ func TestPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Stripe Plugin Suite")
 }
+
+var _ = BeforeSuite(func() {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
+})
 
 var _ = Describe("Stripe Plugin", func() {
 	var (

--- a/internal/connectors/plugins/public/wise/config.go
+++ b/internal/connectors/plugins/public/wise/config.go
@@ -66,8 +66,8 @@ func unmarshalAndValidateConfig(payload json.RawMessage) (Config, error) {
 
 	pp, err := sharedconfig.NewPollingPeriod(
 		raw.PollingPeriod,
-		sharedconfig.DefaultPollingPeriod,
-		sharedconfig.MinimumPollingPeriod,
+		sharedconfig.GetDefaultPollingPeriod(),
+		sharedconfig.GetMinimumPollingPeriod(),
 	)
 	if err != nil {
 		return Config{}, errors.Wrap(models.ErrInvalidConfig, err.Error())

--- a/internal/connectors/plugins/public/wise/config_test.go
+++ b/internal/connectors/plugins/public/wise/config_test.go
@@ -3,6 +3,7 @@ package wise
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 	"github.com/formancehq/payments/internal/models"
@@ -22,6 +23,7 @@ func makePayload(t *testing.T, v any) []byte {
 }
 
 func TestUnmarshalAndValidateConfig(t *testing.T) {
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
 	 t.Parallel()
 
 	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())

--- a/internal/connectors/plugins/public/wise/config_test.go
+++ b/internal/connectors/plugins/public/wise/config_test.go
@@ -24,8 +24,8 @@ func makePayload(t *testing.T, v any) []byte {
 func TestUnmarshalAndValidateConfig(t *testing.T) {
 	 t.Parallel()
 
-	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
-	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.DefaultPollingPeriod, sharedconfig.MinimumPollingPeriod)
+	 defaultPollingPeriod, _ := sharedconfig.NewPollingPeriod("", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
+	 longPollingPeriod, _ := sharedconfig.NewPollingPeriod("45m", sharedconfig.GetDefaultPollingPeriod(), sharedconfig.GetMinimumPollingPeriod())
 
 	 tests := []struct {
 		 name        string

--- a/internal/connectors/plugins/sharedconfig/polling_period.go
+++ b/internal/connectors/plugins/sharedconfig/polling_period.go
@@ -6,8 +6,10 @@ import (
 )
 
 var (
-	minimumPollingPeriod = 20 * time.Minute
-	defaultPollingPeriod = 30 * time.Minute
+	// these have no hard-coded default value because they are supposed to be set as part of the server configuration
+	// using command line flags. as such their default values are also configured in the cmd package
+	minimumPollingPeriod time.Duration
+	defaultPollingPeriod time.Duration
 )
 
 func GetMinimumPollingPeriod() time.Duration { return minimumPollingPeriod }

--- a/internal/connectors/plugins/sharedconfig/polling_period.go
+++ b/internal/connectors/plugins/sharedconfig/polling_period.go
@@ -2,24 +2,25 @@ package sharedconfig
 
 import (
 	"encoding/json"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	// these have no hard-coded default value because they are supposed to be set as part of the server configuration
 	// using command line flags. as such their default values are also configured in the cmd package
-	minimumPollingPeriod time.Duration
-	defaultPollingPeriod time.Duration
+	minimumPollingPeriod atomic.Int64
+	defaultPollingPeriod atomic.Int64
 )
 
-func GetMinimumPollingPeriod() time.Duration { return minimumPollingPeriod }
-func GetDefaultPollingPeriod() time.Duration { return defaultPollingPeriod }
+func GetMinimumPollingPeriod() time.Duration { return time.Duration(minimumPollingPeriod.Load()) }
+func GetDefaultPollingPeriod() time.Duration { return time.Duration(defaultPollingPeriod.Load()) }
 
 // SetPollingPeriodDefaults is only intended to be called from connectors.Manager
 // which gets its configuration from command line arguments set by the service administrator
 func SetPollingPeriodDefaults(def, min time.Duration) {
-	defaultPollingPeriod = def
-	minimumPollingPeriod = min
+	defaultPollingPeriod.Store(int64(def))
+	minimumPollingPeriod.Store(int64(min))
 }
 
 type PollingPeriod time.Duration

--- a/internal/connectors/plugins/sharedconfig/polling_period.go
+++ b/internal/connectors/plugins/sharedconfig/polling_period.go
@@ -5,10 +5,20 @@ import (
 	"time"
 )
 
-const (
-	MinimumPollingPeriod = 20 * time.Minute
-	DefaultPollingPeriod = 30 * time.Minute
+var (
+	minimumPollingPeriod = 20 * time.Minute
+	defaultPollingPeriod = 30 * time.Minute
 )
+
+func GetMinimumPollingPeriod() time.Duration { return minimumPollingPeriod }
+func GetDefaultPollingPeriod() time.Duration { return defaultPollingPeriod }
+
+// SetPollingPeriodDefaults is only intended to be called from connectors.Manager
+// which gets its configuration from command line arguments set by the service administrator
+func SetPollingPeriodDefaults(def, min time.Duration) {
+	defaultPollingPeriod = def
+	minimumPollingPeriod = min
+}
 
 type PollingPeriod time.Duration
 

--- a/internal/connectors/plugins/sharedconfig/polling_period_test.go
+++ b/internal/connectors/plugins/sharedconfig/polling_period_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/sharedconfig"
 )
 
+func TestSetAndGetPollingPeriodDefaults(t *testing.T) {
+	// sequential — mutates package-level atomics
+	sharedconfig.SetPollingPeriodDefaults(30*time.Minute, 20*time.Minute)
+	if got := sharedconfig.GetDefaultPollingPeriod(); got != 30*time.Minute {
+		t.Errorf("GetDefaultPollingPeriod() = %v, want %v", got, 30*time.Minute)
+	}
+	if got := sharedconfig.GetMinimumPollingPeriod(); got != 20*time.Minute {
+		t.Errorf("GetMinimumPollingPeriod() = %v, want %v", got, 20*time.Minute)
+	}
+
+	// overwrite with different values
+	sharedconfig.SetPollingPeriodDefaults(45*time.Minute, 10*time.Minute)
+	if got := sharedconfig.GetDefaultPollingPeriod(); got != 45*time.Minute {
+		t.Errorf("GetDefaultPollingPeriod() = %v, want %v", got, 45*time.Minute)
+	}
+	if got := sharedconfig.GetMinimumPollingPeriod(); got != 10*time.Minute {
+		t.Errorf("GetMinimumPollingPeriod() = %v, want %v", got, 10*time.Minute)
+	}
+}
+
 func TestParsePollingPeriod(t *testing.T) {
 	cases := []struct {
 		raw            string


### PR DESCRIPTION
Fixes: EN-1030