### PR TITLE
feat(routable): expose Routable's message field via metadata (EN-1042)

### DIFF
--- a/ee/plugins/routable/MAPPINGS.md
+++ b/ee/plugins/routable/MAPPINGS.md
@@ -180,6 +180,7 @@ All keys are defined as constants in [`mappers/metadata.go`](mappers/metadata.go
 | `com.routable.spec/acting_team_member` | `MetadataKeyActingTeamMember` | conditional¹ | config `actingTeamMember` | `acting_team_member` | Routable team member ID initiating the payable. |
 | `com.routable.spec/external_id` | `MetadataKeyExternalID` | no | `""` | `external_id` | Caller-supplied external reference (idempotent lookup key on Routable's side). |
 | `com.routable.spec/line_item_description` | `MetadataKeyLineDescription` | no | `PSPPaymentInitiation.Description`, then `"Payment <reference>"` | `line_items[0].description` | Description on the auto-generated single-line item. Required by Routable v1; we always emit a non-empty value. |
+| `com.routable.spec/message` | `MetadataKeyMessage` | no | (omitted) | `message` | Vendor-facing email body sent to the payee's contacts when the payable is processed. A limited subset of HTML is permitted (see [Routable docs](https://developers.routable.com/docs/html-messages)). Omitted from the request body when empty. |
 
 > `com.routable.spec/memo` is read-only metadata on synced payables/receivables (populated from the Routable response). Routable's v1 `POST /v1/payables` rejects `memo` as an unknown field, so we do not forward this key on create. Use `com.routable.spec/line_item_description` for the message that ends up on the payable.
 

--- a/ee/plugins/routable/client/types.go
+++ b/ee/plugins/routable/client/types.go
@@ -185,6 +185,12 @@ type CreatePayableRequest struct {
 	Reference        string            `json:"reference,omitempty"`
 	ExternalID       string            `json:"external_id,omitempty"`
 
+	// Message is Routable's vendor-facing email body sent to the payee's
+	// contacts when the payable is processed. HTML subset permitted; see
+	// https://developers.routable.com/docs/html-messages. Omitted from the
+	// wire body when empty so existing callers see no behavioral change.
+	Message string `json:"message,omitempty"`
+
 	// IdempotencyKey is sent via the Idempotency-Key header, never the body.
 	// memo is intentionally NOT modeled here: Routable's v1 POST /v1/payables
 	// schema rejects it as "Extra inputs are not permitted". The Payable

--- a/ee/plugins/routable/mappers/metadata.go
+++ b/ee/plugins/routable/mappers/metadata.go
@@ -11,6 +11,7 @@ const (
 	MetadataKeyDeliveryMethod   = MetadataPrefix + "delivery_method"
 	MetadataKeyExternalID       = MetadataPrefix + "external_id"
 	MetadataKeyMemo             = MetadataPrefix + "memo"
+	MetadataKeyMessage          = MetadataPrefix + "message"
 	MetadataKeyLineDescription  = MetadataPrefix + "line_item_description"
 	MetadataKeyActingTeamMember = MetadataPrefix + "acting_team_member"
 )

--- a/ee/plugins/routable/payable_create.go
+++ b/ee/plugins/routable/payable_create.go
@@ -68,6 +68,7 @@ func (p *Plugin) initiatePayable(ctx context.Context, pi models.PSPPaymentInitia
 		ActingTeamMember: mappers.FieldOr(pi.Metadata, mappers.MetadataKeyActingTeamMember, p.config.ActingTeamMember),
 		Reference:        pi.Reference,
 		ExternalID:       pi.Metadata[mappers.MetadataKeyExternalID],
+		Message:          pi.Metadata[mappers.MetadataKeyMessage],
 		IdempotencyKey:   pi.Reference,
 	}
 

--- a/ee/plugins/routable/payouts_test.go
+++ b/ee/plugins/routable/payouts_test.go
@@ -162,6 +162,31 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 		Expect(err).To(BeNil())
 	})
 
+	It("forwards com.routable.spec/message to Routable.message when set", func(ctx SpecContext) {
+		piWithMsg := pi()
+		piWithMsg.Metadata = map[string]string{
+			mappers.MetadataKeyMessage: "Hi Acme - invoice #12345 for May services.",
+		}
+		mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+			Expect(req.Message).To(Equal("Hi Acme - invoice #12345 for May services."))
+			return &client.Payable{ID: "pa_msg", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+		})
+		_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: piWithMsg})
+		Expect(err).To(BeNil())
+	})
+
+	It("omits message from the wire body when no metadata is set", func(ctx SpecContext) {
+		mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+			Expect(req.Message).To(BeEmpty())
+			body, err := json.Marshal(req)
+			Expect(err).To(BeNil())
+			Expect(string(body)).NotTo(ContainSubstring(`"message"`))
+			return &client.Payable{ID: "pa_nomsg", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+		})
+		_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: pi()})
+		Expect(err).To(BeNil())
+	})
+
 	// Validation errors must wrap ErrInvalidRequest so Temporal stops
 	// retrying invalid PIs.
 	It("rejects payment initiations with no source/destination and wraps ErrInvalidRequest", func(ctx SpecContext) {


### PR DESCRIPTION
## Summary
Adds an optional `com.routable.spec/message` metadata key on `PSPPaymentInitiation` that flows through to Routable's top-level `message` field on `POST /v1/payables` (the vendor-facing email body).

Backward-compatible and additive: absent or empty metadata = field omitted from the wire body, no behavior change for current users.

## Why
Routable's API exposes a `message` field on payable creation that populates the email Routable sends to the payee's contacts. The connector did not model it (PR #711 deliberately shipped a tight initial set; `message` was identified as a follow-up). Operators want to attach a payment-specific note (e.g. invoice ref, internal context) without relying on `line_items[*].description`.

## Changes
- `client/types.go`: add `Message` to `CreatePayableRequest` (`omitempty`)
- `mappers/metadata.go`: add `MetadataKeyMessage` constant
- `payable_create.go`: populate `req.Message` from `pi.Metadata[MetadataKeyMessage]`
- `payouts_test.go`: pin both forward and omit behavior
- `MAPPINGS.md` §5.1: document the new metadata key

## Out of scope
- HTML validation (Routable validates server-side)
- Other `CommonNewItem` fields (`bill_number`, `attachments`, `ledger.*`, `due_on`, `issued_on`) — separate tickets if/when needed
- `MetadataKeyMemo` cleanup (kept for now since it's already published; safer to deprecate in a dedicated chore)

## Test plan
- [x] Unit: `com.routable.spec/message` set → forwarded to `CreatePayableRequest.Message`
- [x] Unit: metadata absent → `Message` empty, wire body omits the field
- [ ] Manual sandbox: payout with metadata set → confirm Routable sends thred message in the vendor email

Closes EN-1042