### PR TITLE
fix(column): EN-1086 send Idempotency-Key on payouts and transfers

### DIFF
--- a/internal/connectors/plugins/public/column/client/client.go
+++ b/internal/connectors/plugins/public/column/client/client.go
@@ -98,3 +98,15 @@ func (c *client) newRequest(ctx context.Context, method, path string, body io.Re
 	}
 	return req, nil
 }
+
+// idempotencyKeyHeader is Column's header for safely retrying mutating
+// requests. Reusing the same key makes the call idempotent at Column, which
+// protects the money-movement path against duplicate payouts/transfers when
+// the engine retries the activity (see EN-1086).
+const idempotencyKeyHeader = "Idempotency-Key"
+
+func setIdempotencyKey(req *http.Request, key string) {
+	if key != "" {
+		req.Header.Set(idempotencyKeyHeader, key)
+	}
+}

--- a/internal/connectors/plugins/public/column/client/payouts.go
+++ b/internal/connectors/plugins/public/column/client/payouts.go
@@ -242,6 +242,9 @@ type PayoutRequest struct {
 	DestinationAccount string            `json:"destination_account"`
 	Description        string            `json:"description"`
 	Metadata           map[string]string `json:"metadata"`
+	// Reference is the payment initiation reference, sent as the
+	// Idempotency-Key header (never in the body) to make retries safe.
+	Reference string `json:"-"`
 }
 
 type PayoutResponse struct {
@@ -341,7 +344,7 @@ func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*Payout
 			UltimateOriginatorCounterpartyId:  models.ExtractNamespacedMetadata(pr.Metadata, ColumnUltimateOriginatorCounterpartyIdMetadataKey),
 		}
 
-		return c.initiateACHPayout(ctx, achPayload)
+		return c.initiateACHPayout(ctx, achPayload, pr.Reference)
 	case "wire":
 		wirePayload := &WirePayoutRequest{
 			Amount:                           pr.Amount,
@@ -354,7 +357,7 @@ func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*Payout
 			UltimateOriginatorAccountNumber:  models.ExtractNamespacedMetadata(pr.Metadata, ColumnUltimateOriginatorAccountNumberMetadataKey),
 		}
 
-		return c.initiateWirePayouts(ctx, wirePayload)
+		return c.initiateWirePayouts(ctx, wirePayload, pr.Reference)
 	case "international-wire":
 		internationalPayload := &InternationalWirePayoutRequest{
 			Amount:                   pr.Amount,
@@ -374,7 +377,7 @@ func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*Payout
 			},
 		}
 
-		return c.initiateInternationalPayout(ctx, internationalPayload)
+		return c.initiateInternationalPayout(ctx, internationalPayload, pr.Reference)
 	case "realtime":
 		realtimePayload := &RealtimeTransferRequest{
 			Amount:                       pr.Amount,
@@ -388,13 +391,13 @@ func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*Payout
 			EndToEndID:                   models.ExtractNamespacedMetadata(pr.Metadata, ColumnEndToEndIdMetadataKey),
 		}
 
-		return c.initiateRealtimePayout(ctx, realtimePayload)
+		return c.initiateRealtimePayout(ctx, realtimePayload, pr.Reference)
 	}
 
 	return nil, nil
 }
 
-func (c *client) initiateACHPayout(ctx context.Context, pr *ACHPayoutRequest) (*PayoutResponse, error) {
+func (c *client) initiateACHPayout(ctx context.Context, pr *ACHPayoutRequest, idempotencyKey string) (*PayoutResponse, error) {
 	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_ach_payout")
 
 	body, err := json.Marshal(pr)
@@ -406,6 +409,7 @@ func (c *client) initiateACHPayout(ctx context.Context, pr *ACHPayoutRequest) (*
 	if err != nil {
 		return &PayoutResponse{}, fmt.Errorf("failed to create ach transfer request: %w", err)
 	}
+	setIdempotencyKey(req, idempotencyKey)
 
 	var response ACHPayoutResponse
 	var errRes columnError
@@ -416,7 +420,7 @@ func (c *client) initiateACHPayout(ctx context.Context, pr *ACHPayoutRequest) (*
 	return MapAchPayout(response)
 }
 
-func (c *client) initiateWirePayouts(ctx context.Context, pr *WirePayoutRequest) (*PayoutResponse, error) {
+func (c *client) initiateWirePayouts(ctx context.Context, pr *WirePayoutRequest, idempotencyKey string) (*PayoutResponse, error) {
 	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_wire_payout")
 
 	body, err := json.Marshal(pr)
@@ -428,6 +432,7 @@ func (c *client) initiateWirePayouts(ctx context.Context, pr *WirePayoutRequest)
 	if err != nil {
 		return &PayoutResponse{}, fmt.Errorf("failed to create wire transfer request: %w", err)
 	}
+	setIdempotencyKey(req, idempotencyKey)
 
 	var response WirePayoutResponse
 	var errRes columnError
@@ -438,7 +443,7 @@ func (c *client) initiateWirePayouts(ctx context.Context, pr *WirePayoutRequest)
 	return MapWirePayout(response)
 }
 
-func (c *client) initiateInternationalPayout(ctx context.Context, pr *InternationalWirePayoutRequest) (*PayoutResponse, error) {
+func (c *client) initiateInternationalPayout(ctx context.Context, pr *InternationalWirePayoutRequest, idempotencyKey string) (*PayoutResponse, error) {
 	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_international_payout")
 
 	body, err := json.Marshal(pr)
@@ -450,6 +455,7 @@ func (c *client) initiateInternationalPayout(ctx context.Context, pr *Internatio
 	if err != nil {
 		return &PayoutResponse{}, fmt.Errorf("failed to create international transfer request: %w", err)
 	}
+	setIdempotencyKey(req, idempotencyKey)
 
 	var response InternationalWirePayoutResponse
 	var errRes columnError
@@ -460,7 +466,7 @@ func (c *client) initiateInternationalPayout(ctx context.Context, pr *Internatio
 	return MapInternationalWirePayout(response)
 }
 
-func (c *client) initiateRealtimePayout(ctx context.Context, pr *RealtimeTransferRequest) (*PayoutResponse, error) {
+func (c *client) initiateRealtimePayout(ctx context.Context, pr *RealtimeTransferRequest, idempotencyKey string) (*PayoutResponse, error) {
 	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "initiate_realtime_payout")
 
 	body, err := json.Marshal(pr)
@@ -472,6 +478,7 @@ func (c *client) initiateRealtimePayout(ctx context.Context, pr *RealtimeTransfe
 	if err != nil {
 		return &PayoutResponse{}, fmt.Errorf("failed to create rtp transfer request: %w", err)
 	}
+	setIdempotencyKey(req, idempotencyKey)
 
 	var response RealtimeTransferResponse
 	var errRes columnError

--- a/internal/connectors/plugins/public/column/client/tranfers.go
+++ b/internal/connectors/plugins/public/column/client/tranfers.go
@@ -18,6 +18,9 @@ type TransferRequest struct {
 	AllowOverdraft        bool                   `json:"allow_overdraft,omitempty"`
 	Hold                  bool                   `json:"hold,omitempty"`
 	Details               TransferRequestDetails `json:"details,omitempty"`
+	// Reference is the payment initiation reference, sent as the
+	// Idempotency-Key header (never in the body) to make retries safe.
+	Reference string `json:"-"`
 }
 
 type TransferRequestDetails struct {
@@ -60,6 +63,7 @@ func (c *client) InitiateTransfer(ctx context.Context, transferRequest *Transfer
 	if err != nil {
 		return &TransferResponse{}, fmt.Errorf("failed to create transfer request: %w", err)
 	}
+	setIdempotencyKey(req, transferRequest.Reference)
 
 	var response TransferResponse
 	var errRes columnError

--- a/internal/connectors/plugins/public/column/payouts.go
+++ b/internal/connectors/plugins/public/column/payouts.go
@@ -36,6 +36,7 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 			SourceAccount:      pi.SourceAccount.Reference,
 			DestinationAccount: pi.DestinationAccount.Reference,
 			Description:        pi.Description,
+			Reference:          pi.Reference,
 		},
 	)
 	if err != nil {

--- a/internal/connectors/plugins/public/column/payouts_test.go
+++ b/internal/connectors/plugins/public/column/payouts_test.go
@@ -1,8 +1,10 @@
 package column
 
 import (
+	"context"
 	"fmt"
 	"math/big"
+	"net/http"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/public/column/client"
 	"github.com/formancehq/payments/internal/models"
@@ -666,6 +668,70 @@ var _ = Describe("Column Plugin Payouts", func() {
 				Expect(resp.Payment.Asset).To(Equal("USD/2"))
 			})
 		})
+	})
+
+	Context("Idempotency key (EN-1086)", func() {
+		// Each payout rail must send the payment initiation reference as the
+		// Idempotency-Key header so that engine retries do not create a
+		// duplicate money movement at Column.
+		newPayoutRequest := func(payoutType string) models.CreatePayoutRequest {
+			return models.CreatePayoutRequest{
+				PaymentInitiation: models.PSPPaymentInitiation{
+					Reference: "pi-ref-123",
+					Amount:    big.NewInt(100),
+					Asset:     "USD/2",
+					SourceAccount: &models.PSPAccount{
+						Reference: "src-ref",
+					},
+					DestinationAccount: &models.PSPAccount{
+						Reference: "dst-ref",
+					},
+					Metadata: map[string]string{
+						client.ColumnPayoutTypeMetadataKey: payoutType,
+					},
+				},
+			}
+		}
+
+		DescribeTable("should send the payment initiation reference as the Idempotency-Key header",
+			func(ctx SpecContext, payoutType string, setResponse func(any)) {
+				var capturedKey string
+				mockHTTPClient.EXPECT().Do(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).DoAndReturn(func(_ context.Context, r *http.Request, resp any, _ any) (int, error) {
+					capturedKey = r.Header.Get("Idempotency-Key")
+					setResponse(resp)
+					return 200, nil
+				})
+
+				_, err := plg.CreatePayout(ctx, newPayoutRequest(payoutType))
+				Expect(err).To(BeNil())
+				Expect(capturedKey).To(Equal("pi-ref-123"))
+			},
+			Entry("ACH", "ach", func(resp any) {
+				*(resp.(*client.ACHPayoutResponse)) = client.ACHPayoutResponse{
+					ID: "test-id", CreatedAt: "2021-01-01T00:00:00Z", CurrencyCode: "USD", Amount: 100,
+				}
+			}),
+			Entry("wire", "wire", func(resp any) {
+				*(resp.(*client.WirePayoutResponse)) = client.WirePayoutResponse{
+					ID: "test-id", CreatedAt: "2021-01-01T00:00:00Z", CurrencyCode: "USD", Amount: 100,
+				}
+			}),
+			Entry("international-wire", "international-wire", func(resp any) {
+				*(resp.(*client.InternationalWirePayoutResponse)) = client.InternationalWirePayoutResponse{
+					ID: "test-id", CreatedAt: "2021-01-01T00:00:00Z", CurrencyCode: "USD", Amount: 100,
+				}
+			}),
+			Entry("realtime", "realtime", func(resp any) {
+				*(resp.(*client.RealtimeTransferResponse)) = client.RealtimeTransferResponse{
+					ID: "test-id", InitiatedAt: "2021-01-01T00:00:00Z", CurrencyCode: "USD", Amount: 100, Status: "completed",
+				}
+			}),
+		)
 	})
 
 	Context("mapTransactionStatus", func() {

--- a/internal/connectors/plugins/public/column/payouts_test.go
+++ b/internal/connectors/plugins/public/column/payouts_test.go
@@ -3,8 +3,10 @@ package column
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
+	"strings"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/public/column/client"
 	"github.com/formancehq/payments/internal/models"
@@ -45,7 +47,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when sourceAccount is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 				},
 			}
 			_, err := plg.CreatePayout(ctx, req)
@@ -56,6 +59,7 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when sourceAccount reference is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
+					Reference:     "test-ref",
 					Amount:        big.NewInt(100),
 					SourceAccount: &models.PSPAccount{},
 				},
@@ -68,7 +72,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when destinationAccount is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
 					},
@@ -82,7 +87,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when destinationAccount reference is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
 					},
@@ -97,7 +103,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when metadata is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
 					},
@@ -114,7 +121,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when payout type is missing", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
 					},
@@ -132,7 +140,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 		It("should return an error when payout type is invalid", func(ctx SpecContext) {
 			req := models.CreatePayoutRequest{
 				PaymentInitiation: models.PSPPaymentInitiation{
-					Amount: big.NewInt(100),
+					Reference: "test-ref",
+					Amount:    big.NewInt(100),
 					SourceAccount: &models.PSPAccount{
 						Reference: "test-ref",
 					},
@@ -154,7 +163,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should return an error when asset is missing", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -175,8 +185,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -229,8 +240,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -264,8 +276,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should return an error when creating wire payout request fails", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -297,8 +310,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should return an error when creating international-wire payout request fails", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -330,8 +344,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should return an error when creating realtime payout request fails", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -375,8 +390,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 
 					req := models.CreatePayoutRequest{
 						PaymentInitiation: models.PSPPaymentInitiation{
-							Amount: big.NewInt(100),
-							Asset:  "USD/2",
+							Reference: "test-ref",
+							Amount:    big.NewInt(100),
+							Asset:     "USD/2",
 							SourceAccount: &models.PSPAccount{
 								Reference: "test-ref",
 							},
@@ -400,8 +416,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 				It("should return an error when wire payout URL is invalid", func(ctx SpecContext) {
 					req := models.CreatePayoutRequest{
 						PaymentInitiation: models.PSPPaymentInitiation{
-							Amount: big.NewInt(100),
-							Asset:  "USD/2",
+							Reference: "test-ref",
+							Amount:    big.NewInt(100),
+							Asset:     "USD/2",
 							SourceAccount: &models.PSPAccount{
 								Reference: "test-ref",
 							},
@@ -423,8 +440,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 				It("should return an error when international wire payout URL is invalid", func(ctx SpecContext) {
 					req := models.CreatePayoutRequest{
 						PaymentInitiation: models.PSPPaymentInitiation{
-							Amount: big.NewInt(100),
-							Asset:  "USD/2",
+							Reference: "test-ref",
+							Amount:    big.NewInt(100),
+							Asset:     "USD/2",
 							SourceAccount: &models.PSPAccount{
 								Reference: "test-ref",
 							},
@@ -446,8 +464,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 				It("should return an error when realtime payout URL is invalid", func(ctx SpecContext) {
 					req := models.CreatePayoutRequest{
 						PaymentInitiation: models.PSPPaymentInitiation{
-							Amount: big.NewInt(100),
-							Asset:  "USD/2",
+							Reference: "test-ref",
+							Amount:    big.NewInt(100),
+							Asset:     "USD/2",
 							SourceAccount: &models.PSPAccount{
 								Reference: "test-ref",
 							},
@@ -469,8 +488,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 				It("should return an error when asset is invalid", func(ctx SpecContext) {
 					req := models.CreatePayoutRequest{
 						PaymentInitiation: models.PSPPaymentInitiation{
-							Amount: big.NewInt(100),
-							Asset:  "INVALID/2",
+							Reference: "test-ref",
+							Amount:    big.NewInt(100),
+							Asset:     "INVALID/2",
 							SourceAccount: &models.PSPAccount{
 								Reference: "test-ref",
 							},
@@ -497,8 +517,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -540,8 +561,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should create a payment from an ACH payout response", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -585,8 +607,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should create a payment from an international wire payout response", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -627,8 +650,9 @@ var _ = Describe("Column Plugin Payouts", func() {
 			It("should create a payment from a realtime payout response", func(ctx SpecContext) {
 				req := models.CreatePayoutRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						SourceAccount: &models.PSPAccount{
 							Reference: "test-ref",
 						},
@@ -695,7 +719,7 @@ var _ = Describe("Column Plugin Payouts", func() {
 
 		DescribeTable("should send the payment initiation reference as the Idempotency-Key header",
 			func(ctx SpecContext, payoutType string, setResponse func(any)) {
-				var capturedKey string
+				var capturedKey, capturedBody string
 				mockHTTPClient.EXPECT().Do(
 					gomock.Any(),
 					gomock.Any(),
@@ -703,6 +727,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 					gomock.Any(),
 				).DoAndReturn(func(_ context.Context, r *http.Request, resp any, _ any) (int, error) {
 					capturedKey = r.Header.Get("Idempotency-Key")
+					bodyBytes, _ := io.ReadAll(r.Body)
+					capturedBody = string(bodyBytes)
 					setResponse(resp)
 					return 200, nil
 				})
@@ -710,6 +736,8 @@ var _ = Describe("Column Plugin Payouts", func() {
 				_, err := plg.CreatePayout(ctx, newPayoutRequest(payoutType))
 				Expect(err).To(BeNil())
 				Expect(capturedKey).To(Equal("pi-ref-123"))
+				// Reference is header-only (json:"-") and must never leak into the body.
+				Expect(capturedBody).ToNot(ContainSubstring("pi-ref-123"))
 			},
 			Entry("ACH", "ach", func(resp any) {
 				*(resp.(*client.ACHPayoutResponse)) = client.ACHPayoutResponse{
@@ -731,6 +759,19 @@ var _ = Describe("Column Plugin Payouts", func() {
 					ID: "test-id", InitiatedAt: "2021-01-01T00:00:00Z", CurrencyCode: "USD", Amount: 100, Status: "completed",
 				}
 			}),
+		)
+
+		DescribeTable("should reject a reference that cannot be used as a Column Idempotency-Key",
+			func(ctx SpecContext, reference string, expectedErr error) {
+				req := newPayoutRequest("ach")
+				req.PaymentInitiation.Reference = reference
+
+				_, err := plg.CreatePayout(ctx, req)
+				Expect(err).To(MatchError(ContainSubstring(expectedErr.Error())))
+			},
+			Entry("empty reference", "", ErrMissingReference),
+			Entry("reference exceeding 255 chars", strings.Repeat("a", 256), ErrReferenceTooLong),
+			Entry("reference with non-ASCII characters", "réf-123", ErrReferenceInvalidCharacters),
 		)
 	})
 

--- a/internal/connectors/plugins/public/column/plugin.go
+++ b/internal/connectors/plugins/public/column/plugin.go
@@ -37,6 +37,13 @@ var (
 	ErrMissingDestinationAccount          = errors.New("required field destinationAccount must be provided")
 	ErrMissingDestinationAccountReference = errors.New("required destinationAccount field reference must be provided")
 
+	// Reference is sent as Column's Idempotency-Key header (EN-1086); it must
+	// be present and satisfy Column's documented key constraints, otherwise the
+	// money movement would run without idempotency protection or be rejected.
+	ErrMissingReference           = errors.New("required field reference must be provided")
+	ErrReferenceTooLong           = fmt.Errorf("field reference must be at most %d characters", columnMaxIdempotencyKeyLength)
+	ErrReferenceInvalidCharacters = errors.New("field reference must contain only ASCII printable characters")
+
 	ErrMissingRelatedPaymentInitiationReference = fmt.Errorf("required field relatedPaymentInitiation.reference must be provided")
 
 	ErrMissingMetadata = errors.New("required field metadata must be provided")

--- a/internal/connectors/plugins/public/column/transfers.go
+++ b/internal/connectors/plugins/public/column/transfers.go
@@ -34,6 +34,7 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 			ReceiverBankAccountId: pi.DestinationAccount.Reference,
 			AllowOverdraft:        allowOverdraft == "true",
 			Hold:                  hold == "true",
+			Reference:             pi.Reference,
 			Details: client.TransferRequestDetails{
 				SenderName:           *pi.SourceAccount.Name,
 				MerchantName:         pi.Metadata[client.ColumnMerchantNameMetadataKey],

--- a/internal/connectors/plugins/public/column/transfers_test.go
+++ b/internal/connectors/plugins/public/column/transfers_test.go
@@ -1,8 +1,10 @@
 package column
 
 import (
+	"context"
 	"fmt"
 	"math/big"
+	"net/http"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/column/client"
@@ -533,6 +535,48 @@ var _ = Describe("Column Plugin Payments", func() {
 				Expect(res.Payment.Type).To(Equal(models.PAYMENT_TYPE_TRANSFER))
 				Expect(res.Payment.Asset).To(Equal("USD/2"))
 				Expect(res.PollingTransferID).To(BeNil())
+			})
+
+			// EN-1086: the book transfer must carry the payment initiation
+			// reference as the Idempotency-Key header so engine retries do not
+			// create a duplicate transfer at Column.
+			It("should send the payment initiation reference as the Idempotency-Key header", func(ctx SpecContext) {
+				req := models.CreateTransferRequest{
+					PaymentInitiation: models.PSPPaymentInitiation{
+						Reference: "pi-ref-123",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
+						Metadata: map[string]string{
+							client.ColumnAllowOverdraftMetadataKey: "true",
+							client.ColumnHoldMetadataKey:           "false",
+						},
+						SourceAccount: &models.PSPAccount{
+							Name:      pointer.For("Test Source"),
+							Reference: "src_ref",
+						},
+						DestinationAccount: &models.PSPAccount{
+							Reference: "dst_ref",
+						},
+					},
+				}
+
+				var capturedKey string
+				mockHTTPClient.EXPECT().Do(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).DoAndReturn(func(_ context.Context, r *http.Request, resp any, _ any) (int, error) {
+					capturedKey = r.Header.Get("Idempotency-Key")
+					*(resp.(*client.TransferResponse)) = client.TransferResponse{
+						ID: "test-transfer-id", CreatedAt: "2024-03-20T10:00:00Z", CurrencyCode: "USD", Amount: 100,
+					}
+					return 200, nil
+				})
+
+				_, err := plg.CreateTransfer(ctx, req)
+				Expect(err).To(BeNil())
+				Expect(capturedKey).To(Equal("pi-ref-123"))
 			})
 		})
 	})

--- a/internal/connectors/plugins/public/column/transfers_test.go
+++ b/internal/connectors/plugins/public/column/transfers_test.go
@@ -3,8 +3,10 @@ package column
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
+	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/column/client"
@@ -39,7 +41,8 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when amount is missing", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Asset: "USD/2",
+						Reference: "test-ref",
+						Asset:     "USD/2",
 					},
 				}
 
@@ -50,9 +53,10 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when source account reference is missing", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount:   big.NewInt(100),
-						Asset:    "USD",
-						Metadata: map[string]string{},
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
+						Metadata:  map[string]string{},
 						SourceAccount: &models.PSPAccount{
 							Name:     pointer.For("Test Source"),
 							Metadata: map[string]string{},
@@ -67,8 +71,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when address line 1 is provided but city is missing", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressLine1MetadataKey:            "123 Main St",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -91,7 +96,8 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when asset is missing", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
 					},
 				}
 
@@ -102,8 +108,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when metadata is nil", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 					},
 				}
 
@@ -114,9 +121,10 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when source account is nil", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount:   big.NewInt(100),
-						Asset:    "USD",
-						Metadata: map[string]string{},
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
+						Metadata:  map[string]string{},
 					},
 				}
 
@@ -127,6 +135,7 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when source account name is nil", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
+						Reference:     "test-ref",
 						Amount:        big.NewInt(100),
 						Asset:         "USD",
 						Metadata:      map[string]string{},
@@ -141,8 +150,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when destination account is nil", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						Metadata: map[string]string{
 							client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
 						},
@@ -160,8 +170,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when destination account reference is missing", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnSenderAccountNumberIdMetadataKey: "src_acc_num",
 						},
@@ -180,8 +191,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when allow overdraft is invalid", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "invalid",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -204,8 +216,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when hold is invalid", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnHoldMetadataKey:                    "invalid",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -228,8 +241,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when country code is missing with address line 1", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressLine1MetadataKey:            "123 Main St",
 							client.ColumnAddressCityMetadataKey:             "New York",
@@ -253,8 +267,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when city is provided without address line 1", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressCityMetadataKey:             "New York",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -277,8 +292,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when state is provided without address line 1", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressStateMetadataKey:            "NY",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -301,8 +317,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when postal code is provided without address line 1", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressPostalCodeMetadataKey:       "10001",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -325,8 +342,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return error when country code is provided without address line 1", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD",
 						Metadata: map[string]string{
 							client.ColumnAddressCountryCodeMetadataKey:      "US",
 							client.ColumnSenderAccountNumberIdMetadataKey:   "src_acc_num",
@@ -361,8 +379,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return an error when transfer request URL is invalid", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "true",
 							client.ColumnHoldMetadataKey:                    "false",
@@ -390,8 +409,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return an error when HTTP client Do fails", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "true",
 							client.ColumnHoldMetadataKey:                    "false",
@@ -427,8 +447,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return an error when asset currency is invalid", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "INVALID/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "INVALID/2",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "true",
 							client.ColumnHoldMetadataKey:                    "false",
@@ -454,8 +475,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should return an error when parsing invalid CreatedAt timestamp", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "true",
 							client.ColumnHoldMetadataKey:                    "false",
@@ -495,8 +517,9 @@ var _ = Describe("Column Plugin Payments", func() {
 			It("should successfully create a transfer", func(ctx SpecContext) {
 				req := models.CreateTransferRequest{
 					PaymentInitiation: models.PSPPaymentInitiation{
-						Amount: big.NewInt(100),
-						Asset:  "USD/2",
+						Reference: "test-ref",
+						Amount:    big.NewInt(100),
+						Asset:     "USD/2",
 						Metadata: map[string]string{
 							client.ColumnAllowOverdraftMetadataKey:          "true",
 							client.ColumnHoldMetadataKey:                    "false",
@@ -560,7 +583,7 @@ var _ = Describe("Column Plugin Payments", func() {
 					},
 				}
 
-				var capturedKey string
+				var capturedKey, capturedBody string
 				mockHTTPClient.EXPECT().Do(
 					gomock.Any(),
 					gomock.Any(),
@@ -568,6 +591,8 @@ var _ = Describe("Column Plugin Payments", func() {
 					gomock.Any(),
 				).DoAndReturn(func(_ context.Context, r *http.Request, resp any, _ any) (int, error) {
 					capturedKey = r.Header.Get("Idempotency-Key")
+					bodyBytes, _ := io.ReadAll(r.Body)
+					capturedBody = string(bodyBytes)
 					*(resp.(*client.TransferResponse)) = client.TransferResponse{
 						ID: "test-transfer-id", CreatedAt: "2024-03-20T10:00:00Z", CurrencyCode: "USD", Amount: 100,
 					}
@@ -577,7 +602,38 @@ var _ = Describe("Column Plugin Payments", func() {
 				_, err := plg.CreateTransfer(ctx, req)
 				Expect(err).To(BeNil())
 				Expect(capturedKey).To(Equal("pi-ref-123"))
+				// Reference is header-only (json:"-") and must never leak into the body.
+				Expect(capturedBody).ToNot(ContainSubstring("pi-ref-123"))
 			})
+
+			DescribeTable("should reject a reference that cannot be used as a Column Idempotency-Key",
+				func(ctx SpecContext, reference string, expectedErr error) {
+					req := models.CreateTransferRequest{
+						PaymentInitiation: models.PSPPaymentInitiation{
+							Reference: reference,
+							Amount:    big.NewInt(100),
+							Asset:     "USD/2",
+							Metadata: map[string]string{
+								client.ColumnAllowOverdraftMetadataKey: "true",
+								client.ColumnHoldMetadataKey:           "false",
+							},
+							SourceAccount: &models.PSPAccount{
+								Name:      pointer.For("Test Source"),
+								Reference: "src_ref",
+							},
+							DestinationAccount: &models.PSPAccount{
+								Reference: "dst_ref",
+							},
+						},
+					}
+
+					_, err := plg.CreateTransfer(ctx, req)
+					Expect(err).To(MatchError(ContainSubstring(expectedErr.Error())))
+				},
+				Entry("empty reference", "", ErrMissingReference),
+				Entry("reference exceeding 255 chars", strings.Repeat("a", 256), ErrReferenceTooLong),
+				Entry("reference with non-ASCII characters", "réf-123", ErrReferenceInvalidCharacters),
+			)
 		})
 	})
 })

--- a/internal/connectors/plugins/public/column/utils.go
+++ b/internal/connectors/plugins/public/column/utils.go
@@ -16,6 +16,34 @@ type ColumnAddress struct {
 	Country    string
 }
 
+// columnMaxIdempotencyKeyLength mirrors Column's documented Idempotency-Key
+// constraint (https://docs.column.com/working-with-the-api/idempotency): the
+// key must be at most 255 chars and ASCII printable (codes 32-126).
+const columnMaxIdempotencyKeyLength = 255
+
+// validateReference checks that the payment initiation reference can be used as
+// Column's Idempotency-Key header (EN-1086). Empty is not reachable through the
+// public API today, but is guarded as defense-in-depth; the length/charset
+// checks catch references the API accepts (no length cap on v2, up to 1000 on
+// v3, no charset restriction) but Column would reject with a 4xx.
+func validateReference(reference string) error {
+	if reference == "" {
+		return models.NewConnectorValidationError("reference", ErrMissingReference)
+	}
+
+	if len(reference) > columnMaxIdempotencyKeyLength {
+		return models.NewConnectorValidationError("reference", ErrReferenceTooLong)
+	}
+
+	for _, r := range reference {
+		if r < 32 || r > 126 {
+			return models.NewConnectorValidationError("reference", ErrReferenceInvalidCharacters)
+		}
+	}
+
+	return nil
+}
+
 func (p *Plugin) validateTransferRequest(pi models.PSPPaymentInitiation) error {
 
 	if pi.Amount == nil {
@@ -65,6 +93,10 @@ func (p *Plugin) validateTransferRequest(pi models.PSPPaymentInitiation) error {
 		}
 	}
 
+	if err := validateReference(pi.Reference); err != nil {
+		return err
+	}
+
 	countryCode := models.ExtractNamespacedMetadata(pi.Metadata, client.ColumnAddressCountryCodeMetadataKey)
 	address := extractAddressFromMetadata(pi.Metadata, countryCode)
 
@@ -109,6 +141,10 @@ func (p *Plugin) validatePayoutRequests(pi models.PSPPaymentInitiation) error {
 
 	if pi.Asset == "" {
 		return models.NewConnectorValidationError("asset", ErrMissingAsset)
+	}
+
+	if err := validateReference(pi.Reference); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## What

Column was the only money-moving connector not sending an idempotency key on create-payout / create-transfer. Under the engine's `infiniteRetryContext` (unlimited retries, 60s StartToClose — `workflow/context.go`, `create_payout.go:106`), a lost response or a >60s PSP call triggers a Temporal retry that creates a **duplicate money movement** at Column. This is audit finding **H11** ([EN-1086](https://formance-team.atlassian.net/browse/EN-1086)).

## Change

Send the payment initiation reference (`pi.Reference`) as Column's `Idempotency-Key` HTTP header on all five money-movement calls:

- `transfers/ach`, `transfers/wire`, `transfers/international-wire`, `transfers/realtime` (payout rails)
- `transfers/book` (transfer)

This matches the `pi.Reference` pattern every other connector already uses. The key is carried on the request struct as `json:"-"` so it is header-only and never leaks into the request body.

## Why this is correct

Per [Column's idempotency docs](https://docs.column.com/working-with-the-api/idempotency/):

> "Provide an additional `Idempotency-Key: <key>` header to the request for the endpoint that supports it."

> "Results of successful requests with `Idempotency-Key` will be saved and returned on every subsequent request with the same `Idempotency-Key`"

Supported endpoints explicitly include "ACH, wire, book, check, and international wire transfers" — covering every call changed here. Same-key reuse returns the original result, which is exactly the dedup behavior needed on retry.

**Caveat:** Column requires keys to be ≤255 chars, case-sensitive, ASCII-printable (32–126), and reserves the right to expire them after 30 days. `pi.Reference` satisfies this and is the same value used across other connectors.

## Tests

- `payouts_test.go`: `DescribeTable` asserting the captured `Idempotency-Key` header equals `pi.Reference` for all four payout rails.
- `transfers_test.go`: spec asserting the header on the book transfer.
- Full Column suite green (162 passed), `just lint` clean.

## Out of scope (separate EN-1086 follow-ups)

1. Promoting the idempotency key to a first-class field on the `CreatePayout/TransferRequest` plugin contract so new connectors can't silently omit it.
2. Capping `MaximumAttempts` on the creation activities + reconcile-by-polling as defense-in-depth.

[EN-1086]: https://formance-team.atlassian.net/browse/EN-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ