### PR TITLE
fix(wise): EN-1087 stop trimming over-fetched payments to prevent loss

### DIFF
--- a/internal/connectors/plugins/public/wise/payments.go
+++ b/internal/connectors/plugins/public/wise/payments.go
@@ -64,12 +64,15 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	if !needMore {
-		payments = payments[:req.PageSize]
-		paymentIDs = paymentIDs[:req.PageSize]
-
-		// Wise is very annoying with that point, the offset must be a multiple
-		// of the pageSize, otherwise, we will have an error inconsistent
-		// pagination.
+		// We intentionally do NOT trim down to req.PageSize. Wise requires the
+		// offset to be a multiple of pageSize (it returns an "inconsistent
+		// pagination" error otherwise), so we can only ever resume on a page
+		// boundary, never mid-page. Trimming would discard transfers we already
+		// fetched while the offset advances past them, losing them permanently
+		// (EN-1087): trimmed transfers sit below the new offset but have IDs
+		// above LastTransferID, so the next call never re-reads them. Instead we
+		// keep the whole over-fetched batch (up to ~2x pageSize) and only
+		// advance past pages we fully consumed, as the mangopay connector does.
 		newState.Offset += req.PageSize
 	}
 

--- a/internal/connectors/plugins/public/wise/payments.go
+++ b/internal/connectors/plugins/public/wise/payments.go
@@ -44,6 +44,11 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	var paymentIDs []uint64
 	needMore := false
 	hasMore := false
+	// lastPageFull tracks whether the most recently fetched Wise page was full.
+	// It is the real "is there more to fetch" signal: ShouldFetchMore hardcodes
+	// hasMore=true for any over-fetch (it assumes the caller trims), but since we
+	// no longer trim, a short final page means we have reached the end.
+	lastPageFull := false
 	for {
 		pagedTransfers, err := p.client.GetTransfers(ctx, from.ID, newState.Offset, req.PageSize)
 		if err != nil {
@@ -55,6 +60,8 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 
+		lastPageFull = len(pagedTransfers) >= req.PageSize
+
 		needMore, hasMore = pagination.ShouldFetchMore(payments, pagedTransfers, req.PageSize)
 		if !needMore || !hasMore {
 			break
@@ -63,16 +70,20 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		newState.Offset += req.PageSize
 	}
 
-	if !needMore {
-		// We intentionally do NOT trim down to req.PageSize. Wise requires the
-		// offset to be a multiple of pageSize (it returns an "inconsistent
-		// pagination" error otherwise), so we can only ever resume on a page
-		// boundary, never mid-page. Trimming would discard transfers we already
-		// fetched while the offset advances past them, losing them permanently
-		// (EN-1087): trimmed transfers sit below the new offset but have IDs
-		// above LastTransferID, so the next call never re-reads them. Instead we
-		// keep the whole over-fetched batch (up to ~2x pageSize) and only
-		// advance past pages we fully consumed, as the mangopay connector does.
+	// We intentionally do NOT trim down to req.PageSize. Wise requires the offset
+	// to be a multiple of pageSize (it returns an "inconsistent pagination" error
+	// otherwise), so we can only ever resume on a page boundary, never mid-page.
+	// Trimming would discard transfers we already fetched while the offset
+	// advances past them, losing them permanently (EN-1087): trimmed transfers
+	// sit below the new offset but have IDs above LastTransferID, so the next
+	// call never re-reads them. Instead we keep the whole over-fetched batch (up
+	// to ~2x pageSize), like the mangopay connector.
+	//
+	// The offset may only move past the last page when that page was full. On a
+	// short final page we have reached the end, so we leave the offset on that
+	// page: advancing would push it beyond the data and silently skip transfers
+	// that later fill the gap before it.
+	if !needMore && lastPageFull {
 		newState.Offset += req.PageSize
 	}
 
@@ -88,7 +99,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	return models.FetchNextPaymentsResponse{
 		Payments: payments,
 		NewState: payload,
-		HasMore:  hasMore,
+		HasMore:  lastPageFull,
 	}, nil
 }
 

--- a/internal/connectors/plugins/public/wise/payments_test.go
+++ b/internal/connectors/plugins/public/wise/payments_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/wise/client"
 	"github.com/formancehq/payments/internal/models"
 	"go.uber.org/mock/gomock"
@@ -24,7 +25,7 @@ var _ = Describe("Wise Plugin Payments", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg = &Plugin{client: m}
+		plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 	})
 
 	AfterEach(func() {
@@ -191,6 +192,71 @@ var _ = Describe("Wise Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			Expect(state.Offset).To(Equal(40))
 			Expect(state.LastTransferID).To(Equal(uint64(49)))
+		})
+
+		It("should not lose payments when a short page is followed by a full one (EN-1087)", func(ctx SpecContext) {
+			// Page 1 emits fewer than pageSize payments because one transfer has
+			// an unsupported currency and is skipped. Page 2 is full, pushing the
+			// accumulated total above pageSize. The previously buggy trim dropped
+			// the overflow transfers while advancing the offset past them, losing
+			// them permanently.
+			req := models.FetchNextPaymentsRequest{
+				PageSize:    3,
+				FromPayload: []byte(`{"id": 0}`),
+			}
+
+			makeTransfer := func(id uint64, cur string) client.Transfer {
+				return client.Transfer{
+					ID:             id,
+					Reference:      fmt.Sprintf("test%d", id),
+					Status:         "outgoing_payment_sent",
+					SourceAccount:  1,
+					SourceCurrency: "USD",
+					SourceValue:    "100",
+					TargetAccount:  2,
+					TargetCurrency: cur,
+					TargetValue:    "100",
+					User:           1,
+					CreatedAt:      now,
+				}
+			}
+
+			// ID 101 is HUF, which is unsupported and therefore skipped.
+			m.EXPECT().GetTransfers(gomock.Any(), uint64(0), 0, 3).Return(
+				[]client.Transfer{
+					makeTransfer(100, "USD"),
+					makeTransfer(101, "HUF"),
+					makeTransfer(102, "USD"),
+				},
+				nil,
+			)
+			m.EXPECT().GetTransfers(gomock.Any(), uint64(0), 3, 3).Return(
+				[]client.Transfer{
+					makeTransfer(103, "USD"),
+					makeTransfer(104, "USD"),
+					makeTransfer(105, "USD"),
+				},
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+
+			// All five supported transfers must be emitted; none trimmed away.
+			refs := make([]string, 0, len(resp.Payments))
+			for _, p := range resp.Payments {
+				refs = append(refs, p.Reference)
+			}
+			Expect(refs).To(ConsistOf("100", "102", "103", "104", "105"))
+			Expect(resp.HasMore).To(BeTrue())
+
+			var state paymentsState
+			err = json.Unmarshal(resp.NewState, &state)
+			Expect(err).To(BeNil())
+			// Offset advanced one page per page consumed (two pages of 3).
+			Expect(state.Offset).To(Equal(6))
+			// LastTransferID is the last emitted, covering the overflow page.
+			Expect(state.LastTransferID).To(Equal(uint64(105)))
 		})
 	})
 })

--- a/internal/connectors/plugins/public/wise/payments_test.go
+++ b/internal/connectors/plugins/public/wise/payments_test.go
@@ -258,5 +258,72 @@ var _ = Describe("Wise Plugin Payments", func() {
 			// LastTransferID is the last emitted, covering the overflow page.
 			Expect(state.LastTransferID).To(Equal(uint64(105)))
 		})
+
+		It("should keep the offset and stop when an over-fetch ends on a short final page (EN-1087)", func(ctx SpecContext) {
+			// A full first page with a skipped (unsupported) transfer emits fewer
+			// than pageSize payments; the next page is the last one and is short.
+			// The accumulated total still exceeds pageSize, so ShouldFetchMore
+			// reports hasMore=true via its over-fetch branch. We must not advance
+			// the offset past the short final page nor report HasMore: otherwise
+			// the stored offset lands beyond the data and skips transfers that
+			// later fill the gap.
+			req := models.FetchNextPaymentsRequest{
+				PageSize:    3,
+				FromPayload: []byte(`{"id": 0}`),
+			}
+
+			makeTransfer := func(id uint64, cur string) client.Transfer {
+				return client.Transfer{
+					ID:             id,
+					Reference:      fmt.Sprintf("test%d", id),
+					Status:         "outgoing_payment_sent",
+					SourceAccount:  1,
+					SourceCurrency: "USD",
+					SourceValue:    "100",
+					TargetAccount:  2,
+					TargetCurrency: cur,
+					TargetValue:    "100",
+					User:           1,
+					CreatedAt:      now,
+				}
+			}
+
+			// Full first page (ID 201 is HUF and skipped) -> emits 200, 202.
+			m.EXPECT().GetTransfers(gomock.Any(), uint64(0), 0, 3).Return(
+				[]client.Transfer{
+					makeTransfer(200, "USD"),
+					makeTransfer(201, "HUF"),
+					makeTransfer(202, "USD"),
+				},
+				nil,
+			)
+			// Short final page (2 < pageSize) -> emits 203, 204; total now 4 > 3.
+			m.EXPECT().GetTransfers(gomock.Any(), uint64(0), 3, 3).Return(
+				[]client.Transfer{
+					makeTransfer(203, "USD"),
+					makeTransfer(204, "USD"),
+				},
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+
+			refs := make([]string, 0, len(resp.Payments))
+			for _, p := range resp.Payments {
+				refs = append(refs, p.Reference)
+			}
+			Expect(refs).To(ConsistOf("200", "202", "203", "204"))
+			// Short final page => end of data reached.
+			Expect(resp.HasMore).To(BeFalse())
+
+			var state paymentsState
+			err = json.Unmarshal(resp.NewState, &state)
+			Expect(err).To(BeNil())
+			// Offset stays on the short final page (start = 3); it must NOT jump
+			// to 6 and skip transfers that later land at offsets 4..5.
+			Expect(state.Offset).To(Equal(3))
+			Expect(state.LastTransferID).To(Equal(uint64(204)))
+		})
 	})
 })


### PR DESCRIPTION
Wise requires the pagination offset to be a multiple of pageSize, so we can only resume on a page boundary, never mid-page. Trimming the accumulated batch back to pageSize discarded already-fetched transfers while the offset advanced past them: trimmed transfers sat below the new offset but had IDs above LastTransferID, so the next call never re-read them, silently and permanently losing payments. Keep the whole over-fetched batch instead (up to ~2x pageSize), as the mangopay connector does.

Constraint: Wise rejects a non-page-aligned offset (verified: offset=1,limit=3 -> inconsistent.pagination)
Rejected: Rewind offset to the last-kept element | offset must stay a multiple of pageSize
Rejected: Trim but track each payment's page to re-read it | more state, leans on ID dedup, no benefit as engine tolerates variable batch sizes
Confidence: high
Scope-risk: narrow
Directive: Do not re-introduce trimming here — the page-aligned-offset constraint makes it lossy
Not-tested: storage/e2e suites (Docker unavailable locally; covered by CI)