### PR TITLE
fix(workflow): EN-1093 Temporal non-determinism (uuid.New in workflow body + in-process polling period)

### DIFF
--- a/internal/connectors/engine/activities/activity.go
+++ b/internal/connectors/engine/activities/activity.go
@@ -237,6 +237,10 @@ func (a Activities) DefinitionSet() temporalworker.DefinitionSet {
 			Func: a.StorageConnectorsScheduleForDeletion,
 		}).
 		Append(temporalworker.Definition{
+			Name: "StorageConnectorsGetPollingPeriod",
+			Func: a.StorageConnectorsGetPollingPeriod,
+		}).
+		Append(temporalworker.Definition{
 			Name: "StorageSchedulesGet",
 			Func: a.StorageSchedulesGet,
 		}).

--- a/internal/connectors/engine/activities/storage_connectors_polling_period.go
+++ b/internal/connectors/engine/activities/storage_connectors_polling_period.go
@@ -1,0 +1,47 @@
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/formancehq/payments/internal/models"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+// StorageConnectorsGetPollingPeriod returns only the connector's polling period — a
+// non-secret value read deterministically (recorded in workflow history) so that schedule
+// creation does not depend on mutable in-process manager state, and so a polling-period
+// change on replay cannot make the workflow non-deterministic (EN-1093 / H12). It MUST
+// never return the connector config or any secret: prod Temporal payload encryption is OFF,
+// so activity results are stored in clear in workflow history.
+func (a Activities) StorageConnectorsGetPollingPeriod(ctx context.Context, connectorID models.ConnectorID) (time.Duration, error) {
+	connector, err := a.storage.ConnectorsGet(ctx, connectorID)
+	if err != nil {
+		return 0, temporalStorageError(err)
+	}
+
+	// Parse onto the configurer's default config (exactly like manager.Load / GetConfig) so
+	// an absent pollingPeriod resolves to the default rather than zero — otherwise migrated
+	// configs (which may omit it) would yield a zero-interval schedule.
+	cfg := a.connectors.DefaultConfig()
+	if len(connector.Config) > 0 {
+		if err := json.Unmarshal(connector.Config, &cfg); err != nil {
+			// Corrupt config will not self-heal; fail fast instead of retrying forever.
+			return 0, temporal.NewNonRetryableApplicationError("invalid connector config", ErrTypeInvalidArgument, err)
+		}
+	}
+
+	return cfg.PollingPeriod, nil
+}
+
+var StorageConnectorsGetPollingPeriodActivity = Activities{}.StorageConnectorsGetPollingPeriod
+
+func StorageConnectorsGetPollingPeriod(ctx workflow.Context, connectorID models.ConnectorID) (time.Duration, error) {
+	var pollingPeriod time.Duration
+	if err := executeActivity(ctx, StorageConnectorsGetPollingPeriodActivity, &pollingPeriod, connectorID); err != nil {
+		return 0, err
+	}
+	return pollingPeriod, nil
+}

--- a/internal/connectors/engine/activities/storage_connectors_polling_period_test.go
+++ b/internal/connectors/engine/activities/storage_connectors_polling_period_test.go
@@ -1,0 +1,99 @@
+package activities_test
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/payments/internal/connectors"
+	"github.com/formancehq/payments/internal/connectors/engine/activities"
+	"github.com/formancehq/payments/internal/events"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/internal/storage"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.temporal.io/sdk/temporal"
+	gomock "go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Activity StorageConnectorsGetPollingPeriod", func() {
+	var (
+		act       activities.Activities
+		p         *connectors.MockManager
+		s         *storage.MockStorage
+		evts      *events.Events
+		publisher *TestPublisher
+		logger    = logging.NewDefaultLogger(GinkgoWriter, true, false, false)
+
+		connectorID models.ConnectorID
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		p = connectors.NewMockManager(ctrl)
+		s = storage.NewMockStorage(ctrl)
+		publisher = newTestPublisher()
+		evts = events.New(publisher, "")
+
+		act = activities.New(logger, nil, s, evts, p, 0, 0)
+
+		connectorID = models.ConnectorID{Provider: "test", Reference: uuid.New()}
+	})
+
+	AfterEach(func() {
+		publisher.Close()
+	})
+
+	It("returns error when storage.ConnectorsGet fails", func(ctx SpecContext) {
+		s.EXPECT().ConnectorsGet(gomock.Any(), connectorID).Return(nil, errors.New("boom"))
+
+		_, err := act.StorageConnectorsGetPollingPeriod(ctx, connectorID)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("boom"))
+	})
+
+	It("returns the polling period from the config (and never the secret config)", func(ctx SpecContext) {
+		connector := &models.Connector{
+			ConnectorBase: models.ConnectorBase{ID: connectorID, Provider: "test"},
+			Config:        json.RawMessage(`{"name":"test","pollingPeriod":"2m","apiKey":"super-secret"}`),
+		}
+		s.EXPECT().ConnectorsGet(gomock.Any(), connectorID).Return(connector, nil)
+		p.EXPECT().DefaultConfig().Return(models.Config{PollingPeriod: time.Minute})
+
+		got, err := act.StorageConnectorsGetPollingPeriod(ctx, connectorID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(2 * time.Minute))
+	})
+
+	It("falls back to the default polling period when the config omits it", func(ctx SpecContext) {
+		connector := &models.Connector{
+			ConnectorBase: models.ConnectorBase{ID: connectorID, Provider: "test"},
+			Config:        json.RawMessage(`{"name":"test"}`),
+		}
+		s.EXPECT().ConnectorsGet(gomock.Any(), connectorID).Return(connector, nil)
+		p.EXPECT().DefaultConfig().Return(models.Config{PollingPeriod: 90 * time.Second})
+
+		got, err := act.StorageConnectorsGetPollingPeriod(ctx, connectorID)
+		Expect(err).NotTo(HaveOccurred())
+		// EN-1093/H12: an absent pollingPeriod must resolve to the configurer default,
+		// not zero — otherwise a zero-interval schedule would be created.
+		Expect(got).To(Equal(90 * time.Second))
+	})
+
+	It("returns a non-retryable error on a corrupt config", func(ctx SpecContext) {
+		connector := &models.Connector{
+			ConnectorBase: models.ConnectorBase{ID: connectorID, Provider: "test"},
+			Config:        json.RawMessage(`{not-json`),
+		}
+		s.EXPECT().ConnectorsGet(gomock.Any(), connectorID).Return(connector, nil)
+		p.EXPECT().DefaultConfig().Return(models.Config{PollingPeriod: time.Minute})
+
+		_, err := act.StorageConnectorsGetPollingPeriod(ctx, connectorID)
+		Expect(err).To(HaveOccurred())
+		var appErr *temporal.ApplicationError
+		Expect(errors.As(err, &appErr)).To(BeTrue())
+		Expect(appErr.NonRetryable()).To(BeTrue())
+	})
+})

--- a/internal/connectors/engine/workflow/connector_state.go
+++ b/internal/connectors/engine/workflow/connector_state.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/formancehq/payments/internal/connectors/engine/activities"
+	"github.com/formancehq/payments/internal/models"
+	"go.temporal.io/sdk/workflow"
+)
+
+// connectorPollingPeriod returns the connector's polling period.
+//
+// For new workflow executions it reads the value deterministically via a storage-backed
+// activity, so the polling period that flows into TemporalScheduleCreate is recorded in
+// history. This avoids a non-determinism panic if the connector's polling period is changed
+// (via UpdateConnector, which does not terminate running workflows) while a workflow that
+// already scheduled is later replayed (EN-1093 / H12).
+//
+// The legacy (DefaultVersion) branch reads the in-process connectors manager and is retained
+// for in-flight workflows until the next major version. It cannot be exercised via Temporal's
+// TestWorkflowEnvironment (which always reports the newest GetVersion), so only the activity
+// branch is unit-tested.
+func (w Workflow) connectorPollingPeriod(ctx workflow.Context, connectorID models.ConnectorID) (time.Duration, error) {
+	if IsDeterministicPollingPeriodEnabled(ctx) {
+		pollingPeriod, err := activities.StorageConnectorsGetPollingPeriod(infiniteRetryContext(ctx), connectorID)
+		if err != nil {
+			return 0, fmt.Errorf("getting connector polling period: %w", err)
+		}
+		return pollingPeriod, nil
+	}
+
+	config, err := w.connectors.GetConfig(connectorID)
+	if err != nil {
+		return 0, err
+	}
+	return config.PollingPeriod, nil
+}

--- a/internal/connectors/engine/workflow/create_payout.go
+++ b/internal/connectors/engine/workflow/create_payout.go
@@ -140,7 +140,7 @@ func (w Workflow) createPayout(
 		}
 
 		if createPayoutResponse.PollingPayoutID != nil {
-			config, err := w.connectors.GetConfig(createPayout.ConnectorID)
+			pollingPeriod, err := w.connectorPollingPeriod(ctx, createPayout.ConnectorID)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ func (w Workflow) createPayout(
 				activities.ScheduleCreateOptions{
 					ScheduleID: scheduleID,
 					Interval: &client.ScheduleIntervalSpec{
-						Every: config.PollingPeriod,
+						Every: pollingPeriod,
 					},
 					Action: client.ScheduleWorkflowAction{
 						Workflow: RunPollPayout,

--- a/internal/connectors/engine/workflow/create_transfer.go
+++ b/internal/connectors/engine/workflow/create_transfer.go
@@ -142,7 +142,7 @@ func (w Workflow) createTransfer(
 
 		if createTransferResponse.PollingTransferID != nil {
 			// payment not yet available, waiting for the next polling
-			config, err := w.connectors.GetConfig(createTransfer.ConnectorID)
+			pollingPeriod, err := w.connectorPollingPeriod(ctx, createTransfer.ConnectorID)
 			if err != nil {
 				return err
 			}
@@ -165,7 +165,7 @@ func (w Workflow) createTransfer(
 				activities.ScheduleCreateOptions{
 					ScheduleID: scheduleID,
 					Interval: &client.ScheduleIntervalSpec{
-						Every: config.PollingPeriod,
+						Every: pollingPeriod,
 					},
 					Action: client.ScheduleWorkflowAction{
 						Workflow: RunPollTransfer,

--- a/internal/connectors/engine/workflow/main_test.go
+++ b/internal/connectors/engine/workflow/main_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	temporallog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/testsuite"
@@ -65,10 +66,26 @@ func (s *UnitTestSuite) SetupTest() {
 	}
 
 	s.addData()
+
+	// EN-1093/H12: scheduleNextWorkflow now reads the polling period via a deterministic
+	// activity (the test env always takes the activity branch). Register it globally so any
+	// test that schedules is covered; .Maybe() leaves non-scheduling tests unaffected.
+	s.mockPollingPeriod(2 * time.Minute)
 }
 
 func (s *UnitTestSuite) AfterTest(suiteName, testName string) {
 	s.env.AssertExpectations(s.T())
+}
+
+// mockPollingPeriod registers the deterministic StorageConnectorsGetPollingPeriod activity
+// (EN-1093/H12). Temporal's TestWorkflowEnvironment always reports the newest GetVersion, so
+// scheduleNextWorkflow / create_payout / create_transfer always take the activity branch in
+// tests. Registered with .Maybe() since not every test reaches the polling-period read.
+func (s *UnitTestSuite) mockPollingPeriod(pollingPeriod time.Duration) {
+	s.env.OnActivity(activities.StorageConnectorsGetPollingPeriodActivity, mock.Anything, mock.Anything).Maybe().Return(
+		pollingPeriod,
+		nil,
+	)
 }
 
 func TestUnitTestSuite(t *testing.T) {

--- a/internal/connectors/engine/workflow/plugin_workflow.go
+++ b/internal/connectors/engine/workflow/plugin_workflow.go
@@ -185,7 +185,7 @@ func (w Workflow) scheduleNextWorkflow(
 		return err
 	}
 
-	config, err := w.connectors.GetConfig(connectorID)
+	pollingPeriod, err := w.connectorPollingPeriod(ctx, connectorID)
 	if err != nil {
 		return err
 	}
@@ -194,9 +194,9 @@ func (w Workflow) scheduleNextWorkflow(
 		infiniteRetryContext(ctx),
 		activities.ScheduleCreateOptions{
 			ScheduleID: scheduleID,
-			Jitter:     calculateJitter(config.PollingPeriod),
+			Jitter:     calculateJitter(pollingPeriod),
 			Interval: &client.ScheduleIntervalSpec{
-				Every: config.PollingPeriod,
+				Every: pollingPeriod,
 			},
 			Action: client.ScheduleWorkflowAction{
 				// Use the same ID as the schedule ID, so we can identify the workflows running.

--- a/internal/connectors/engine/workflow/plugin_workflow_test.go
+++ b/internal/connectors/engine/workflow/plugin_workflow_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/models"
@@ -10,6 +11,33 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
+
+// Test_Run_Periodically_UsesActivityPollingPeriod asserts scheduleNextWorkflow uses the
+// polling period returned by the deterministic activity (EN-1093/H12) for both the schedule
+// interval and the jitter. The global mock (SetupTest) returns 2m.
+func (s *UnitTestSuite) Test_Run_Periodically_UsesActivityPollingPeriod() {
+	pollingPeriod := 2 * time.Minute
+	s.env.OnActivity(activities.StorageSchedulesStoreActivity, mock.Anything, mock.Anything).Once().Return(nil)
+	s.env.OnActivity(activities.TemporalScheduleCreateActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, req activities.ScheduleCreateOptions) error {
+		s.Equal(RunFetchNextAccounts, req.Action.Workflow)
+		s.NotNil(req.Interval)
+		s.Equal(pollingPeriod, req.Interval.Every)
+		s.Equal(calculateJitter(pollingPeriod), req.Jitter)
+		return nil
+	})
+
+	s.env.ExecuteWorkflow(
+		RunNextTasksV3_1,
+		s.connectorID,
+		&FromPayload{ID: "1", Payload: []byte(`{}`)},
+		[]models.ConnectorTaskTree{
+			{TaskType: models.TASK_FETCH_ACCOUNTS, Name: "test", Periodically: true, NextTasks: []models.ConnectorTaskTree{}},
+		},
+	)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
 
 func (s *UnitTestSuite) Test_Run_Periodically_FetchAccounts_Success() {
 	s.env.OnActivity(activities.StorageSchedulesStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, schedule models.Schedule) error {

--- a/internal/connectors/engine/workflow/reset_connector.go
+++ b/internal/connectors/engine/workflow/reset_connector.go
@@ -83,10 +83,23 @@ func (w Workflow) resetConnector(
 	// We need to change the connector ID to a new one, otherwise, we will
 	// have some conflicts with temporal and previous workflows related to the
 	// previous connector ID.
+	//
+	// The reference must be generated through workflow.SideEffect: calling
+	// uuid.New() directly in the workflow body is non-deterministic, so on replay
+	// a different UUID would be produced and the install child WorkflowID below
+	// (install-{stack}-{newConnector.ID}) would no longer match history, failing
+	// the workflow task in a loop and leaving the reset stuck (EN-1093 / H10).
+	var newReference uuid.UUID
+	if err := workflow.SideEffect(ctx, func(workflow.Context) interface{} {
+		return uuid.New()
+	}).Get(&newReference); err != nil {
+		return nil, fmt.Errorf("generating new connector reference: %w", err)
+	}
+
 	newConnector := models.Connector{
 		ConnectorBase: models.ConnectorBase{
 			ID: models.ConnectorID{
-				Reference: uuid.New(),
+				Reference: newReference,
 				Provider:  connector.Provider,
 			},
 			Name:      connector.Name,

--- a/internal/connectors/engine/workflow/versions.go
+++ b/internal/connectors/engine/workflow/versions.go
@@ -7,6 +7,7 @@ const (
 	versionFlagRunNextTaskAsActivity             = "run_next_task_as_activity"
 	versionFlagPaymentInitiationUpdateAsActivity = "storage_payment_initiation_update_as_activity"
 	versionFlagConnectorIDSearchAttributeEnabled = "connector_id_search_attribute_enabled"
+	versionFlagDeterministicPollingPeriod        = "deterministic_polling_period"
 )
 
 func IsEventOutboxPatternEnabled(ctx workflow.Context) bool {
@@ -26,5 +27,10 @@ func IsPaymentInitiationUpdateOptimizationsEnabled(ctx workflow.Context) bool {
 
 func IsConnectorIDSearchAttributeEnabled(ctx workflow.Context) bool {
 	version := workflow.GetVersion(ctx, versionFlagConnectorIDSearchAttributeEnabled, workflow.DefaultVersion, 1)
+	return version > workflow.DefaultVersion
+}
+
+func IsDeterministicPollingPeriodEnabled(ctx workflow.Context) bool {
+	version := workflow.GetVersion(ctx, versionFlagDeterministicPollingPeriod, workflow.DefaultVersion, 1)
 	return version > workflow.DefaultVersion
 }

--- a/internal/connectors/manager.go
+++ b/internal/connectors/manager.go
@@ -28,6 +28,10 @@ type Manager interface {
 	Unload(models.ConnectorID)
 	GetConfig(models.ConnectorID) (models.Config, error)
 	Get(models.ConnectorID) (models.Plugin, error)
+	// DefaultConfig returns the configurer's default connector config. It carries
+	// no per-connector state (no lookup, never ErrNotFound) and is used to apply
+	// the same defaults the manager applies when parsing a stored config.
+	DefaultConfig() models.Config
 }
 
 // Will start, hold, manage and stop Connectors
@@ -163,6 +167,10 @@ func (m *manager) Get(connectorID models.ConnectorID) (models.Plugin, error) {
 	}
 
 	return c.plugin, nil
+}
+
+func (m *manager) DefaultConfig() models.Config {
+	return m.configurer.DefaultConfig()
 }
 
 func (m *manager) GetConfig(connectorID models.ConnectorID) (models.Config, error) {

--- a/internal/connectors/manager_generated.go
+++ b/internal/connectors/manager_generated.go
@@ -41,6 +41,20 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// DefaultConfig mocks base method.
+func (m *MockManager) DefaultConfig() models.Config {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultConfig")
+	ret0, _ := ret[0].(models.Config)
+	return ret0
+}
+
+// DefaultConfig indicates an expected call of DefaultConfig.
+func (mr *MockManagerMockRecorder) DefaultConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultConfig", reflect.TypeOf((*MockManager)(nil).DefaultConfig))
+}
+
 // Get mocks base method.
 func (m *MockManager) Get(arg0 models.ConnectorID) (models.Plugin, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes the two critical findings of [EN-1093](https://formance-team.atlassian.net/browse/EN-1093) — Temporal workflow non-determinism.

## H10 — `uuid.New()` in the workflow body (`resetConnector`)
`resetConnector` built the new connector with `Reference: uuid.New()` directly in the workflow body. Since the workflow awaits a potentially long uninstall child, a replay generated a *different* UUID → the install child WorkflowID `install-{stack}-{newConnector.ID}` no longer matched history → non-deterministic workflow task failing in a loop, leaving the reset stuck.

**Fix:** generate the reference via `workflow.SideEffect`, which records the value in history and returns the same UUID on replay.

## H12 — workflow reads of mutable in-process `connectors.Manager` state
H12 spans two reads. Investigation showed they are **not** equivalent:

- **`IsScheduledForDeletion` flag** — left as the original live in-process per-page read. Its only non-deterministic transition is `false→true` on schedule-for-deletion (uninstall/reset), and `RunTerminateWorkflows` reaps exactly those workflows, so the divergence is self-cleaning. No change warranted.
- **`PollingPeriod`** — read via `w.connectors.GetConfig()` in `scheduleNextWorkflow`/`create_payout`/`create_transfer` and fed into the recorded `TemporalScheduleCreate` activity args. A polling-period change via `UpdateConnector` (which does **not** terminate running workflows) could make an already-scheduled workflow diverge on replay → permanently stuck. This is the genuinely non-self-healing case.

**Fix:** read the polling period through a new `StorageConnectorsGetPollingPeriod` activity (DB-backed, recorded in history), gated by `workflow.GetVersion` (one shared flag in `versions.go`, matching the established pattern). In-flight workflows keep the legacy in-process read until they drain. The activity parses onto the configurer `DefaultConfig` (absent `pollingPeriod` → default, never a zero-interval schedule) and returns **only** the duration — prod Temporal payload encryption is OFF, so activity results must not carry connector config/secrets.

## Out of scope / follow-ups
- The legacy `DefaultVersion` branch removal is tied to the next major Payments version (no visibility into customer versions).
- Orphan schedules/workflows from a fetch racing an uninstall (PG-notify-delay window) are pre-existing; best addressed by teardown hardening separately.
- The remaining `w.connectors` lifecycle uses in `install_connector`/`uninstall_connector` (scope C) are deferred.

## Testing
- New activity unit tests: default-fallback, corrupt-config → non-retryable, secret-safety.
- `Test_Run_Periodically_UsesActivityPollingPeriod` asserts the schedule interval + jitter come from the activity; global mock in `SetupTest` covers all scheduling tests.
- `just lint` clean; `go test ./internal/connectors/...` green.

[EN-1093]: https://formance-team.atlassian.net/browse/EN-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ