### PR TITLE
fix(EN-1090):  drain and close response body on all return paths

### DIFF
--- a/internal/connectors/httpwrapper/client.go
+++ b/internal/connectors/httpwrapper/client.go
@@ -108,18 +108,24 @@ func (c *client) Do(ctx context.Context, req *http.Request, expectedBody, errorB
 		return 0, fmt.Errorf("failed to make request: %w", err)
 	}
 
-	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
-	// the caller doesn't care about the response body so we return early
-	if resp.Body == nil || (reqErr == nil && expectedBody == nil) || (reqErr != nil && errorBody == nil) {
-		return resp.StatusCode, reqErr
-	}
-
+	// Always drain and close the body, regardless of the return path below.
+	// Draining lets the underlying connection be reused (keep-alive); closing
+	// without draining (or not closing at all on early returns) leaks file
+	// descriptors and connections in a long-running worker.
+	// net/http guarantees resp.Body is non-nil on a successful Do, so there is
+	// no nil check to perform here.
 	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			logging.FromContext(ctx).Errorf("failed to close response body: %w", err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logging.FromContext(ctx).Errorf("failed to close response body: %v", closeErr)
 		}
 	}()
+
+	reqErr := c.httpErrorCheckerFn(resp.StatusCode)
+	// the caller doesn't care about the response body so we return early
+	if (reqErr == nil && expectedBody == nil) || (reqErr != nil && errorBody == nil) {
+		return resp.StatusCode, reqErr
+	}
 
 	// TODO: reading everything into memory might not be optimal if we expect long responses
 	rawBody, err := io.ReadAll(resp.Body)

--- a/internal/connectors/httpwrapper/client_test.go
+++ b/internal/connectors/httpwrapper/client_test.go
@@ -1,9 +1,11 @@
 package httpwrapper_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,6 +29,40 @@ type successRes struct {
 
 type errorRes struct {
 	Code string `json:"code"`
+}
+
+// trackingBody records whether it was read to EOF (drained) and closed.
+type trackingBody struct {
+	reader  *bytes.Reader
+	drained bool
+	closed  bool
+}
+
+func (b *trackingBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		b.drained = true
+	}
+	return n, err
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+// trackingTransport returns a fixed response whose body tracks read/close state.
+type trackingTransport struct {
+	statusCode int
+	body       *trackingBody
+}
+
+func (t *trackingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: t.statusCode,
+		Body:       t.body,
+		Header:     make(http.Header),
+	}, nil
 }
 
 var _ = Describe("ClientWrapper", func() {
@@ -165,5 +201,28 @@ var _ = Describe("ClientWrapper", func() {
 			Expect(errors.Is(doErr, httpwrapper.ErrStatusCodeClientError)).To(BeFalse())
 			Expect(doErr).To(MatchError(ContainSubstring("failed to make request")))
 		})
+	})
+
+	Context("draining and closing the response body", func() {
+		DescribeTable("always drains and closes the body, including on early-return paths",
+			func(ctx SpecContext, statusCode int, expectedBody, errorBody any) {
+				body := &trackingBody{reader: bytes.NewReader([]byte(`{"id":"someid"}`))}
+				trackingClient := httpwrapper.NewClient(&httpwrapper.Config{
+					Transport: &trackingTransport{statusCode: statusCode, body: body},
+				})
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.invalid", http.NoBody)
+				Expect(err).To(BeNil())
+
+				code, _ := trackingClient.Do(context.Background(), req, expectedBody, errorBody)
+				Expect(code).To(Equal(statusCode))
+				Expect(body.drained).To(BeTrue(), "response body should be drained for keep-alive reuse")
+				Expect(body.closed).To(BeTrue(), "response body should be closed")
+			},
+			Entry("success with nil expectedBody (early return)", http.StatusOK, nil, nil),
+			Entry("error status with nil errorBody (early return)", http.StatusInternalServerError, nil, nil),
+			Entry("success with expectedBody (read path)", http.StatusOK, &successRes{}, nil),
+			Entry("error status with errorBody (read path)", http.StatusInternalServerError, &successRes{}, &errorRes{}),
+		)
 	})
 })


### PR DESCRIPTION
## EN-1090 — httpwrapper leaks HTTP response bodies on early-return paths

[EN-1090](https://formance-team.atlassian.net/browse/EN-1090) (audit finding H5)

### Problem
In `internal/connectors/httpwrapper/client.go`, the `defer resp.Body.Close()` was registered **after** the early-return branch. Every call with a nil `expectedBody` (on success) or nil `errorBody` (on error status) returned without closing or draining the body — leaking connections/FDs and defeating keep-alive reuse. This affects all 10+ connector call sites that use the shared wrapper (powens, tink, plaid, wise, mangopay, bankingcircle).

### Fix
- Register the cleanup `defer` **immediately after** a successful `Do`, before any early return.
- **Drain** via `io.Copy(io.Discard, resp.Body)` before `Close()` so the underlying connection becomes eligible for keep-alive reuse (not merely closed).
- Drop the dead `resp.Body == nil` check — `net/http` guarantees a non-nil body on a successful `Do`.
- Centralized in the wrapper; no connector call-site changes needed.

### Tests
Added a table-driven spec with an instrumented transport/body that records drain + close, covering all four paths (success/error × read-path/early-return). Verified the early-return cases fail against the pre-fix code and pass with the fix.

### Notes
- One pre-existing test (`"no such host"`, transport-failure branch — untouched by this change) fails only in the local sandbox due to captive DNS resolution of `.invalid`; it is environmental, not a regression.

[EN-1090]: https://formance-team.atlassian.net/browse/EN-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ