### PR TITLE
fix(api): EN-1091 repair broken v2 connector webhooks route

### DIFF
--- a/internal/api/v2/handler_connectors_webhooks.go
+++ b/internal/api/v2/handler_connectors_webhooks.go
@@ -1,8 +1,10 @@
 package v2
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/payments/internal/api/backend"
@@ -12,10 +14,28 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+// v2WebhookProviders is the set of connectors that ever registered webhook URLs
+// in v2 (/connectors/webhooks/{provider}/{connectorID}/). Only Adyen and
+// MangoPay did, so any other provider in the path is rejected with 404 rather
+// than silently accepted (EN-1091).
+var v2WebhookProviders = map[string]struct{}{
+	"adyen":    {},
+	"mangopay": {},
+}
+
 func connectorsWebhooks(backend backend.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := otel.Tracer().Start(r.Context(), "v2_connectorsWebhooks")
 		defer span.End()
+
+		provider := strings.ToLower(connectorProvider(r))
+		span.SetAttributes(attribute.String("provider", provider))
+		if _, ok := v2WebhookProviders[provider]; !ok {
+			err := fmt.Errorf("webhooks are not supported for connector %q in v2", connectorProvider(r))
+			otel.RecordError(span, err)
+			api.NotFound(w, err)
+			return
+		}
 
 		span.SetAttributes(attribute.String("connectorID", connectorID(r)))
 		connectorID, err := models.ConnectorIDFromString(connectorID(r))

--- a/internal/api/v2/handler_connectors_webhooks_test.go
+++ b/internal/api/v2/handler_connectors_webhooks_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,21 +38,28 @@ var _ = Describe("API v2 Connector Webhooks", func() {
 		})
 
 		It("should return a bad request error when connector ID is invalid", func(ctx SpecContext) {
-			req := prepareQueryRequest(http.MethodGet, "connectorID", "invalid")
+			req := prepareQueryRequest(http.MethodGet, "connector", "mangopay", "connectorID", "invalid")
 			handlerFn(w, req)
 
 			assertExpectedResponse(w.Result(), http.StatusBadRequest, ErrInvalidID)
 		})
 
+		It("should return not found when the provider never supported v2 webhooks", func(ctx SpecContext) {
+			req := prepareQueryRequest(http.MethodPost, "connector", "stripe", "connectorID", connID.String())
+			handlerFn(w, req)
+
+			assertExpectedResponse(w.Result(), http.StatusNotFound, ErrNotFound)
+		})
+
 		It("should return an internal server error when backend returns error", func(ctx SpecContext) {
 			m.EXPECT().ConnectorsHandleWebhooks(gomock.Any(), "/", "/", gomock.Any()).Return(fmt.Errorf("connector webhooks err"))
-			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "connectorID", connID.String(), &config))
+			handlerFn(w, prepareQueryRequestWithBody(http.MethodPost, bytes.NewReader(config), "connector", "mangopay", "connectorID", connID.String()))
 			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
 		})
 
 		It("should return status ok on success", func(ctx SpecContext) {
 			m.EXPECT().ConnectorsHandleWebhooks(gomock.Any(), "/", "/", gomock.Any()).Return(nil)
-			handlerFn(w, prepareJSONRequestWithQuery(http.MethodPost, "connectorID", connID.String(), &config))
+			handlerFn(w, prepareQueryRequestWithBody(http.MethodPost, bytes.NewReader(config), "connector", "mangopay", "connectorID", connID.String()))
 			assertExpectedResponse(w.Result(), http.StatusOK, "")
 		})
 	})

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -16,7 +16,11 @@ func newRouter(backend backend.Backend, a jwt.Authenticator, debug bool) *chi.Mu
 	r.Group(func(r chi.Router) {
 		// Public routes
 		r.Group(func(r chi.Router) {
-			r.Handle("/connectors/webhooks/{connectorID}/*", connectorsWebhooks(backend))
+			// v2 webhook URLs registered with PSPs include the provider as a
+			// path segment before the connector ID, e.g.
+			// /connectors/webhooks/mangopay/{connectorID}/ (see EN-1091). The
+			// provider segment must be preserved or real PSP traffic 404s.
+			r.Handle("/connectors/webhooks/{connector}/{connectorID}/*", connectorsWebhooks(backend))
 		})
 
 		// Authenticated routes

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -16,7 +16,7 @@ func newRouter(backend backend.Backend, a jwt.Authenticator, debug bool) *chi.Mu
 	r.Group(func(r chi.Router) {
 		// Public routes
 		r.Group(func(r chi.Router) {
-			r.Post("/connectors/webhooks/{connector}/connectorID", connectorsWebhooks(backend))
+			r.Handle("/connectors/C/{connectorID}/*", connectorsWebhooks(backend))
 		})
 
 		// Authenticated routes

--- a/internal/api/v2/router.go
+++ b/internal/api/v2/router.go
@@ -16,7 +16,7 @@ func newRouter(backend backend.Backend, a jwt.Authenticator, debug bool) *chi.Mu
 	r.Group(func(r chi.Router) {
 		// Public routes
 		r.Group(func(r chi.Router) {
-			r.Handle("/connectors/C/{connectorID}/*", connectorsWebhooks(backend))
+			r.Handle("/connectors/webhooks/{connectorID}/*", connectorsWebhooks(backend))
 		})
 
 		// Authenticated routes

--- a/internal/api/v2/router_test.go
+++ b/internal/api/v2/router_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/google/uuid"
@@ -29,9 +30,14 @@ var _ = Describe("API v2 Router", func() {
 		BeforeEach(func() {
 			ctrl := gomock.NewController(GinkgoT())
 			m = backend.NewMockBackend(ctrl)
-			// authenticator is nil: the webhooks route is public so the JWT
-			// middleware closure is never invoked for it.
-			r = newRouter(m, nil, false)
+			// Build the router with a real authenticator that DENIES every
+			// request. The webhooks route is public, so requests must reach the
+			// handler regardless of authentication. If the route were ever moved
+			// behind the JWT middleware, this authenticator would reject the
+			// request with 401 and these tests would fail.
+			auth := jwt.NewMockAuthenticator(ctrl)
+			auth.EXPECT().Authenticate(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+			r = newRouter(m, auth, false)
 			connID = models.ConnectorID{Reference: uuid.New(), Provider: "psp"}
 		})
 

--- a/internal/api/v2/router_test.go
+++ b/internal/api/v2/router_test.go
@@ -18,9 +18,13 @@ var _ = Describe("API v2 Router", func() {
 	// Routing-level tests: requests go through the chi router (newRouter) rather
 	// than calling handlers directly, so the URL path is parsed into chi
 	// URLParams the same way it is in production. This guards against route
-	// declaration bugs that handler-only tests cannot catch (EN-1091: the route
-	// declared a literal "connectorID" segment instead of a "{connectorID}"
-	// param, so chi.URLParam(r, "connectorID") was always empty).
+	// declaration bugs that handler-only tests cannot catch.
+	//
+	// EN-1091: v2 webhook URLs registered with PSPs have the shape
+	// /connectors/webhooks/{provider}/{connectorID}/ (e.g.
+	// /connectors/webhooks/mangopay/<id>/). The route must keep the provider
+	// segment, parse the connectorID param (not a literal segment), and allow
+	// arbitrary sub-paths via the trailing wildcard.
 	Context("public connector webhooks route", func() {
 		var (
 			r      http.Handler
@@ -38,7 +42,7 @@ var _ = Describe("API v2 Router", func() {
 			auth := jwt.NewMockAuthenticator(ctrl)
 			auth.EXPECT().Authenticate(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 			r = newRouter(m, auth, false)
-			connID = models.ConnectorID{Reference: uuid.New(), Provider: "psp"}
+			connID = models.ConnectorID{Reference: uuid.New(), Provider: "mangopay"}
 		})
 
 		It("routes the connector ID from the path to the handler", func(ctx SpecContext) {
@@ -49,7 +53,22 @@ var _ = Describe("API v2 Router", func() {
 					return nil
 				})
 
-			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/"+connID.String()+"/", strings.NewReader("{}"))
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/mangopay/"+connID.String()+"/", strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			Expect(w.Result().StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("accepts the upper-cased provider segment", func(ctx SpecContext) {
+			// v2 registered the route for both Provider.String() ("MANGOPAY",
+			// the raw uppercase constant) and Provider.StringLower()
+			// ("mangopay"), so both casings must still route.
+			m.EXPECT().
+				ConnectorsHandleWebhooks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/MANGOPAY/"+connID.String()+"/", strings.NewReader("{}"))
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
@@ -61,7 +80,7 @@ var _ = Describe("API v2 Router", func() {
 				ConnectorsHandleWebhooks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil)
 
-			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/"+connID.String()+"/some/provider/path", strings.NewReader("{}"))
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/mangopay/"+connID.String()+"/some/provider/path", strings.NewReader("{}"))
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
@@ -69,11 +88,21 @@ var _ = Describe("API v2 Router", func() {
 		})
 
 		It("returns a bad request when the connector ID in the path is invalid", func(ctx SpecContext) {
-			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/invalid/", strings.NewReader("{}"))
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/mangopay/invalid/", strings.NewReader("{}"))
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
 			Expect(w.Result().StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns not found when the provider never supported v2 webhooks", func(ctx SpecContext) {
+			// Only Adyen and MangoPay used webhooks in v2; any other provider is
+			// rejected rather than silently accepted.
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/stripe/"+connID.String()+"/", strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			Expect(w.Result().StatusCode).To(Equal(http.StatusNotFound))
 		})
 	})
 })

--- a/internal/api/v2/router_test.go
+++ b/internal/api/v2/router_test.go
@@ -1,0 +1,73 @@
+package v2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/models"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("API v2 Router", func() {
+	// Routing-level tests: requests go through the chi router (newRouter) rather
+	// than calling handlers directly, so the URL path is parsed into chi
+	// URLParams the same way it is in production. This guards against route
+	// declaration bugs that handler-only tests cannot catch (EN-1091: the route
+	// declared a literal "connectorID" segment instead of a "{connectorID}"
+	// param, so chi.URLParam(r, "connectorID") was always empty).
+	Context("public connector webhooks route", func() {
+		var (
+			r      http.Handler
+			m      *backend.MockBackend
+			connID models.ConnectorID
+		)
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			m = backend.NewMockBackend(ctrl)
+			// authenticator is nil: the webhooks route is public so the JWT
+			// middleware closure is never invoked for it.
+			r = newRouter(m, nil, false)
+			connID = models.ConnectorID{Reference: uuid.New(), Provider: "psp"}
+		})
+
+		It("routes the connector ID from the path to the handler", func(ctx SpecContext) {
+			m.EXPECT().
+				ConnectorsHandleWebhooks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ any, _ string, _ string, webhook models.Webhook) error {
+					Expect(webhook.ConnectorID.String()).To(Equal(connID.String()))
+					return nil
+				})
+
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/"+connID.String()+"/", strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			Expect(w.Result().StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("routes webhook sub-paths via the wildcard", func(ctx SpecContext) {
+			m.EXPECT().
+				ConnectorsHandleWebhooks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/"+connID.String()+"/some/provider/path", strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			Expect(w.Result().StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("returns a bad request when the connector ID in the path is invalid", func(ctx SpecContext) {
+			req := httptest.NewRequest(http.MethodPost, "/connectors/webhooks/invalid/", strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			Expect(w.Result().StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+})

--- a/internal/api/v2/router_test.go
+++ b/internal/api/v2/router_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/payments/internal/api/backend"
-	"github.com/formancehq/payments/internal/models"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
## Bug

The v2 webhook route was migrated from stack as `/connectors/webhooks/{connector}/connectorID` — a literal `connectorID` segment, with the `{connector}` param unused — while the handler reads `chi.URLParam(r, "connectorID")`. So the param was always empty, `ConnectorIDFromString("")` failed, and every request got a systematic 400 `INVALID_ID`. Present since commit `0308e100` (2024-09); any PSP webhook posted to the v2 URL was lost. Undetected because handler tests inject the URL param manually, bypassing the chi router.

## Fix

Real v2 webhook URLs registered with PSPs include the **provider as a path segment** before the connector ID:

```
/api/payments/connectors/webhooks/{provider}/{connectorID}/
```

Confirmed against `stack@release/v2.0` — e.g. mangopay registered `fmt.Sprintf("%s/api/payments/connectors/webhooks/mangopay/%s/", stackPublicURL, &connectorID)`, and the v2 router registered the prefix for both `Provider.String()` ("MangoPay") and `Provider.StringLower()` ("mangopay"). The v2 router is mounted at root (no version prefix), so this path is unchanged today.

This PR restores that exact shape:

```go
r.Handle("/connectors/webhooks/{connector}/{connectorID}/*", connectorsWebhooks(backend))
```

Only **Adyen** and **MangoPay** ever used webhooks in v2 (the only connectors with webhook tasks in v2), so the handler rejects any other provider with **404** rather than silently accepting it.

> ⚠️ An earlier revision of this PR mirrored the v3 route (`/connectors/webhooks/{connectorID}/*`), which dropped the provider segment — a live MangoPay webhook would then bind `connectorID="mangopay"` and 400. That was incorrect and is corrected here (thanks @laouji for catching it).

Router-level tests now drive the real provider-prefixed path (lower- and title-cased), sub-paths via the wildcard, the invalid-ID 400, and the unknown-provider 404 — exercising route declaration through `newRouter` rather than manual `URLParam` injection.

## Notes

This endpoint is not in the OpenAPI spec (neither v2 nor v3 webhook ingress is documented) — it is a public route PSPs post to. **Kept rather than removed:** v2-era connector installs still have PSP-side registrations pointing at this URL, and it aids v2→v3 migration.

Directive: webhook ingress routes are intentionally absent from OpenAPI; test them at the router level, not via manual URLParam injection.
