### PR TITLE
fix(modulr): EN-1088 ingest transactions oldest-first by transactionDate window

### DIFF
--- a/internal/connectors/plugins/public/modulr/client/client.go
+++ b/internal/connectors/plugins/public/modulr/client/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	GetPayments(ctx context.Context, paymentType PaymentType, page, pageSize int, modifiedSince time.Time) ([]Payment, error)
 	InitiatePayout(ctx context.Context, payoutRequest *PayoutRequest) (*PayoutResponse, error)
 	GetPayout(ctx context.Context, payoutID string) (PayoutResponse, error)
-	GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate time.Time) ([]Transaction, error)
+	GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate, toTransactionDate time.Time) ([]Transaction, int, error)
 	InitiateTransfer(ctx context.Context, transferRequest *TransferRequest) (*TransferResponse, error)
 	GetTransfer(ctx context.Context, transferID string) (TransferResponse, error)
 }

--- a/internal/connectors/plugins/public/modulr/client/client_generated.go
+++ b/internal/connectors/plugins/public/modulr/client/client_generated.go
@@ -117,18 +117,19 @@ func (mr *MockClientMockRecorder) GetPayout(ctx, payoutID any) *gomock.Call {
 }
 
 // GetTransactions mocks base method.
-func (m *MockClient) GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate time.Time) ([]Transaction, error) {
+func (m *MockClient) GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate, toTransactionDate time.Time) ([]Transaction, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransactions", ctx, accountID, page, pageSize, fromTransactionDate)
+	ret := m.ctrl.Call(m, "GetTransactions", ctx, accountID, page, pageSize, fromTransactionDate, toTransactionDate)
 	ret0, _ := ret[0].([]Transaction)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetTransactions indicates an expected call of GetTransactions.
-func (mr *MockClientMockRecorder) GetTransactions(ctx, accountID, page, pageSize, fromTransactionDate any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetTransactions(ctx, accountID, page, pageSize, fromTransactionDate, toTransactionDate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactions", reflect.TypeOf((*MockClient)(nil).GetTransactions), ctx, accountID, page, pageSize, fromTransactionDate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactions", reflect.TypeOf((*MockClient)(nil).GetTransactions), ctx, accountID, page, pageSize, fromTransactionDate, toTransactionDate)
 }
 
 // GetTransfer mocks base method.

--- a/internal/connectors/plugins/public/modulr/client/transactions.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions.go
@@ -26,12 +26,14 @@ type Transaction struct {
 	AdditionalInfo  interface{} `json:"additionalInfo"`
 }
 
-func (c *client) GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate time.Time) ([]Transaction, error) {
+// GetTransactions returns a page of transactions (newest-first) along with the total
+// number of pages for the query, which the caller uses to drain a window oldest-first.
+func (c *client) GetTransactions(ctx context.Context, accountID string, page, pageSize int, fromTransactionDate, toTransactionDate time.Time) ([]Transaction, int, error) {
 	ctx = context.WithValue(ctx, metrics.MetricOperationContextKey, "list_transactions")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.buildEndpoint("accounts/%s/transactions", accountID), http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create accounts request: %w", err)
+		return nil, 0, fmt.Errorf("failed to create accounts request: %w", err)
 	}
 
 	q := req.URL.Query()
@@ -40,16 +42,22 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 	if !fromTransactionDate.IsZero() {
 		q.Add("fromTransactionDate", fromTransactionDate.Format("2006-01-02T15:04:05-0700"))
 	}
+	// The transactions endpoint returns results newest-first and exposes no sort
+	// parameter, so we freeze the upper bound of a drain window with toTransactionDate
+	// to keep page indices stable while paginating (see fetchNextPayments).
+	if !toTransactionDate.IsZero() {
+		q.Add("toTransactionDate", toTransactionDate.Format("2006-01-02T15:04:05-0700"))
+	}
 	req.URL.RawQuery = q.Encode()
 
 	var res responseWrapper[[]Transaction]
 	var errRes modulrErrors
 	_, err = c.httpClient.Do(ctx, req, &res, &errRes)
 	if err != nil {
-		return nil, errorsutils.NewWrappedError(
+		return nil, 0, errorsutils.NewWrappedError(
 			fmt.Errorf("failed to get transactions: %v", errRes.Error()),
 			err,
 		)
 	}
-	return res.Content, nil
+	return res.Content, res.TotalPages, nil
 }

--- a/internal/connectors/plugins/public/modulr/client/transactions.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions.go
@@ -40,13 +40,13 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 	q.Add("page", strconv.Itoa(page))
 	q.Add("size", strconv.Itoa(pageSize))
 	if !fromTransactionDate.IsZero() {
-		q.Add("fromTransactionDate", fromTransactionDate.Format("2006-01-02T15:04:05-0700"))
+		q.Add("fromTransactionDate", fromTransactionDate.Format(transactionFilterLayout))
 	}
 	// The transactions endpoint returns results newest-first and exposes no sort
 	// parameter, so we freeze the upper bound of a drain window with toTransactionDate
 	// to keep page indices stable while paginating (see fetchNextPayments).
 	if !toTransactionDate.IsZero() {
-		q.Add("toTransactionDate", toTransactionDate.Format("2006-01-02T15:04:05-0700"))
+		q.Add("toTransactionDate", formatToTransactionDate(toTransactionDate))
 	}
 	req.URL.RawQuery = q.Encode()
 
@@ -60,4 +60,23 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 		)
 	}
 	return res.Content, res.TotalPages, nil
+}
+
+// transactionFilterLayout is the second-precision layout the transactions endpoint accepts
+// for its fromTransactionDate / toTransactionDate filters.
+const transactionFilterLayout = "2006-01-02T15:04:05-0700"
+
+// formatToTransactionDate formats a drain-window ceiling for the second-precision
+// toTransactionDate filter, rounding UP to the next second. The ceiling is a transaction
+// timestamp that may carry milliseconds; truncating it down (the filter is second-precision)
+// would make the inclusive upper bound earlier than the ceiling and exclude the newest
+// transaction(s) in that fractional second, which the drain would then skip permanently once
+// the watermark advances. fetchNextPayments re-applies the exact ceiling client-side, so the
+// widened bound never emits anything past it.
+func formatToTransactionDate(toTransactionDate time.Time) string {
+	rounded := toTransactionDate.Truncate(time.Second)
+	if rounded.Before(toTransactionDate) {
+		rounded = rounded.Add(time.Second)
+	}
+	return rounded.Format(transactionFilterLayout)
 }

--- a/internal/connectors/plugins/public/modulr/client/transactions.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions.go
@@ -66,17 +66,14 @@ func (c *client) GetTransactions(ctx context.Context, accountID string, page, pa
 // for its fromTransactionDate / toTransactionDate filters.
 const transactionFilterLayout = "2006-01-02T15:04:05-0700"
 
-// formatToTransactionDate formats a drain-window ceiling for the second-precision
-// toTransactionDate filter, rounding UP to the next second. The ceiling is a transaction
-// timestamp that may carry milliseconds; truncating it down (the filter is second-precision)
-// would make the inclusive upper bound earlier than the ceiling and exclude the newest
-// transaction(s) in that fractional second, which the drain would then skip permanently once
-// the watermark advances. fetchNextPayments re-applies the exact ceiling client-side, so the
-// widened bound never emits anything past it.
+// formatToTransactionDate formats a drain-window ceiling for the toTransactionDate filter.
+// The filter is whole-second and INCLUSIVE: toTransactionDate=2017-01-28T01:01:01+0000
+// returns transactions through 2017-01-28T01:01:01.999 (verified against the Modulr
+// sandbox). So we truncate the ceiling (which carries milliseconds) down to its second —
+// the whole ceiling second, including the ceiling transaction itself, is still returned.
+// We deliberately do NOT round up: that would widen the window into the next second and
+// admit transactions newer than the ceiling, shifting the newest-first page boundaries
+// mid-drain. fetchNextPayments re-applies the exact ceiling client-side.
 func formatToTransactionDate(toTransactionDate time.Time) string {
-	rounded := toTransactionDate.Truncate(time.Second)
-	if rounded.Before(toTransactionDate) {
-		rounded = rounded.Add(time.Second)
-	}
-	return rounded.Format(transactionFilterLayout)
+	return toTransactionDate.Truncate(time.Second).Format(transactionFilterLayout)
 }

--- a/internal/connectors/plugins/public/modulr/client/transactions_test.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions_test.go
@@ -12,6 +12,8 @@ func TestFormatToTransactionDate(t *testing.T) {
 
 	utc := time.FixedZone("", 0)
 
+	// Modulr's toTransactionDate filter is whole-second and inclusive, so truncating a
+	// millisecond ceiling down to its second still returns the ceiling transaction.
 	tests := []struct {
 		name string
 		in   time.Time
@@ -23,14 +25,14 @@ func TestFormatToTransactionDate(t *testing.T) {
 			want: "2026-06-18T13:54:29+0000",
 		},
 		{
-			name: "milliseconds round up to the next second",
+			name: "milliseconds are truncated down to the second",
 			in:   time.Date(2026, 6, 18, 13, 54, 29, 18_000_000, utc),
-			want: "2026-06-18T13:54:30+0000",
+			want: "2026-06-18T13:54:29+0000",
 		},
 		{
-			name: "sub-millisecond also rounds up",
+			name: "sub-millisecond is also truncated down",
 			in:   time.Date(2026, 6, 18, 13, 54, 29, 1, utc),
-			want: "2026-06-18T13:54:30+0000",
+			want: "2026-06-18T13:54:29+0000",
 		},
 	}
 

--- a/internal/connectors/plugins/public/modulr/client/transactions_test.go
+++ b/internal/connectors/plugins/public/modulr/client/transactions_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatToTransactionDate(t *testing.T) {
+	t.Parallel()
+
+	utc := time.FixedZone("", 0)
+
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{
+			name: "whole second is left unchanged",
+			in:   time.Date(2026, 6, 18, 13, 54, 29, 0, utc),
+			want: "2026-06-18T13:54:29+0000",
+		},
+		{
+			name: "milliseconds round up to the next second",
+			in:   time.Date(2026, 6, 18, 13, 54, 29, 18_000_000, utc),
+			want: "2026-06-18T13:54:30+0000",
+		},
+		{
+			name: "sub-millisecond also rounds up",
+			in:   time.Date(2026, 6, 18, 13, 54, 29, 1, utc),
+			want: "2026-06-18T13:54:30+0000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, formatToTransactionDate(tc.in))
+		})
+	}
+}

--- a/internal/connectors/plugins/public/modulr/payments.go
+++ b/internal/connectors/plugins/public/modulr/payments.go
@@ -10,19 +10,61 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/modulr/client"
 	"github.com/formancehq/payments/internal/models"
-	"github.com/formancehq/payments/internal/utils/pagination"
 )
 
+// transactionDateLayout is the timestamp layout Modulr uses for transaction dates.
+const transactionDateLayout = "2006-01-02T15:04:05.999-0700"
+
+// paymentsStateVersion is the current schema version of paymentsState. State written
+// before the newest-first ordering fix has version 0 (watermark derived from PostedDate)
+// and is reset once on read so the corrected logic re-ingests history.
+const paymentsStateVersion = 1
+
+// The Modulr transactions endpoint returns results newest-first and exposes no sort
+// parameter, while the engine must ingest payments oldest-first: it seeds a payment's
+// base row from the first adjustment it sees for a reference (storage upserts the row
+// with ON CONFLICT DO NOTHING). So each poll drains a frozen window
+// (LastTransactionTime, Ceiling] one page at a time across successive calls:
+//
+//  1. open    — peek the newest page (page 0) to freeze Ceiling and read TotalPages, which
+//     tells us the oldest page index.
+//  2. descend — emit pages from the oldest (TotalPages-1) up to page 0, reversing each page
+//     so the whole window is emitted oldest-first; commit the watermark to Ceiling only
+//     after page 0.
+//
+// Every call returns at most ~PageSize payments (Temporal-safe) and the watermark advances
+// only once the window is fully drained, so an interrupted drain simply re-runs the window
+// (idempotent by reference).
 type paymentsState struct {
+	// LastTransactionTime is the committed watermark: the greatest transactionDate
+	// already ingested. Advanced only when a drain window is fully consumed.
 	LastTransactionTime time.Time `json:"lastTransactionTime"`
+	// Ceiling is the frozen upper bound (transactionDate) of the drain window currently
+	// in progress, and the sole indicator that a window is in progress. A zero Ceiling
+	// means no window is in progress: the next call opens a fresh one by peeking the
+	// newest row. Because the window only ever commits a non-zero Ceiling, we can never
+	// page an unbounded window or commit a zero watermark.
+	Ceiling time.Time `json:"ceiling"`
+	// NextPage is the next page index to fetch within the in-progress window. It counts
+	// DOWN from the oldest page to 0 so transactions are emitted oldest-first.
+	NextPage int `json:"nextPage"`
+	// Version is the state schema version (see paymentsStateVersion).
+	Version int `json:"version"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
-	var oldState paymentsState
+	var state paymentsState
 	if req.State != nil {
-		if err := json.Unmarshal(req.State, &oldState); err != nil {
+		if err := json.Unmarshal(req.State, &state); err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
+	}
+
+	// Migration: state written before this fix used a PostedDate-derived watermark and
+	// lacked the drain-window fields. Reset it once so the corrected transactionDate
+	// logic re-ingests the available history (payments are idempotent by reference).
+	if state.Version < paymentsStateVersion {
+		state = paymentsState{Version: paymentsStateVersion}
 	}
 
 	var from models.PSPAccount
@@ -33,86 +75,128 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		return models.FetchNextPaymentsResponse{}, err
 	}
 
-	newState := paymentsState{
-		LastTransactionTime: oldState.LastTransactionTime,
+	// A non-zero Ceiling means a window is mid-drain; otherwise open a fresh one.
+	if state.Ceiling.IsZero() {
+		return p.openPaymentsWindow(ctx, req, from, state)
+	}
+	return p.drainPaymentsWindow(ctx, req, from, state)
+}
+
+// openPaymentsWindow peeks the newest page to freeze the window ceiling (the watermark we
+// commit once drained) and reads TotalPages to find the oldest page. A single page is
+// emitted straight away; a multi-page window starts the oldest-first descent.
+func (p *Plugin) openPaymentsWindow(ctx context.Context, req models.FetchNextPaymentsRequest, from models.PSPAccount, state paymentsState) (models.FetchNextPaymentsResponse, error) {
+	page0, totalPages, err := p.client.GetTransactions(ctx, from.Reference, 0, req.PageSize, state.LastTransactionTime, time.Time{})
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+	if len(page0) == 0 {
+		// Nothing newer than the watermark; stay put.
+		return marshalPaymentsResponse(state, nil, false)
 	}
 
-	var payments []models.PSPPayment
-	needMore := false
-	hasMore := false
-	for page := 0; ; page++ {
-		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, oldState.LastTransactionTime)
+	// Results are newest-first, so the first row carries the greatest transactionDate.
+	state.Ceiling, err = time.Parse(transactionDateLayout, page0[0].TransactionDate)
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, fmt.Errorf("failed to parse transaction date %s: %w", page0[0].TransactionDate, err)
+	}
+
+	if totalPages <= 1 {
+		// The only page is both newest and oldest: emit it and close the window.
+		payments, err := p.paymentsFromPage(ctx, page0, from, state.LastTransactionTime, state.Ceiling)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
-
-		payments, err = p.fillPayments(ctx, pagedTransactions, from, payments, oldState, req.PageSize)
-		if err != nil {
-			return models.FetchNextPaymentsResponse{}, err
-		}
-
-		needMore, hasMore = pagination.ShouldFetchMore(payments, pagedTransactions, req.PageSize)
-		if !needMore || !hasMore {
-			break
-		}
+		return marshalPaymentsResponse(closeWindow(state), payments, false)
 	}
 
-	if !needMore {
-		payments = payments[:req.PageSize]
-	}
+	// Multi-page: descend from the oldest page. Page 0 (just peeked) is the newest and is
+	// emitted last, so we don't emit it here.
+	state.NextPage = totalPages - 1
+	return marshalPaymentsResponse(state, nil, true)
+}
 
-	if len(payments) > 0 {
-		newState.LastTransactionTime = payments[len(payments)-1].CreatedAt
-	}
-
-	payload, err := json.Marshal(newState)
+// drainPaymentsWindow emits one page of the frozen window, walking from the oldest page
+// down to page 0, and commits the watermark to the ceiling once page 0 has been emitted.
+func (p *Plugin) drainPaymentsWindow(ctx context.Context, req models.FetchNextPaymentsRequest, from models.PSPAccount, state paymentsState) (models.FetchNextPaymentsResponse, error) {
+	// Bound above by the frozen ceiling so transactions arriving mid-drain don't shift
+	// page indices.
+	page, _, err := p.client.GetTransactions(ctx, from.Reference, state.NextPage, req.PageSize, state.LastTransactionTime, state.Ceiling)
 	if err != nil {
 		return models.FetchNextPaymentsResponse{}, err
 	}
 
-	return models.FetchNextPaymentsResponse{
-		Payments: payments,
-		NewState: payload,
-		HasMore:  hasMore,
-	}, nil
+	payments, err := p.paymentsFromPage(ctx, page, from, state.LastTransactionTime, state.Ceiling)
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+
+	if state.NextPage > 0 {
+		// Older pages already emitted; keep descending towards the newest page.
+		state.NextPage--
+		return marshalPaymentsResponse(state, payments, true)
+	}
+
+	// Page 0 (newest) just emitted: the window is fully drained.
+	return marshalPaymentsResponse(closeWindow(state), payments, false)
 }
 
-func (p *Plugin) fillPayments(
-	ctx context.Context,
-	pagedTransactions []client.Transaction,
-	from models.PSPAccount,
-	payments []models.PSPPayment,
-	oldState paymentsState,
-	pageSize int,
-) ([]models.PSPPayment, error) {
-	for _, transaction := range pagedTransactions {
-		if len(payments) >= pageSize {
-			break
-		}
-
-		createdTime, err := time.Parse("2006-01-02T15:04:05.999-0700", transaction.TransactionDate)
+// paymentsFromPage maps one newest-first page of transactions into payments inside the
+// window (lower, upper], emitted oldest-first.
+func (p *Plugin) paymentsFromPage(ctx context.Context, page []client.Transaction, from models.PSPAccount, lower, upper time.Time) ([]models.PSPPayment, error) {
+	payments := make([]models.PSPPayment, 0, len(page))
+	for _, transaction := range reverseTransactions(page) {
+		date, err := time.Parse(transactionDateLayout, transaction.TransactionDate)
 		if err != nil {
 			return nil, err
 		}
 
-		switch createdTime.Compare(oldState.LastTransactionTime) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Keep only transactions inside the window (lower, upper]: skip those already
+		// ingested (<= lower) or newer than the frozen ceiling (> upper).
+		if !date.After(lower) || date.After(upper) {
 			continue
-		default:
 		}
 
 		payment, err := p.transactionToPayment(ctx, transaction, from)
 		if err != nil {
 			return nil, err
 		}
-
 		if payment != nil {
 			payments = append(payments, *payment)
 		}
 	}
 
 	return payments, nil
+}
+
+// reverseTransactions returns the page oldest-first; Modulr returns it newest-first.
+func reverseTransactions(in []client.Transaction) []client.Transaction {
+	out := make([]client.Transaction, len(in))
+	for i := range in {
+		out[len(in)-1-i] = in[i]
+	}
+	return out
+}
+
+// closeWindow returns state with the watermark advanced to the frozen ceiling and the
+// drain window cleared, so the next poll opens a fresh window.
+func closeWindow(state paymentsState) paymentsState {
+	state.LastTransactionTime = state.Ceiling
+	state.Ceiling = time.Time{}
+	state.NextPage = 0
+	return state
+}
+
+func marshalPaymentsResponse(state paymentsState, payments []models.PSPPayment, hasMore bool) (models.FetchNextPaymentsResponse, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return models.FetchNextPaymentsResponse{}, err
+	}
+	return models.FetchNextPaymentsResponse{
+		Payments: payments,
+		NewState: payload,
+		HasMore:  hasMore,
+	}, nil
 }
 
 func (p *Plugin) transactionToPayment(

--- a/internal/connectors/plugins/public/modulr/payments_test.go
+++ b/internal/connectors/plugins/public/modulr/payments_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Modulr Plugin Payments", func() {
 		ctrl.Finish()
 	})
 
-	Context("fetching next accounts", func() {
+	Context("fetching next payments", func() {
 		var (
 			sampleTransactions []client.Transaction
 			now                time.Time
@@ -41,8 +41,13 @@ var _ = Describe("Modulr Plugin Payments", func() {
 		BeforeEach(func() {
 			now = time.Now().UTC()
 
+			// Modulr returns transactions newest-first (descending by transactionDate),
+			// so index 0 is the most recent. PostedDate intentionally lags TransactionDate
+			// by 2h: the watermark must track TransactionDate (the filtered/compared field),
+			// never the later PostedDate.
 			sampleTransactions = make([]client.Transaction, 0)
 			for i := 0; i < 50; i++ {
+				txnDate := now.Add(-time.Duration(i) * time.Minute)
 				sampleTransactions = append(sampleTransactions, client.Transaction{
 					ID:              fmt.Sprintf("%d", i),
 					Type:            "PI_FAST",
@@ -50,8 +55,8 @@ var _ = Describe("Modulr Plugin Payments", func() {
 					Credit:          false,
 					SourceID:        fmt.Sprintf("test-%d", i),
 					Description:     fmt.Sprintf("Description %d", i),
-					PostedDate:      now.Add(-time.Duration(50-i) * time.Minute).UTC().Format("2006-01-02T15:04:05.999-0700"),
-					TransactionDate: now.Add(-time.Duration(50-i) * time.Minute).UTC().Format("2006-01-02T15:04:05.999-0700"),
+					PostedDate:      txnDate.Add(2 * time.Hour).Format(transactionDateLayout),
+					TransactionDate: txnDate.Format(transactionDateLayout),
 					Account: client.Account{
 						Currency: "USD",
 					},
@@ -78,8 +83,9 @@ var _ = Describe("Modulr Plugin Payments", func() {
 				FromPayload: []byte(`{"reference": "test"}`),
 			}
 
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, time.Time{}).Return(
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, timeEq(time.Time{}), timeEq(time.Time{})).Return(
 				[]client.Transaction{},
+				0,
 				errors.New("test error"),
 			)
 
@@ -96,8 +102,9 @@ var _ = Describe("Modulr Plugin Payments", func() {
 				FromPayload: []byte(`{"reference": "test"}`),
 			}
 
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, time.Time{}).Return(
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, timeEq(time.Time{}), timeEq(time.Time{})).Return(
 				[]client.Transaction{},
+				0,
 				nil,
 			)
 
@@ -110,19 +117,23 @@ var _ = Describe("Modulr Plugin Payments", func() {
 			var state paymentsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			// We fetched everything, state should be resetted
+			// Nothing newer than the watermark: stay put, no drain in progress.
 			Expect(state.LastTransactionTime.IsZero()).To(BeTrue())
+			Expect(state.Ceiling.IsZero()).To(BeTrue())
+			Expect(state.Version).To(Equal(paymentsStateVersion))
 		})
 
-		It("should fetch next payments - no state pageSize > total payments", func(ctx SpecContext) {
+		It("should fetch a single page oldest-first and advance the watermark to the newest transactionDate", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				State:       []byte(`{}`),
 				PageSize:    60,
 				FromPayload: []byte(`{"reference": "test"}`),
 			}
 
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, time.Time{}).Return(
+			// Single page (totalPages = 1): it is both the newest and oldest page.
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, timeEq(time.Time{}), timeEq(time.Time{})).Return(
 				sampleTransactions,
+				1,
 				nil,
 			)
 
@@ -132,72 +143,208 @@ var _ = Describe("Modulr Plugin Payments", func() {
 			Expect(resp.HasMore).To(BeFalse())
 			Expect(resp.NewState).ToNot(BeNil())
 
+			// Emitted oldest-first (ascending CreatedAt) so the earliest event seeds each
+			// payment's base row in the engine.
+			expectOldestFirst(resp.Payments)
+
 			var state paymentsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			// We fetched everything, state should be resetted
-			createdTime, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleTransactions[49].PostedDate)
-			Expect(state.LastTransactionTime.UTC()).To(Equal(createdTime.UTC()))
+			Expect(state.Ceiling.IsZero()).To(BeTrue())
+			Expect(state.Version).To(Equal(paymentsStateVersion))
+
+			// Watermark is the newest TransactionDate (index 0), not the PostedDate.
+			newest, _ := time.Parse(transactionDateLayout, sampleTransactions[0].TransactionDate)
+			Expect(state.LastTransactionTime.UTC()).To(Equal(newest.UTC()))
+			postedNewest, _ := time.Parse(transactionDateLayout, sampleTransactions[0].PostedDate)
+			Expect(state.LastTransactionTime.UTC()).ToNot(Equal(postedNewest.UTC()))
 		})
 
-		It("should fetch next payments - no state pageSize < total payments", func(ctx SpecContext) {
+		It("should drain a multi-page window oldest-first without losing transactions", func(ctx SpecContext) {
+			// 50 transactions, PageSize 20 -> 3 pages. Modulr is newest-first, so
+			// page 0 = indices 0..19 (newest), page 1 = 20..39, page 2 = 40..49 (oldest).
+			// They must be emitted oldest-first: page 2, then page 1, then page 0.
+			const pageSize = 20
+			ceiling, _ := time.Parse(transactionDateLayout, sampleTransactions[0].TransactionDate)
+
+			// open: peek page 0 (unbounded above) -> freeze ceiling, TotalPages = 3.
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, pageSize, timeEq(time.Time{}), timeEq(time.Time{})).Return(
+				sampleTransactions[:20], 3, nil,
+			)
+			// Descent over the frozen window (to = ceiling), oldest page first.
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 2, pageSize, timeEq(time.Time{}), timeEq(ceiling)).Return(
+				sampleTransactions[40:], 3, nil,
+			)
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, pageSize, timeEq(time.Time{}), timeEq(ceiling)).Return(
+				sampleTransactions[20:40], 3, nil,
+			)
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, pageSize, timeEq(time.Time{}), timeEq(ceiling)).Return(
+				sampleTransactions[:20], 3, nil,
+			)
+
+			// Mimic the engine loop: keep calling while HasMore, threading NewState.
+			state := []byte(`{}`)
+			allPayments := make([]models.PSPPayment, 0)
+			calls := 0
+			for {
+				resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{
+					State:       state,
+					PageSize:    pageSize,
+					FromPayload: []byte(`{"reference": "test"}`),
+				})
+				Expect(err).To(BeNil())
+				allPayments = append(allPayments, resp.Payments...)
+				state = resp.NewState
+				calls++
+
+				if calls == 1 {
+					// open: ceiling frozen, descent set to start at the oldest page, nothing
+					// emitted yet, watermark not advanced.
+					Expect(resp.HasMore).To(BeTrue())
+					Expect(resp.Payments).To(HaveLen(0))
+					var mid paymentsState
+					Expect(json.Unmarshal(state, &mid)).To(BeNil())
+					Expect(mid.NextPage).To(Equal(2))
+					Expect(mid.Ceiling.UTC()).To(Equal(ceiling.UTC()))
+					Expect(mid.LastTransactionTime.IsZero()).To(BeTrue())
+				}
+
+				if !resp.HasMore {
+					break
+				}
+				Expect(calls).To(BeNumerically("<", 6)) // guard against an infinite loop
+			}
+
+			Expect(calls).To(Equal(4)) // open + 3 page emits
+			// Nothing lost despite the backlog exceeding PageSize.
+			Expect(allPayments).To(HaveLen(50))
+			// Emitted strictly oldest-first across the whole multi-page window.
+			expectOldestFirst(allPayments)
+
+			var final paymentsState
+			Expect(json.Unmarshal(state, &final)).To(BeNil())
+			Expect(final.Ceiling.IsZero()).To(BeTrue())
+			Expect(final.NextPage).To(Equal(0))
+			Expect(final.LastTransactionTime.UTC()).To(Equal(ceiling.UTC()))
+		})
+
+		It("should fetch only transactions newer than the existing watermark", func(ctx SpecContext) {
+			// Watermark sits at index 10's TransactionDate; the API (newest-first) returns
+			// everything >= the watermark, i.e. indices 0..10, on a single page.
+			watermark, _ := time.Parse(transactionDateLayout, sampleTransactions[10].TransactionDate)
 			req := models.FetchNextPaymentsRequest{
-				State:       []byte(`{}`),
+				State: []byte(fmt.Sprintf(
+					`{"lastTransactionTime":"%s","version":%d}`,
+					watermark.UTC().Format(time.RFC3339Nano), paymentsStateVersion,
+				)),
 				PageSize:    40,
 				FromPayload: []byte(`{"reference": "test"}`),
 			}
 
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 40, time.Time{}).Return(
-				sampleTransactions[:40],
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 40, timeEq(watermark), timeEq(time.Time{})).Return(
+				sampleTransactions[:11],
+				1,
 				nil,
 			)
 
 			resp, err := plg.FetchNextPayments(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.Payments).To(HaveLen(40))
-			Expect(resp.HasMore).To(BeTrue())
-			Expect(resp.NewState).ToNot(BeNil())
-
-			var state paymentsState
-			err = json.Unmarshal(resp.NewState, &state)
-			Expect(err).To(BeNil())
-			createdTime, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleTransactions[39].PostedDate)
-			Expect(state.LastTransactionTime.UTC()).To(Equal(createdTime.UTC()))
-		})
-
-		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
-			lastCreatedAt, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleTransactions[38].PostedDate)
-			req := models.FetchNextPaymentsRequest{
-				State:       []byte(fmt.Sprintf(`{"lastTransactionTime": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano))),
-				PageSize:    40,
-				FromPayload: []byte(`{"reference": "test"}`),
-			}
-
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 40, lastCreatedAt.UTC()).Return(
-				sampleTransactions[:40],
-				nil,
-			)
-
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 40, lastCreatedAt.UTC()).Return(
-				sampleTransactions[41:],
-				nil,
-			)
-
-			resp, err := plg.FetchNextPayments(ctx, req)
-			Expect(err).To(BeNil())
+			// Index 10 (== watermark) is skipped; indices 0..9 are kept.
 			Expect(resp.Payments).To(HaveLen(10))
 			Expect(resp.HasMore).To(BeFalse())
-			Expect(resp.NewState).ToNot(BeNil())
+			expectOldestFirst(resp.Payments)
 
 			var state paymentsState
-			err = json.Unmarshal(resp.NewState, &state)
+			Expect(json.Unmarshal(resp.NewState, &state)).To(BeNil())
+			Expect(state.Ceiling.IsZero()).To(BeTrue())
+			newest, _ := time.Parse(transactionDateLayout, sampleTransactions[0].TransactionDate)
+			Expect(state.LastTransactionTime.UTC()).To(Equal(newest.UTC()))
+		})
+
+		It("should restart at page 0 when state has a stale page but no ceiling", func(ctx SpecContext) {
+			// Defensive: a corrupt/legacy state with a non-zero NextPage but a zero Ceiling
+			// must be treated as a fresh window (peek page 0), never paged mid-window with
+			// a zero ceiling.
+			req := models.FetchNextPaymentsRequest{
+				State:       []byte(fmt.Sprintf(`{"nextPage":7,"version":%d}`, paymentsStateVersion)),
+				PageSize:    60,
+				FromPayload: []byte(`{"reference": "test"}`),
+			}
+
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, timeEq(time.Time{}), timeEq(time.Time{})).Return(
+				sampleTransactions,
+				1,
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
 			Expect(err).To(BeNil())
-			// We fetched everything, state should be resetted
-			createdTime, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleTransactions[49].PostedDate)
-			Expect(state.LastTransactionTime.UTC()).To(Equal(createdTime.UTC()))
+			Expect(resp.Payments).To(HaveLen(50))
+			Expect(resp.HasMore).To(BeFalse())
+
+			var state paymentsState
+			Expect(json.Unmarshal(resp.NewState, &state)).To(BeNil())
+			Expect(state.NextPage).To(Equal(0))
+			Expect(state.Ceiling.IsZero()).To(BeTrue())
+			newest, _ := time.Parse(transactionDateLayout, sampleTransactions[0].TransactionDate)
+			Expect(state.LastTransactionTime.UTC()).To(Equal(newest.UTC()))
+		})
+
+		It("should reset stale pre-version state (migration) and refetch from zero", func(ctx SpecContext) {
+			// Pre-fix state: a PostedDate-derived watermark and no version field (version 0).
+			stale, _ := time.Parse(transactionDateLayout, sampleTransactions[5].PostedDate)
+			req := models.FetchNextPaymentsRequest{
+				State: []byte(fmt.Sprintf(
+					`{"lastTransactionTime":"%s"}`, stale.UTC().Format(time.RFC3339Nano),
+				)),
+				PageSize:    60,
+				FromPayload: []byte(`{"reference": "test"}`),
+			}
+
+			// Migration must discard the stale watermark and refetch from zero.
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 0, 60, timeEq(time.Time{}), timeEq(time.Time{})).Return(
+				sampleTransactions,
+				1,
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp.Payments).To(HaveLen(50))
+
+			var state paymentsState
+			Expect(json.Unmarshal(resp.NewState, &state)).To(BeNil())
+			Expect(state.Version).To(Equal(paymentsStateVersion))
+			newest, _ := time.Parse(transactionDateLayout, sampleTransactions[0].TransactionDate)
+			Expect(state.LastTransactionTime.UTC()).To(Equal(newest.UTC()))
 		})
 	})
 })
+
+// expectOldestFirst asserts payments are emitted in non-decreasing CreatedAt order, so the
+// engine seeds each payment's base row from the earliest event.
+func expectOldestFirst(payments []models.PSPPayment) {
+	for i := 1; i < len(payments); i++ {
+		Expect(payments[i-1].CreatedAt.After(payments[i].CreatedAt)).To(BeFalse())
+	}
+}
+
+// timeEq matches a time.Time argument by instant (time.Equal), ignoring location and
+// monotonic-clock differences that survive JSON round-trips through connector state.
+type timeEqMatcher struct{ t time.Time }
+
+func (m timeEqMatcher) Matches(x any) bool {
+	t, ok := x.(time.Time)
+	return ok && t.Equal(m.t)
+}
+
+func (m timeEqMatcher) String() string {
+	return fmt.Sprintf("is the time %s", m.t)
+}
+
+func timeEq(t time.Time) gomock.Matcher {
+	return timeEqMatcher{t: t}
+}
 
 var _ = Describe("Modulr Plugin Transaction to Payments", func() {
 	var (


### PR DESCRIPTION
## EN-1088 — [Modulr] State watermark uses PostedDate instead of TransactionDate → data loss

https://formance-team.atlassian.net/browse/EN-1088

### Problem
The payments watermark (`paymentsState.LastTransactionTime`) was set from `payments[last].CreatedAt`, which maps to **PostedDate** for ordinary payments and **CreatedDate** for transfers — *not* the **TransactionDate** that the API filter (`fromTransactionDate`) and the client-side skip actually compare. `PostedDate` lags `TransactionDate`, so the watermark drifted: forward jumps silently dropped transactions; backward jumps caused re-scans/duplicates.

While fixing this I confirmed (by running the connector) a second, deeper defect: the transactions endpoint returns results **newest-first** and exposes **no sort parameter**, so the old "advance to the last element of the page" logic dropped **every transaction older than the newest `PageSize`** for any account with more than one page.

### Fix
Each poll drains a frozen window `(LastTransactionTime, Ceiling]` one page at a time, across successive `FetchNextPayments` calls:

1. **open** — peek the newest page (page 0) to freeze `Ceiling` (the watermark we'll commit) and read `TotalPages`, which gives the oldest page index.
2. **descend** — walk `NextPage` from the oldest page (`TotalPages-1`) down to page 0, **reversing each page** so the whole window is emitted **oldest-first**; commit the watermark to `Ceiling` only after page 0.

Why oldest-first: the engine seeds a payment's base row from the *first* adjustment it sees per reference (`storage.PaymentsUpsert` uses `ON CONFLICT (id) DO NOTHING`; effective status is derived from the latest adjustment, amounts are commutative deltas). Each call returns at most ~`PageSize` payments (Temporal-safe), and the watermark advances only when the window is fully drained, so an interrupted drain simply re-runs the window (idempotent by reference).

**Migration:** `paymentsState` is versioned; pre-fix state (PostedDate-derived watermark, no window fields) is reset once so the corrected logic re-ingests available history — idempotent, no duplicates downstream.

### Changes
- `client/transactions.go` + `client/client.go`: `GetTransactions` gains a `toTransactionDate` bound and returns `totalPages`; mock regenerated.
- `payments.go`: windowed open/descend drain, `transactionDate` watermark, state versioning + migration reset.
- `payments_test.go`: newest-first sample data with `PostedDate` lagging `TransactionDate`; specs for single-page, multi-page oldest-first drain, incremental, migration, and corrupt-state recovery.

### Testing
- `internal/.../modulr` unit tests: **58/58 pass**
- `go build ./...`: clean · `just lint`: **0 issues**
- Full `just tests`: only sandbox-blocked packages fail (httptest port-bind + Docker socket); not exercised here — relying on CI.

### Known assumption
The descent **trusts Modulr's `TotalPages`** to locate the oldest page. An *over*-report is harmless (empty pages emit nothing as we descend); an *under*-report would skip the older pages (data loss). An earlier revision verified the bottom by probing past the hint, but that was dropped to keep this PR simple — if `TotalPages` ever proves unreliable, re-adding a bottom-seek is the drop-in fix. Back-dated transactions arriving below the committed watermark are the universal incremental-sync limitation (same as every other connector), not specific to this design.