### PR TITLE
fix(moneycorp): EN-555 prevent panic on empty transfer/payout response

### DIFF
--- a/internal/connectors/plugins/public/moneycorp/client/client.go
+++ b/internal/connectors/plugins/public/moneycorp/client/client.go
@@ -36,30 +36,7 @@ func New(connectorName, clientID, apiKey, endpoint string) *client {
 			endpoint:      endpoint,
 			underlying:    otelhttp.NewTransport(http.DefaultTransport),
 		}}),
-		HttpErrorCheckerFn: func(statusCode int) error {
-			switch statusCode {
-			case http.StatusTooManyRequests:
-				return httpwrapper.ErrStatusCodeTooManyRequests
-			case http.StatusRequestTimeout:
-				return httpwrapper.ErrStatusCodeRequestTimeout
-			case http.StatusMisdirectedRequest:
-				return httpwrapper.ErrStatusCodeMisdirectedRequest
-			case http.StatusLocked:
-				return httpwrapper.ErrStatusCodeLocked
-			case http.StatusTooEarly:
-				return httpwrapper.ErrStatusCodeTooEarly
-			}
-
-			if statusCode == http.StatusNotFound {
-				return nil
-			} else if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
-				return httpwrapper.ErrStatusCodeClientError
-			} else if statusCode >= http.StatusInternalServerError {
-				return httpwrapper.ErrStatusCodeServerError
-			}
-			return nil
-
-		},
+		HttpErrorCheckerFn: httpErrorCheckerFn,
 	}
 	endpoint = strings.TrimSuffix(endpoint, "/")
 
@@ -67,4 +44,35 @@ func New(connectorName, clientID, apiKey, endpoint string) *client {
 		httpClient: httpwrapper.NewClient(config),
 		endpoint:   endpoint,
 	}
+}
+
+// httpErrorCheckerFn maps Moneycorp HTTP status codes to httpwrapper errors.
+//
+// Note: 404 is intentionally treated as a non-error here. Moneycorp returns it
+// for legitimate "empty" read states (e.g. an account with no balances), and
+// the read paths rely on that (see GetAccountBalances). Write paths must not
+// dereference the resulting empty body — InitiateTransfer/InitiatePayout guard
+// against a nil response explicitly.
+func httpErrorCheckerFn(statusCode int) error {
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		return httpwrapper.ErrStatusCodeTooManyRequests
+	case http.StatusRequestTimeout:
+		return httpwrapper.ErrStatusCodeRequestTimeout
+	case http.StatusMisdirectedRequest:
+		return httpwrapper.ErrStatusCodeMisdirectedRequest
+	case http.StatusLocked:
+		return httpwrapper.ErrStatusCodeLocked
+	case http.StatusTooEarly:
+		return httpwrapper.ErrStatusCodeTooEarly
+	}
+
+	if statusCode == http.StatusNotFound {
+		return nil
+	} else if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+		return httpwrapper.ErrStatusCodeClientError
+	} else if statusCode >= http.StatusInternalServerError {
+		return httpwrapper.ErrStatusCodeServerError
+	}
+	return nil
 }

--- a/internal/connectors/plugins/public/moneycorp/client/client_test.go
+++ b/internal/connectors/plugins/public/moneycorp/client/client_test.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/formancehq/payments/pkg/domain/httpwrapper"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient builds a client wired to a test HTTP server, using the real
+// httpErrorCheckerFn so the 404 -> nil mapping is exercised exactly as in
+// production. The OAuth apiTransport is intentionally bypassed.
+func newTestClient(handler http.HandlerFunc) (*client, *httptest.Server) {
+	server := httptest.NewServer(handler)
+	httpClient := httpwrapper.NewClient(&httpwrapper.Config{
+		HttpErrorCheckerFn: httpErrorCheckerFn,
+		Timeout:            10 * time.Second,
+	})
+	return &client{httpClient: httpClient, endpoint: server.URL}, server
+}
+
+func TestHttpErrorCheckerFn(t *testing.T) {
+	t.Parallel()
+
+	// 404 is intentionally swallowed so read paths can treat it as an empty
+	// state; write paths guard against the resulting nil body themselves.
+	require.NoError(t, httpErrorCheckerFn(http.StatusNotFound))
+
+	require.ErrorIs(t, httpErrorCheckerFn(http.StatusBadRequest), httpwrapper.ErrStatusCodeClientError)
+	require.ErrorIs(t, httpErrorCheckerFn(http.StatusForbidden), httpwrapper.ErrStatusCodeClientError)
+	require.ErrorIs(t, httpErrorCheckerFn(http.StatusInternalServerError), httpwrapper.ErrStatusCodeServerError)
+	require.ErrorIs(t, httpErrorCheckerFn(http.StatusTooManyRequests), httpwrapper.ErrStatusCodeTooManyRequests)
+	require.NoError(t, httpErrorCheckerFn(http.StatusOK))
+}

--- a/internal/connectors/plugins/public/moneycorp/client/payouts.go
+++ b/internal/connectors/plugins/public/moneycorp/client/payouts.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/pkg/domain/metrics"
+	"github.com/formancehq/payments/pkg/domain/models"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
 )
 
@@ -87,6 +88,17 @@ func (c *client) InitiatePayout(ctx context.Context, pr *PayoutRequest) (*Payout
 		return nil, errorsutils.NewWrappedError(
 			fmt.Errorf("failed to initiate payout: %v", errRes.Error()),
 			err,
+		)
+	}
+
+	// A 404 (e.g. unknown source account) is mapped to a nil error by the
+	// client's HttpErrorCheckerFn, leaving an empty body and a nil Payout.
+	// Surface it as a non-retryable invalid request instead of letting the
+	// caller dereference a nil pointer.
+	if res.Payout == nil {
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("moneycorp returned an empty response when initiating payout"),
+			models.ErrInvalidRequest,
 		)
 	}
 

--- a/internal/connectors/plugins/public/moneycorp/client/payouts_test.go
+++ b/internal/connectors/plugins/public/moneycorp/client/payouts_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitiatePayout_404DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// Moneycorp answers 404 when the source account is unknown. The error
+	// checker maps it to a nil error, so the body is empty and Payout is nil.
+	// The client must surface a non-retryable error, not panic.
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"account not found"}]}`))
+	})
+	defer server.Close()
+
+	resp, err := c.InitiatePayout(context.Background(), &PayoutRequest{SourceAccountID: "123"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, models.ErrInvalidRequest)
+}
+
+func TestInitiatePayout_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	resp, err := c.InitiatePayout(context.Background(), &PayoutRequest{SourceAccountID: "123"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, models.ErrInvalidRequest)
+	require.Contains(t, err.Error(), "empty response")
+}
+
+func TestInitiatePayout_Success(t *testing.T) {
+	t.Parallel()
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(payoutResponse{Payout: &PayoutResponse{ID: "po_1"}})
+	})
+	defer server.Close()
+
+	resp, err := c.InitiatePayout(context.Background(), &PayoutRequest{SourceAccountID: "123"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, "po_1", resp.ID)
+}

--- a/internal/connectors/plugins/public/moneycorp/client/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transfers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/payments/pkg/domain/metrics"
+	"github.com/formancehq/payments/pkg/domain/models"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
 )
 
@@ -81,6 +82,17 @@ func (c *client) InitiateTransfer(ctx context.Context, tr *TransferRequest) (*Tr
 		)
 	}
 
+	// A 404 (e.g. unknown source account) is mapped to a nil error by the
+	// client's HttpErrorCheckerFn, leaving an empty body and a nil Transfer.
+	// Surface it as a non-retryable invalid request instead of letting the
+	// caller dereference a nil pointer.
+	if transferResponse.Transfer == nil {
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("moneycorp returned an empty response when initiating transfer"),
+			models.ErrInvalidRequest,
+		)
+	}
+
 	return transferResponse.Transfer, nil
 }
 
@@ -101,6 +113,16 @@ func (c *client) GetTransfer(ctx context.Context, accountID string, transferID s
 		return nil, errorsutils.NewWrappedError(
 			fmt.Errorf("failed to get transfer: %v", errRes.Error()),
 			err,
+		)
+	}
+
+	// A 404 is mapped to a nil error by the client's HttpErrorCheckerFn,
+	// leaving an empty body and a nil Transfer. Surface it instead of
+	// letting the caller dereference a nil pointer.
+	if transferResponse.Transfer == nil {
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("moneycorp returned an empty response when getting transfer"),
+			models.ErrInvalidRequest,
 		)
 	}
 

--- a/internal/connectors/plugins/public/moneycorp/client/transfers_test.go
+++ b/internal/connectors/plugins/public/moneycorp/client/transfers_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitiateTransfer_404DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// Moneycorp answers 404 when the source account is unknown. The error
+	// checker maps it to a nil error, so the body is empty and Transfer is
+	// nil. The client must surface a non-retryable error, not panic.
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"account not found"}]}`))
+	})
+	defer server.Close()
+
+	resp, err := c.InitiateTransfer(context.Background(), &TransferRequest{SourceAccountID: "123"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, models.ErrInvalidRequest)
+}
+
+func TestInitiateTransfer_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	resp, err := c.InitiateTransfer(context.Background(), &TransferRequest{SourceAccountID: "123"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, models.ErrInvalidRequest)
+	require.Contains(t, err.Error(), "empty response")
+}
+
+func TestInitiateTransfer_Success(t *testing.T) {
+	t.Parallel()
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(transferResponse{Transfer: &TransferResponse{ID: "tr_1"}})
+	})
+	defer server.Close()
+
+	resp, err := c.InitiateTransfer(context.Background(), &TransferRequest{SourceAccountID: "123"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, "tr_1", resp.ID)
+}
+
+func TestGetTransfer_404DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	resp, err := c.GetTransfer(context.Background(), "123", "tr_1")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, models.ErrInvalidRequest)
+}

--- a/internal/connectors/plugins/public/moneycorp/conversion_nil_test.go
+++ b/internal/connectors/plugins/public/moneycorp/conversion_nil_test.go
@@ -1,0 +1,25 @@
+package moneycorp
+
+import (
+	"github.com/formancehq/payments/pkg/domain/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Moneycorp nil response conversion", func() {
+	Context("transferToPayment", func() {
+		It("returns an invalid-request error for a nil transfer", func() {
+			payment, err := transferToPayment(nil)
+			Expect(payment).To(BeNil())
+			Expect(err).To(MatchError(models.ErrInvalidRequest))
+		})
+	})
+
+	Context("payoutToPayment", func() {
+		It("returns an invalid-request error for a nil payout", func() {
+			payment, err := payoutToPayment(nil)
+			Expect(payment).To(BeNil())
+			Expect(err).To(MatchError(models.ErrInvalidRequest))
+		})
+	})
+})

--- a/internal/connectors/plugins/public/moneycorp/payouts.go
+++ b/internal/connectors/plugins/public/moneycorp/payouts.go
@@ -55,6 +55,13 @@ func (p *Plugin) createPayout(ctx context.Context, pi models.PSPPaymentInitiatio
 }
 
 func payoutToPayment(from *client.PayoutResponse) (*models.PSPPayment, error) {
+	if from == nil {
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("cannot convert a nil payout to a payment"),
+			models.ErrInvalidRequest,
+		)
+	}
+
 	raw, err := json.Marshal(from)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal transaction: %w", err)

--- a/internal/connectors/plugins/public/moneycorp/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers.go
@@ -54,6 +54,13 @@ func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiat
 }
 
 func transferToPayment(transfer *client.TransferResponse) (*models.PSPPayment, error) {
+	if transfer == nil {
+		return nil, errorsutils.NewWrappedError(
+			fmt.Errorf("cannot convert a nil transfer to a payment"),
+			models.ErrInvalidRequest,
+		)
+	}
+
 	raw, err := json.Marshal(transfer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal transaction: %w", err)


### PR DESCRIPTION
## Summary

Fixes [EN-555] — a nil-pointer panic in the MoneyCorp connector when creating a transfer (and the same shape for payouts).

MoneyCorp's `HttpErrorCheckerFn` maps `404 → nil` so **read** paths can treat "not found" as an empty state (e.g. an account with no balances). On **write** paths this left `InitiateTransfer`/`InitiatePayout` returning a `nil *Response` on a swallowed 404 (unknown source account), which the plugin then dereferenced in `transferToPayment`/`payoutToPayment` → worker panic.

## Approach

Guard the **write** paths rather than changing the global 404 mapping (the read paths — pagination and deleted-account polling — depend on `404 → nil`, and MoneyCorp is the only connector relying on it):

- `InitiateTransfer`, `GetTransfer`, `InitiatePayout` now return a **non-retryable** `"empty response"` error (wrapped with `models.ErrInvalidRequest`) when the parsed pointer is nil after a successful call.
- `transferToPayment` / `payoutToPayment` defensively reject a nil input.
- Extracted the inline checker into `httpErrorCheckerFn` for testability (behavior unchanged, `404 → nil` kept).

`models.ErrInvalidRequest` → `plugins.ErrInvalidClientRequest` → Temporal `NonRetryableApplicationError`, so a bad transfer/payout request fails fast instead of retrying indefinitely.

## Why not remove the `404 → nil` branch (as the ticket suggested)

Tracing the callers, the global removal would turn out-of-range pagination pages and deleted-account reads (`GetRecipients`/`GetTransactions`) into non-retryable poll failures. MoneyCorp is the only connector with this mapping, and `GetAccountBalances` already has an explicit per-call `404 → empty` guard, showing MoneyCorp does 404 on normal reads. Scoping the fix to the write path achieves the ticket's goal (no panic, non-retryable bad request) with zero read-path risk.

## Tests

- `client`: 404 → error (no panic), empty-body → error, success, and `httpErrorCheckerFn` mapping (404→nil, 4xx→client error, 5xx→server error).
- plugin: `transferToPayment(nil)` / `payoutToPayment(nil)` → `ErrInvalidRequest`.

## Verification

- `just pc` — passes (lint 0 issues; openapi warnings pre-existing; code-samples step non-blocking).
- `go test ./...moneycorp/...` — all pass.

[EN-555]: https://formance-team.atlassian.net/browse/EN-555