### PR TITLE
fix(connectors): EN-1342 return 400 for malformed install JSON body

### DIFF
--- a/internal/connectors/manager.go
+++ b/internal/connectors/manager.go
@@ -78,7 +78,9 @@ func (m *manager) Load(connectorModel models.Connector, updateExisting bool, str
 
 	config := m.configurer.DefaultConfig()
 	if err := json.Unmarshal(connectorModel.Config, &config); err != nil {
-		return "", nil, err
+		// A malformed JSON body is a client error: classify it as invalid config
+		// so install/update surfaces a 400 rather than a 500.
+		return "", nil, fmt.Errorf("%w: %w", models.ErrInvalidConfig, err)
 	}
 
 	// Check if plugin is already installed

--- a/internal/connectors/manager_test.go
+++ b/internal/connectors/manager_test.go
@@ -166,6 +166,30 @@ func TestManager_Load_ClientErrors(t *testing.T) {
 	}
 }
 
+func TestManager_Load_MalformedConfig(t *testing.T) {
+	t.Parallel()
+
+	minimumPollingPeriod := time.Second
+	defaultPollingPeriod := 3 * time.Minute
+	logger := logging.NewDefaultLogger(io.Discard, false, false, false)
+
+	manager := NewManager(logger, false, defaultPollingPeriod, minimumPollingPeriod)
+	connectorID := models.ConnectorID{Reference: uuid.New(), Provider: registry.DummyPSPName}
+	connector := models.Connector{
+		ConnectorBase: models.ConnectorBase{
+			ID:       connectorID,
+			Provider: registry.DummyPSPName,
+		},
+		// Malformed JSON body: must be reported as invalid config (=> API 400)
+		// rather than bubbling up as an unclassified error (=> API 500).
+		Config: json.RawMessage(`{bad-json`),
+	}
+
+	_, _, err := manager.Load(connector, false, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, models.ErrInvalidConfig)
+}
+
 func TestManager_Unload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## EN-1342

[EN-1342](https://formance-team.atlassian.net/browse/EN-1342) / [#765](https://github.com/formancehq/payments/issues/765): `POST /v3/connectors/install/{provider}` with a malformed JSON body returned **500 INTERNAL** instead of **400**. Found by heal.dev E2E (scenario CI-S3).

## Root cause

`manager.Load()` unmarshals the base connector config and returned the raw `json` error. `engine.InstallConnector` only reclassifies `validator.ValidationErrors` / `models.ErrInvalidConfig` as `ErrValidation`; the unwrapped JSON error fell through to `handleServiceErrors`' default branch → 500.

Valid-JSON-but-invalid-config already returned 400 (provider config unmarshal + validation are classified), so only the malformed-JSON path was wrong.

## Fix

Wrap the base-config unmarshal error with `models.ErrInvalidConfig` (same pattern already used for the provider-config and polling-period paths). `InstallConnector` then wraps it as `ErrValidation` → **400**. Fixes both v2 and v3 via the shared engine path.

## Tests / verification
- New `TestManager_Load_MalformedConfig` asserts a malformed body surfaces as `models.ErrInvalidConfig`.
- Existing engine test already covers `Load → ErrInvalidConfig ⇒ ErrValidation`, completing the chain to a 400.
- `just lint` → 0 issues · `go test ./internal/connectors/...` + engine pass.
- The heal.dev E2E test (CI-S3) is untouched.

[EN-1342]: https://formance-team.atlassian.net/browse/EN-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ