### PR TITLE
fix(connectors): EN-1344 return 4xx for uninstall of non-existent connector

### DIFF
--- a/internal/api/v3/handler_connectors_uninstall.go
+++ b/internal/api/v3/handler_connectors_uninstall.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/payments/internal/api/backend"
-	"github.com/formancehq/payments/internal/api/common"
-	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -31,7 +30,7 @@ func connectorsUninstall(backend backend.Backend) http.HandlerFunc {
 		task, err := backend.ConnectorsUninstall(ctx, connectorID)
 		if err != nil {
 			otel.RecordError(span, err)
-			common.InternalServerError(w, r, err)
+			handleServiceErrors(w, r, err)
 			return
 		}
 

--- a/internal/api/v3/handler_connectors_uninstall_test.go
+++ b/internal/api/v3/handler_connectors_uninstall_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/formancehq/payments/internal/api/backend"
+	"github.com/formancehq/payments/internal/storage"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -45,6 +46,20 @@ var _ = Describe("API v3 Connectors uninstall", func() {
 			m.EXPECT().ConnectorsUninstall(gomock.Any(), gomock.Any()).Return(models.Task{}, expectedErr)
 			handlerFn(w, prepareQueryRequest(http.MethodGet, "connectorID", connID.String()))
 			assertExpectedResponse(w.Result(), http.StatusInternalServerError, "INTERNAL")
+		})
+
+		// A non-existent connector trips the tasks->connectors foreign key when the
+		// uninstall task is upserted; this must be a 4xx, not a 500 (EN-1344 / CU-S3).
+		It("should return a 4xx (not a 500) when the connector does not exist", func(ctx SpecContext) {
+			m.EXPECT().ConnectorsUninstall(gomock.Any(), gomock.Any()).Return(models.Task{}, storage.ErrForeignKeyViolation)
+			handlerFn(w, prepareQueryRequest(http.MethodGet, "connectorID", connID.String()))
+			assertExpectedResponse(w.Result(), http.StatusBadRequest, "VALIDATION")
+		})
+
+		It("should map a not found error to 404", func(ctx SpecContext) {
+			m.EXPECT().ConnectorsUninstall(gomock.Any(), gomock.Any()).Return(models.Task{}, storage.ErrNotFound)
+			handlerFn(w, prepareQueryRequest(http.MethodGet, "connectorID", connID.String()))
+			assertExpectedResponse(w.Result(), http.StatusNotFound, "NOT_FOUND")
 		})
 
 		It("should return status accepted on success", func(ctx SpecContext) {


### PR DESCRIPTION
## EN-1344

[EN-1344](https://formance-team.atlassian.net/browse/EN-1344) / [#767](https://github.com/formancehq/payments/issues/767): `DELETE /v3/connectors/{id}` for a well-formed but non-existent connector id returned **500 INTERNAL** instead of a 4xx. Found by heal.dev E2E (scenario CU-S3).

## Root cause

The v3 uninstall handler is the odd one out: it routed **every** backend error through `common.InternalServerError` (always 500). v2's uninstall handler — and every other v3 connector handler (install, config, reset, list, …) — use `handleServiceErrors`, which already maps storage errors to the right 4xx.

For a non-existent connector the flow is:
1. `ConnectorsScheduleForDeletion` is a 0-row `UPDATE` → no error.
2. `TasksUpsert` inserts the uninstall task, which trips the `tasks_connector_id_fk` foreign key (`tasks.connector_id → connectors(id)`). The transaction rolls back, so **no uninstall is started**.
3. `e()` maps that to `storage.ErrForeignKeyViolation` — which the handler discarded into a 500.

## Fix

Route the error through `handleServiceErrors` (matching v2 and the other v3 handlers). The FK violation now maps to **400 VALIDATION** — a clean 4xx, no uninstall started.

A dedicated 404 would require an explicit existence check in `engine.UninstallConnector`, which changes shared engine behaviour (including v2) and is out of scope; a 4xx already satisfies CU-S3.

## Tests / verification
- New handler cases: a foreign-key violation (the real missing-connector path) → **400**, and `storage.ErrNotFound` → **404**; the existing generic-error → 500 case is unchanged (unmapped errors still 500).
- `just lint` → 0 issues · `go test ./internal/api/v3/...` pass.
- The heal.dev E2E test (CU-S3) is untouched.

[EN-1344]: https://formance-team.atlassian.net/browse/EN-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ