### PR TITLE
fix(payments): EN-1345/1346/1347 payment-initiation validation & reverse workflow id

### DIFF
--- a/internal/api/v3/handler_payment_initiations_create.go
+++ b/internal/api/v3/handler_payment_initiations_create.go
@@ -11,8 +11,8 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
-	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -23,7 +23,7 @@ type PaymentInitiationsCreateRequest struct {
 	ConnectorID string    `json:"connectorID" validate:"required,connectorID"`
 	Description string    `json:"description" validate:"omitempty,lte=10000"`
 	Type        string    `json:"type" validate:"required,paymentInitiationType"`
-	Amount      *big.Int  `json:"amount" validate:"required"`
+	Amount      *big.Int  `json:"amount" validate:"required,gtZero"`
 	Asset       string    `json:"asset" validate:"required,asset"`
 
 	SourceAccountID      *string `json:"sourceAccountID" validate:"omitempty,accountID"`

--- a/internal/api/v3/handler_payment_initiations_reverse.go
+++ b/internal/api/v3/handler_payment_initiations_reverse.go
@@ -10,8 +10,8 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/payments/internal/api/backend"
 	"github.com/formancehq/payments/internal/api/validation"
-	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -19,7 +19,7 @@ import (
 type PaymentInitiationsReverseRequest struct {
 	Reference   string            `json:"reference" validate:"required,gte=3,lte=1000"`
 	Description string            `json:"description" validate:"omitempty,lte=10000"`
-	Amount      *big.Int          `json:"amount" validate:"required"`
+	Amount      *big.Int          `json:"amount" validate:"required,gtZero"`
 	Asset       string            `json:"asset" validate:"required,asset"`
 	Metadata    map[string]string `json:"metadata" validate:""`
 }

--- a/internal/api/validation/checkers.go
+++ b/internal/api/validation/checkers.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"math/big"
 	"regexp"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -163,6 +164,20 @@ func IsEmail(fl validator.FieldLevel) bool {
 	}
 
 	return emailRegexp.MatchString(str)
+}
+
+// IsPositiveBigInt reports whether the field holds a strictly positive
+// (*)big.Int. The validator dereferences non-nil pointers before calling this,
+// so both big.Int and *big.Int are handled; a nil pointer is left to `required`.
+func IsPositiveBigInt(fl validator.FieldLevel) bool {
+	switch v := fl.Field().Interface().(type) {
+	case big.Int:
+		return v.Sign() > 0
+	case *big.Int:
+		return v != nil && v.Sign() > 0
+	default:
+		return false
+	}
 }
 
 func IsLocale(fl validator.FieldLevel) bool {

--- a/internal/api/validation/validation.go
+++ b/internal/api/validation/validation.go
@@ -45,6 +45,7 @@ func NewValidator() *Validator {
 	registerCustomChecker("phoneNumber", IsPhoneNumber, "", validate, translator)
 	registerCustomChecker("email", IsEmail, "", validate, translator)
 	registerCustomChecker("locale", IsLocale, "", validate, translator)
+	registerCustomChecker("gtZero", IsPositiveBigInt, "{0} must be greater than 0", validate, translator)
 	return &Validator{
 		internal:   validate,
 		translator: translator,

--- a/internal/api/validation/validation_test.go
+++ b/internal/api/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
@@ -227,6 +228,17 @@ var _ = Describe("Validator custom type checks", func() {
 			Entry("locale: unsupported type for this matcher", "locale", "FieldName", struct {
 				FieldName int `validate:"locale"`
 			}{FieldName: 34}),
+
+			// gtZero
+			Entry("gtZero: negative amount on required field", "gtZero", "FieldName", struct {
+				FieldName *big.Int `validate:"required,gtZero"`
+			}{FieldName: big.NewInt(-100)}),
+			Entry("gtZero: zero amount on required field", "gtZero", "FieldName", struct {
+				FieldName *big.Int `validate:"required,gtZero"`
+			}{FieldName: big.NewInt(0)}),
+			Entry("gtZero: unsupported type for this matcher", "gtZero", "FieldName", struct {
+				FieldName int `validate:"gtZero"`
+			}{FieldName: 5}),
 		)
 
 		It("connectorID supports expected values", func(ctx SpecContext) {
@@ -310,6 +322,12 @@ var _ = Describe("Validator custom type checks", func() {
 				Email:         "dev@formance.com",
 				EmailNullable: pointer.For("dev@formance.com"),
 			})
+			Expect(err).To(BeNil())
+		})
+		It("gtZero supports strictly positive amounts", func(ctx SpecContext) {
+			_, err := validate.Validate(struct {
+				FieldName *big.Int `validate:"required,gtZero"`
+			}{FieldName: big.NewInt(100)})
 			Expect(err).To(BeNil())
 		})
 		It("language supports expected values", func(ctx SpecContext) {

--- a/internal/connectors/engine/engine.go
+++ b/internal/connectors/engine/engine.go
@@ -17,10 +17,10 @@ import (
 	"github.com/formancehq/payments/internal/connectors/engine/utils"
 	"github.com/formancehq/payments/internal/connectors/engine/workflow"
 	"github.com/formancehq/payments/internal/connectors/plugins/registry"
-	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/internal/otel"
 	"github.com/formancehq/payments/internal/storage"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -621,7 +621,10 @@ func (e *engine) ReverseTransfer(ctx context.Context, reversal models.PaymentIni
 	e.wg.Add(1)
 	defer e.wg.Done()
 
-	id := models.TaskIDReference(fmt.Sprintf("reverse-transfer-%s-%s", e.stack, reversal.CreatedAt.String()), reversal.ConnectorID, reversal.ID.String())
+	// The reversal.ID already uniquely identifies this reversal (reference +
+	// connector); including reversal.CreatedAt.String() here only bloated the
+	// Temporal workflow id past its length limit (EN-1346/EN-1347).
+	id := models.TaskIDReference(fmt.Sprintf("reverse-transfer-%s", e.stack), reversal.ConnectorID, reversal.ID.String())
 	now := time.Now().UTC()
 	task := models.Task{
 		ID: models.TaskID{
@@ -741,7 +744,10 @@ func (e *engine) ReversePayout(ctx context.Context, reversal models.PaymentIniti
 	e.wg.Add(1)
 	defer e.wg.Done()
 
-	id := models.TaskIDReference(fmt.Sprintf("reverse-payout-%s-%s", e.stack, reversal.CreatedAt.String()), reversal.ConnectorID, reversal.ID.String())
+	// The reversal.ID already uniquely identifies this reversal (reference +
+	// connector); including reversal.CreatedAt.String() here only bloated the
+	// Temporal workflow id past its length limit (EN-1346/EN-1347).
+	id := models.TaskIDReference(fmt.Sprintf("reverse-payout-%s", e.stack), reversal.ConnectorID, reversal.ID.String())
 	now := time.Now().UTC()
 	task := models.Task{
 		ID: models.TaskID{

--- a/internal/connectors/engine/engine_test.go
+++ b/internal/connectors/engine/engine_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/formancehq/payments/internal/connectors/engine"
 	"github.com/formancehq/payments/internal/connectors/engine/activities"
 	"github.com/formancehq/payments/internal/connectors/engine/workflow"
-	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/internal/storage"
+	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1250,6 +1250,56 @@ var _ = Describe("Engine Tests", func() {
 
 			_, err := eng.CreateTransfer(ctx, piID, 0, false)
 			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("reversing a payment initiation", func() {
+		var (
+			reverseConnID models.ConnectorID
+			reversal      models.PaymentInitiationReversal
+		)
+		BeforeEach(func() {
+			reverseConnID = models.ConnectorID{Reference: uuid.New(), Provider: "dummypay"}
+			reversal = models.PaymentInitiationReversal{
+				ID:          models.PaymentInitiationReversalID{Reference: "ref", ConnectorID: reverseConnID},
+				ConnectorID: reverseConnID,
+				Reference:   "ref",
+				CreatedAt:   time.Now().UTC(),
+			}
+		})
+
+		// EN-1346/EN-1347: the reverse workflow id must not embed the verbose
+		// CreatedAt timestamp, which pushed it past Temporal's WorkflowId length limit.
+		It("builds a reverse-payout workflow id without the CreatedAt timestamp", func(ctx SpecContext) {
+			var capturedID string
+			store.EXPECT().TasksUpsert(gomock.Any(), gomock.AssignableToTypeOf(models.Task{})).Return(nil)
+			cl.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), workflow.RunReversePayout, gomock.AssignableToTypeOf(workflow.ReversePayout{})).
+				DoAndReturn(func(_ interface{}, options client.StartWorkflowOptions, _ interface{}, _ workflow.ReversePayout) (client.WorkflowRun, error) {
+					capturedID = options.ID
+					return nil, nil
+				})
+
+			_, err := eng.ReversePayout(ctx, reversal, false)
+			Expect(err).To(BeNil())
+			Expect(capturedID).To(HavePrefix("reverse-payout-"))
+			Expect(capturedID).NotTo(ContainSubstring(reversal.CreatedAt.String()))
+			Expect(strings.ContainsAny(capturedID, " ")).To(BeFalse())
+		})
+
+		It("builds a reverse-transfer workflow id without the CreatedAt timestamp", func(ctx SpecContext) {
+			var capturedID string
+			store.EXPECT().TasksUpsert(gomock.Any(), gomock.AssignableToTypeOf(models.Task{})).Return(nil)
+			cl.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), workflow.RunReverseTransfer, gomock.AssignableToTypeOf(workflow.ReverseTransfer{})).
+				DoAndReturn(func(_ interface{}, options client.StartWorkflowOptions, _ interface{}, _ workflow.ReverseTransfer) (client.WorkflowRun, error) {
+					capturedID = options.ID
+					return nil, nil
+				})
+
+			_, err := eng.ReverseTransfer(ctx, reversal, false)
+			Expect(err).To(BeNil())
+			Expect(capturedID).To(HavePrefix("reverse-transfer-"))
+			Expect(capturedID).NotTo(ContainSubstring(reversal.CreatedAt.String()))
+			Expect(strings.ContainsAny(capturedID, " ")).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
Three heal.dev payment-initiation bugs, split into two commits by root cause.

## EN-1345 — reject non-positive amount ([#768](https://github.com/formancehq/payments/issues/768))
`POST /v3/payment-initiations` accepted `amount: -100` (and `0`) and recorded the initiation. The `Amount` (`*big.Int`) field was validated only as `required`, which only guards a nil pointer.

**Fix:** new `gtZero` custom validator (strictly positive `big.Int`), applied to the create **and** reverse request amounts → non-positive amount now returns **400 VALIDATION**.

## EN-1346 + EN-1347 — reverse returns 500 ([#769](https://github.com/formancehq/payments/issues/769), [#770](https://github.com/formancehq/payments/issues/770))
Reversing a payment initiation (EN-1346) or a payout (EN-1347) returned **500** with `"WorkflowId length exceeds limit."`. Both land in `engine.ReverseTransfer` / `engine.ReversePayout`, whose Temporal `WorkflowId` embedded `reversal.CreatedAt.String()` — a verbose, space-containing Go timestamp (~55 chars) — on top of the connector id and the reversal id. That's the only thing making these ids longer than the working `CreatePayout`/`CreateTransfer` ids.

**Fix:** drop the `CreatedAt` timestamp from both ids. `reversal.ID` already uniquely identifies the reversal (reference + connector), so uniqueness/idempotency is preserved and the construction now matches the proven-good create ids.

## Commits
1. `EN-1345` — non-positive amount guard (validation + both handlers)
2. `EN-1346/EN-1347` — shorten reverse-payout/transfer workflow id (engine)

## Tests / verification
- `gtZero` validator: negative/zero rejected, positive accepted (`validation_test.go`).
- Engine: new assertions that the reverse-payout and reverse-transfer workflow ids contain no whitespace and do not embed `CreatedAt` (would fail on the old code).
- `just lint` → 0 issues · `go test ./internal/api/validation/... ./internal/api/v3/... ./internal/connectors/engine/` pass.
- heal.dev E2E specs (PIC-S8, payment-initiation-reverse, payout-to-external-account) untouched.