### PR TITLE
fix(ci): EN-1372 cap goreleaser build parallelism to avoid OOM

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -77,11 +77,11 @@ release-local:
 
 [group('releases')]
 release-ci:
-    @goreleaser release --nightly --clean
+    @goreleaser release --nightly --clean --parallelism 2
 
 [group('releases')]
 release:
-    @goreleaser release --clean
+    @goreleaser release --clean --parallelism 2
 
 [group('deploy')]
 deploy server auth-token application additional-args:


### PR DESCRIPTION
## What

Cap GoReleaser build parallelism to `2` in the `release-ci` (nightly) and `release` (tagged) recipes.

```diff
 release-ci:
-    @goreleaser release --nightly --clean
+    @goreleaser release --nightly --clean --parallelism 2

 release:
-    @goreleaser release --clean
+    @goreleaser release --clean --parallelism 2
```

## Why

The **GoReleaser** nightly job on `main` has been failing intermittently since ~2026-06-09 and almost continuously over the past week. Every failure is identical:

```
build failed: exit status 1: github.com/plaid/plaid-go/v34/plaid:
  .../go-1.26.1/.../compile: signal: killed
target=linux_amd64_v1
```

`signal: killed` (no panic) = the Go compiler is **OOM-killed**. It always dies on `github.com/plaid/plaid-go/v34/plaid`, a generated single-package monolith (**1,778 files / ~463K lines / 17 MB** of source). The Go compiler holds a whole package in memory at once.

GoReleaser's default build parallelism equals the CPU count, so the `namespace-profile-linux-amd64-4vcpu` (~8 GB) runner compiled all **4 targets** (CE/EE × amd64/arm64) concurrently — 4 simultaneous copies of that huge compile exhausted RAM. It's intermittent because it's a marginal OOM. Capping to `-p 2` means at most two heavy compiles run at once, roughly halving peak memory.

## Alternatives considered

- **Upgrade plaid-go** — rejected: newer majors are *larger* (v42.2.0 is 2,030 files / ~535K lines, +15%), which would make the OOM worse.
- **Build-tag plaid out of the CE binary** — not viable: plaid is a **public/CE connector** (`internal/connectors/plugins/public/plaid`), imported by both `generated_ce.go` (`//go:build !ee`) and `generated_ee.go` (`//go:build ee`). It's compiled into all editions by design; excluding it would drop the connector from the product.
- **Bigger runner** (`8vcpu`) — viable fallback if `-p 2` still OOMs, but it has a per-run cost; the parallelism cap is zero-cost.

## Testing

Cannot reproduce GoReleaser locally (requires license + CI secrets). Validation is the nightly CI run on `main` once merged.

Closes EN-1372.