### PR TITLE
fix(connectors): EN-1348 return 404 for webhook with no registered config

### DIFF
--- a/internal/connectors/engine/engine.go
+++ b/internal/connectors/engine/engine.go
@@ -1310,7 +1310,7 @@ func (e *engine) verifyAndTrimWebhook(ctx context.Context, urlPath string, webho
 	}
 
 	if config == nil {
-		return nil, nil, errors.New("webhook config not found")
+		return nil, nil, fmt.Errorf("webhook config %w", ErrNotFound)
 	}
 
 	config.FullURL, err = url.JoinPath(e.stackPublicURL, "/api/payments/v3", urlPath)

--- a/internal/connectors/engine/engine_test.go
+++ b/internal/connectors/engine/engine_test.go
@@ -1316,5 +1316,18 @@ var _ = Describe("Engine Tests", func() {
 			err := eng.HandleWebhook(ctx, "/url", "/path", webhook)
 			Expect(err).To(MatchError(expectedErr))
 		})
+
+		It("should return ErrNotFound when connector has no matching webhook config", func(ctx SpecContext) {
+			connector := &models.Connector{
+				ConnectorBase: models.ConnectorBase{
+					ID: connectorID,
+				},
+			}
+			store.EXPECT().ConnectorsGet(gomock.Any(), connectorID).Return(connector, nil)
+			manager.EXPECT().Get(connectorID).Return(models.NewMockPlugin(gomock.NewController(GinkgoT())), nil)
+			store.EXPECT().WebhooksConfigsGetFromConnectorID(gomock.Any(), connectorID).Return(nil, nil)
+			err := eng.HandleWebhook(ctx, "/url", "/path", webhook)
+			Expect(err).To(MatchError(engine.ErrNotFound))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

Fixes [EN-1348](https://formance-team.atlassian.net/browse/EN-1348) (GitHub issue #771).

An inbound webhook `POST /v3/connectors/webhooks/{connectorID}/<path>` to a well-formed, installed connector that registers **no** matching webhook config returned **500 `{errorCode:INTERNAL}`** instead of a typed 4xx.

### Root cause
`engine.verifyAndTrimWebhook` returned a plain `errors.New("webhook config not found")` when no config matched. That unclassified error fell through `handleEngineErrors` and `handleServiceErrors` to `default → InternalServerError` → 500.

### Fix
Wrap the error with the existing `engine.ErrNotFound` sentinel (`fmt.Errorf("webhook config %w", ErrNotFound)` — the idiom used 5+ places in this file). It now flows `engine.ErrNotFound → services.ErrNotFound → api.NotFound → **404 NOT_FOUND**`, matching the sibling connector-uninstalled path directly above it.

Chose 404 over 501: the ticket asks for a "typed 4xx" (501 is 5xx), and 404 reuses existing plumbing with no new error codes. The fix is in the shared engine, so both v2 and v3 handlers benefit.

## Test
Added an engine test asserting `HandleWebhook` returns `engine.ErrNotFound` when the connector has no matching webhook config.

```
ok  github.com/formancehq/payments/internal/connectors/engine
```

## Notes
- `just pc` run clean (lint: 0 issues; no generated-file drift).
- The e2e spec `WE-edges.spec.ts` (WE-S3) that documented the 500 divergence lives in the external heal.dev harness, not this repo.

[EN-1348]: https://formance-team.atlassian.net/browse/EN-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ