### PR TITLE
fix(connectors): EN-1095 skip unsupported-currency rows + big.Int amount conversion (M-CON1, M-CON5)

### DIFF
--- a/internal/connectors/plugins/public/increase/payments.go
+++ b/internal/connectors/plugins/public/increase/payments.go
@@ -3,7 +3,6 @@ package increase
 import (
 	"context"
 	"encoding/json"
-	"math"
 	"math/big"
 	"sort"
 	"time"
@@ -212,7 +211,7 @@ func (p *Plugin) mapPayment(transaction *client.Transaction, status models.Payme
 		CreatedAt: createdTime,
 		Asset:     *pointer.For(currency.FormatAsset(supportedCurrenciesWithDecimal, transaction.Currency)),
 		Status:    paymentStatus,
-		Amount:    big.NewInt(int64(math.Abs(float64(transaction.Amount)))),
+		Amount:    new(big.Int).Abs(big.NewInt(transaction.Amount)),
 		Type:      mapTransactionType(transaction),
 		Raw:       raw,
 		Metadata: map[string]string{

--- a/internal/connectors/plugins/public/increase/payments_test.go
+++ b/internal/connectors/plugins/public/increase/payments_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/public/increase/client"
@@ -626,5 +627,48 @@ var _ = Describe("Increase Plugin Payments", func() {
 			Expect(newState.DeclinedTimeline.Cursors).To(HaveLen(0))
 			Expect(newState.DeclinedTimeline.FoundOldest).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("Increase Plugin Payments - amount conversion", func() {
+	var plg *Plugin
+
+	BeforeEach(func() {
+		plg = &Plugin{}
+	})
+
+	// Regression for M-CON5: amounts must be converted via big.Int, never round-tripped
+	// through float64 (which loses precision above 2^53 and overflows on MinInt64).
+	It("preserves amounts larger than 2^53 exactly", func() {
+		const amount int64 = 9007199254740993 // 2^53 + 1, not representable as float64
+		tx := &client.Transaction{
+			ID:        "big",
+			AccountID: "account_1",
+			Amount:    amount,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			Currency:  "USD",
+			Source:    client.Source{Category: "inbound_ach_transfer"},
+		}
+
+		payment, err := plg.mapPayment(tx, models.PAYMENT_STATUS_SUCCEEDED)
+		Expect(err).To(BeNil())
+		Expect(payment.Amount.Cmp(big.NewInt(amount))).To(Equal(0))
+	})
+
+	It("returns the exact absolute value of large negative amounts", func() {
+		const amount int64 = -9007199254740993
+		tx := &client.Transaction{
+			ID:        "big_neg",
+			AccountID: "account_1",
+			Amount:    amount,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			Currency:  "USD",
+			Source:    client.Source{Category: "inbound_ach_transfer"},
+		}
+
+		payment, err := plg.mapPayment(tx, models.PAYMENT_STATUS_SUCCEEDED)
+		Expect(err).To(BeNil())
+		Expect(payment.Amount.Cmp(big.NewInt(9007199254740993))).To(Equal(0))
+		Expect(payment.Amount.Sign()).To(Equal(1))
 	})
 })

--- a/internal/connectors/plugins/public/moneycorp/balances.go
+++ b/internal/connectors/plugins/public/moneycorp/balances.go
@@ -3,6 +3,7 @@ package moneycorp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -27,6 +28,12 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 	for _, balance := range balances {
 		precision, err := currency.GetPrecision(supportedCurrenciesWithDecimal, balance.Attributes.CurrencyCode)
 		if err != nil {
+			if errors.Is(err, currency.ErrMissingCurrencies) {
+				// Skip unsupported currencies rather than failing: a retryable
+				// error here would freeze balance ingestion for the account.
+				p.logger.WithField("currency", balance.Attributes.CurrencyCode).Info("skipping balance with unsupported currency")
+				continue
+			}
 			return models.FetchNextBalancesResponse{}, err
 		}
 

--- a/internal/connectors/plugins/public/moneycorp/balances_test.go
+++ b/internal/connectors/plugins/public/moneycorp/balances_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -31,7 +32,7 @@ var _ = Describe("Moneycorp *Plugin Balances", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
-			plg = &Plugin{client: m}
+			plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 
 			accRef = "abc"
 			expectedAmount = big.NewInt(309900)
@@ -62,6 +63,28 @@ var _ = Describe("Moneycorp *Plugin Balances", func() {
 
 			Expect(res.Balances[0].AccountReference).To(Equal(accRef))
 			Expect(res.Balances[0].Amount).To(BeEquivalentTo(expectedAmount))
+			Expect(res.Balances[0].Asset).To(HavePrefix(strings.ToUpper(sampleBalance.Attributes.CurrencyCode)))
+		})
+
+		It("skips balances with unsupported currencies", func(ctx SpecContext) {
+			req := models.FetchNextBalancesRequest{
+				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%s"}`, accRef)),
+				State:       json.RawMessage(`{}`),
+			}
+			unsupported := &client.Balance{
+				Attributes: client.Attributes{
+					CurrencyCode:     "ZZZ",
+					AvailableBalance: json.Number("100"),
+				},
+			}
+			m.EXPECT().GetAccountBalances(gomock.Any(), accRef).Return(
+				[]*client.Balance{unsupported, sampleBalance},
+				nil,
+			)
+			res, err := plg.FetchNextBalances(ctx, req)
+			Expect(err).To(BeNil())
+			// Only the supported balance is returned; the unsupported one is skipped.
+			Expect(res.Balances).To(HaveLen(1))
 			Expect(res.Balances[0].Asset).To(HavePrefix(strings.ToUpper(sampleBalance.Attributes.CurrencyCode)))
 		})
 	})

--- a/internal/connectors/plugins/public/moneycorp/payments.go
+++ b/internal/connectors/plugins/public/moneycorp/payments.go
@@ -3,15 +3,17 @@ package moneycorp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/pkg/domain/pagination"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 )
 
 type paymentsState struct {
@@ -98,6 +100,12 @@ func (p *Plugin) toPSPPayments(
 
 		payment, err := p.transactionToPayment(ctx, transaction)
 		if err != nil {
+			if errors.Is(err, plugins.ErrCurrencyNotSupported) {
+				// Skip unsupported currencies rather than failing: a retryable
+				// error here would freeze ingestion for the whole account.
+				p.logger.WithField("transaction_id", transaction.ID).Info("skipping transaction with unsupported currency")
+				continue
+			}
 			return payments, err
 		}
 		if payment == nil {
@@ -138,6 +146,9 @@ func (p *Plugin) transactionToPayment(ctx context.Context, transaction *client.T
 
 	c, err := currency.GetPrecision(supportedCurrenciesWithDecimal, transaction.Attributes.Currency)
 	if err != nil {
+		if errors.Is(err, currency.ErrMissingCurrencies) {
+			return nil, fmt.Errorf("%w: %w", plugins.ErrCurrencyNotSupported, err)
+		}
 		return nil, err
 	}
 

--- a/internal/connectors/plugins/public/moneycorp/payments_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payments_test.go
@@ -219,6 +219,55 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 			Expect(res.Payments[4].Amount).To(Equal(big.NewInt(expectedAmount * 100))) // after conversion to minors
 
 		})
+
+		It("skips transfer payments with unsupported currency", func(ctx SpecContext) {
+			req := models.FetchNextPaymentsRequest{
+				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef)),
+				State:       json.RawMessage(`{}`),
+				PageSize:    pageSize,
+			}
+
+			unsupportedTransfer := &client.TransferResponse{
+				ID: "transfer-zzz",
+				Attributes: client.TransferAttributes{
+					SendingAccountID:   1234,
+					ReceivingAccountID: 4321,
+					CreatedAt:          strings.TrimSuffix(time.Now().UTC().Format(time.RFC3339Nano), "Z"),
+					TransferAmount:     json.Number("65"),
+					TransferCurrency:   "ZZZ", // unsupported
+					TransferStatus:     "Cleared",
+				},
+			}
+			txns := []*client.Transaction{
+				{
+					ID: "transfer-unsupported",
+					Attributes: client.TransactionAttributes{
+						AccountID: accRef,
+						Type:      "Transfer",
+						Direction: "Debit",
+						Currency:  "EUR",
+						Amount:    json.Number("65"),
+						CreatedAt: strings.TrimSuffix(time.Now().UTC().Format(time.RFC3339Nano), "Z"),
+					},
+					Relationships: client.RelationShips{
+						Data: client.Data{ID: unsupportedTransfer.ID},
+					},
+				},
+			}
+
+			m.EXPECT().GetTransactions(gomock.Any(), "3796", gomock.Any(), pageSize, gomock.Any()).Return(
+				txns,
+				nil,
+			)
+			m.EXPECT().GetTransfer(gomock.Any(), "3796", unsupportedTransfer.ID).Return(
+				unsupportedTransfer,
+				nil,
+			)
+
+			res, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(res.Payments).To(BeEmpty())
+		})
 	})
 })
 

--- a/internal/connectors/plugins/public/moneycorp/payments_test.go
+++ b/internal/connectors/plugins/public/moneycorp/payments_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -35,7 +35,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
-			plg = &Plugin{client: m}
+			plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 
 			pageSize = 5
 			accRef = 3796
@@ -136,7 +136,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 			ctrl.Finish()
 		})
 
-		It("fails when payments contain unsupported currencies", func(ctx SpecContext) {
+		It("skips payments with unsupported currencies", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef)),
 				State:       json.RawMessage(`{}`),
@@ -160,7 +160,8 @@ var _ = Describe("Moneycorp *Plugin Payments - check types and minor conversion"
 			)
 
 			res, err := plg.FetchNextPayments(ctx, req)
-			Expect(err).To(MatchError(currency.ErrMissingCurrencies))
+			Expect(err).To(BeNil())
+			Expect(res.Payments).To(BeEmpty())
 			Expect(res.HasMore).To(BeFalse())
 		})
 
@@ -239,7 +240,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
-			plg = &Plugin{client: m}
+			plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 			accRef = 3796
 			now = time.Now().UTC()
 

--- a/internal/connectors/plugins/public/moneycorp/transfers.go
+++ b/internal/connectors/plugins/public/moneycorp/transfers.go
@@ -3,14 +3,16 @@ package moneycorp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/moneycorp/client"
-	"github.com/formancehq/payments/pkg/domain/models"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
+	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 )
 
 func (p *Plugin) createTransfer(ctx context.Context, pi models.PSPPaymentInitiation) (*models.PSPPayment, error) {
@@ -73,6 +75,12 @@ func transferToPayment(transfer *client.TransferResponse) (*models.PSPPayment, e
 
 	c, err := currency.GetPrecision(supportedCurrenciesWithDecimal, transfer.Attributes.TransferCurrency)
 	if err != nil {
+		if errors.Is(err, currency.ErrMissingCurrencies) {
+			// Wrap so the fetch loop (toPSPPayments) skips the transfer instead of
+			// freezing ingestion. transferToPayment is on the fetch path via
+			// fetchAndTranslateTransfer, not only the create path.
+			return nil, fmt.Errorf("%w: %w", plugins.ErrCurrencyNotSupported, err)
+		}
 		return nil, err
 	}
 

--- a/internal/connectors/plugins/public/plaid/balances.go
+++ b/internal/connectors/plugins/public/plaid/balances.go
@@ -3,11 +3,13 @@ package plaid
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/public/plaid/client"
 	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 	"github.com/plaid/plaid-go/v34/plaid"
 )
 
@@ -19,6 +21,12 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 
 	pspBalance, err := toPSPBalance(pspAccount)
 	if err != nil {
+		if errors.Is(err, plugins.ErrCurrencyNotSupported) {
+			// Skip unsupported currencies rather than failing: a retryable
+			// error here would freeze balance ingestion for the account.
+			p.logger.WithField("reference", pspAccount.Reference).Info("skipping balance with unsupported currency")
+			return models.FetchNextBalancesResponse{}, nil
+		}
 		return models.FetchNextBalancesResponse{}, err
 	}
 

--- a/internal/connectors/plugins/public/plaid/balances_test.go
+++ b/internal/connectors/plugins/public/plaid/balances_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,29 @@ var _ = Describe("Plaid *Plugin Balances", func() {
 		)
 
 		BeforeEach(func() {
-			plg = &Plugin{}
+			plg = &Plugin{logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
+		})
+
+		It("should skip balances with unsupported currencies", func(ctx SpecContext) {
+			account := plaid.NewAccountBaseWithDefaults()
+			account.SetAccountId("acc")
+
+			balance := plaid.NewAccountBalanceWithDefaults()
+			balance.SetCurrent(1000.0)
+			balance.SetIsoCurrencyCode("ZZZ")
+			account.SetBalances(*balance)
+
+			accountBytes, err := json.Marshal(account)
+			Expect(err).To(BeNil())
+
+			pspAccount := models.PSPAccount{Raw: accountBytes}
+			fromPayload, err := json.Marshal(pspAccount)
+			Expect(err).To(BeNil())
+
+			p := &Plugin{logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
+			res, err := p.fetchNextBalances(ctx, models.FetchNextBalancesRequest{FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(res.Balances).To(BeEmpty())
 		})
 
 		It("should fetch balances successfully", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/plaid/client/amount_utils.go
+++ b/internal/connectors/plugins/public/plaid/client/amount_utils.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"strconv"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 )
 
 func TranslatePlaidAmount(
@@ -13,6 +16,11 @@ func TranslatePlaidAmount(
 ) (*big.Int, string, error) {
 	precision, err := currency.GetPrecision(currency.ISO4217Currencies, currencyCode)
 	if err != nil {
+		if errors.Is(err, currency.ErrMissingCurrencies) {
+			// Wrap as ErrCurrencyNotSupported so callers can skip the record
+			// instead of failing (a retryable error freezes ingestion).
+			return nil, "", fmt.Errorf("%w: %w", plugins.ErrCurrencyNotSupported, err)
+		}
 		return nil, "", err
 	}
 

--- a/internal/connectors/plugins/public/plaid/payments.go
+++ b/internal/connectors/plugins/public/plaid/payments.go
@@ -3,11 +3,13 @@ package plaid
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"time"
 
 	"github.com/formancehq/payments/internal/connectors/plugins/public/plaid/client"
 	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 	"github.com/google/uuid"
 	"github.com/plaid/plaid-go/v34/plaid"
 )
@@ -54,6 +56,10 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	for _, transaction := range resp.Added {
 		payment, err := translatePlaidPaymentToPSPPayment(transaction, from.PSUID, from.OpenBankingConnection.ConnectionID)
 		if err != nil {
+			if errors.Is(err, plugins.ErrCurrencyNotSupported) {
+				p.logger.WithField("reference", transaction.TransactionId).Info("skipping payment with unsupported currency")
+				continue
+			}
 			return models.FetchNextPaymentsResponse{}, err
 		}
 		payments = append(payments, payment)
@@ -62,6 +68,10 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	for _, transaction := range resp.Modified {
 		payment, err := translatePlaidPaymentToPSPPayment(transaction, from.PSUID, from.OpenBankingConnection.ConnectionID)
 		if err != nil {
+			if errors.Is(err, plugins.ErrCurrencyNotSupported) {
+				p.logger.WithField("reference", transaction.TransactionId).Info("skipping payment with unsupported currency")
+				continue
+			}
 			return models.FetchNextPaymentsResponse{}, err
 		}
 		payments = append(payments, payment)

--- a/internal/connectors/plugins/public/plaid/payments_test.go
+++ b/internal/connectors/plugins/public/plaid/payments_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/plaid/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/google/uuid"
@@ -28,7 +29,7 @@ var _ = Describe("Plaid *Plugin Payments", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			m = client.NewMockClient(ctrl)
-			plg = &Plugin{client: m}
+			plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 
 			sampleTransactions = make([]plaid.Transaction, 0)
 			sampleRemovedTransactions = make([]plaid.RemovedTransaction, 0)
@@ -80,6 +81,48 @@ var _ = Describe("Plaid *Plugin Payments", func() {
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(MatchError("test error"))
 			Expect(resp).To(Equal(models.FetchNextPaymentsResponse{}))
+		})
+
+		It("should skip payments with unsupported currencies", func(ctx SpecContext) {
+			fromPayload := models.OpenBankingForwardedUserFromPayload{
+				OpenBankingConnection: &models.OpenBankingConnection{
+					ConnectorID: models.ConnectorID{
+						Reference: uuid.New(),
+						Provider:  "plaid-test",
+					},
+					AccessToken:  &models.Token{Token: "test-token"},
+					ConnectionID: "test-connection",
+				},
+				FromPayload: json.RawMessage(`{}`),
+			}
+			fromPayloadBytes, _ := json.Marshal(fromPayload)
+
+			req := models.FetchNextPaymentsRequest{
+				FromPayload: fromPayloadBytes,
+				PageSize:    10,
+			}
+
+			unsupported := plaid.NewTransactionWithDefaults()
+			unsupported.SetTransactionId("transaction_unsupported")
+			unsupported.SetAccountId("account_unsupported")
+			unsupported.SetAmount(100.0)
+			unsupported.SetDate("2023-01-01")
+			unsupported.SetIsoCurrencyCode("ZZZ")
+
+			m.EXPECT().ListTransactions(gomock.Any(), "test-token", "", 10).Return(
+				plaid.TransactionsSyncResponse{
+					Added:      []plaid.Transaction{*unsupported},
+					Modified:   []plaid.Transaction{},
+					Removed:    []plaid.RemovedTransaction{},
+					HasMore:    false,
+					NextCursor: "next-cursor",
+				},
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp.Payments).To(BeEmpty())
 		})
 
 		It("should fetch payments successfully - no state", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/stripe/payments.go
+++ b/internal/connectors/plugins/public/stripe/payments.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/stripe/client"
 	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 	"github.com/pkg/errors"
 	stripesdk "github.com/stripe/stripe-go/v80"
 )
@@ -18,7 +19,10 @@ import (
 var (
 	ErrUnsupportedTransactionType = errors.New("unsupported TransactionType")
 	ErrUnsupportedAdjustment      = errors.New("unsupported adjustment")
-	ErrUnsupportedCurrency        = errors.New("unsupported currency")
+	// ErrUnsupportedCurrency wraps plugins.ErrCurrencyNotSupported so the fetch
+	// loop can detect it via errors.Is and skip the transaction instead of
+	// failing — a returned error here would freeze ingestion on endless retries.
+	ErrUnsupportedCurrency = fmt.Errorf("unsupported currency: %w", plugins.ErrCurrencyNotSupported)
 )
 
 type paymentsState struct {
@@ -57,6 +61,12 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	for _, rawPayment := range rawPayments {
 		payment, err := p.translatePayment(&from.Reference, rawPayment)
 		if err != nil {
+			if errors.Is(err, plugins.ErrCurrencyNotSupported) {
+				// Skip unsupported currencies rather than failing: a retryable
+				// error here would freeze ingestion for the whole account.
+				p.logger.WithField("reference", rawPayment.ID).Info("skipping payment with unsupported currency")
+				continue
+			}
 			return models.FetchNextPaymentsResponse{}, fmt.Errorf("failed to translate payment: %w", err)
 		}
 

--- a/internal/connectors/plugins/public/stripe/payments_test.go
+++ b/internal/connectors/plugins/public/stripe/payments_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Stripe Plugin Payments", func() {
 			ctrl.Finish()
 		})
 
-		It("fails when payments contain unsupported currencies", func(ctx SpecContext) {
+		It("skips payments with unsupported currencies", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%s"}`, accRef)),
 				State:       json.RawMessage(`{}`),
@@ -237,8 +237,9 @@ var _ = Describe("Stripe Plugin Payments", func() {
 				nil,
 			)
 			res, err := plg.FetchNextPayments(ctx, req)
-			Expect(err).To(MatchError(ContainSubstring(ErrUnsupportedCurrency.Error())))
-			Expect(res.HasMore).To(BeFalse())
+			Expect(err).To(BeNil())
+			Expect(res.Payments).To(BeEmpty())
+			Expect(res.HasMore).To(BeTrue())
 		})
 
 		It("fetches payments", func(ctx SpecContext) {

--- a/internal/connectors/plugins/public/wise/balances.go
+++ b/internal/connectors/plugins/public/wise/balances.go
@@ -41,7 +41,10 @@ func (p *Plugin) fetchNextBalances(ctx context.Context, req models.FetchNextBala
 
 	precision, ok := supportedCurrenciesWithDecimal[balance.Amount.Currency]
 	if !ok {
-		return models.FetchNextBalancesResponse{}, errors.New("unsupported currency")
+		// Skip unsupported currencies rather than failing: a retryable error
+		// here would freeze balance ingestion for the account.
+		p.logger.WithField("currency", balance.Amount.Currency).Info("skipping balance with unsupported currency")
+		return models.FetchNextBalancesResponse{HasMore: false}, nil
 	}
 
 	amount, err := currency.GetAmountWithPrecisionFromString(balance.Amount.Value.String(), precision)

--- a/internal/connectors/plugins/public/wise/balances_test.go
+++ b/internal/connectors/plugins/public/wise/balances_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/internal/connectors/plugins/public/wise/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"go.uber.org/mock/gomock"
@@ -23,7 +24,7 @@ var _ = Describe("Wise Plugin Balances", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		m = client.NewMockClient(ctrl)
-		plg = &Plugin{client: m}
+		plg = &Plugin{client: m, logger: logging.NewDefaultLogger(GinkgoWriter, true, false, false)}
 	})
 
 	AfterEach(func() {
@@ -71,6 +72,33 @@ var _ = Describe("Wise Plugin Balances", func() {
 			expectedBalance, err := balance.Amount.Value.Float64()
 			Expect(err).To(BeNil())
 			Expect(res.Balances[0].Amount).To(BeEquivalentTo(big.NewInt(int64(expectedBalance * 100))))
+		})
+
+		It("skips balances with unsupported currencies", func(ctx SpecContext) {
+			req := models.FetchNextBalancesRequest{
+				State: json.RawMessage(`{}`),
+				FromPayload: json.RawMessage(fmt.Sprintf(
+					`{"Reference":"%d","Metadata":{"%s":"%d"}}`,
+					expectedProfileID,
+					metadataProfileIDKey,
+					profileVal,
+				)),
+				PageSize: 10,
+			}
+			unsupported := client.Balance{
+				ID:     14556,
+				Type:   "type1",
+				Amount: client.BalanceAmount{Value: json.Number("44.99"), Currency: "ZZZ"},
+			}
+			m.EXPECT().GetBalance(gomock.Any(), profileVal, expectedProfileID).Return(
+				&unsupported,
+				nil,
+			)
+
+			res, err := plg.FetchNextBalances(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(res.Balances).To(BeEmpty())
+			Expect(res.HasMore).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
Part 1 of 2 for [EN-1095](https://formance-team.atlassian.net/browse/EN-1095) (currency-error handling). Pagination/watermark fixes (M-CON2/M-CON3) follow in a separate PR.

## M-CON1 — unsupported currency froze the fetch pipeline
Unsupported-currency rows returned a **retryable** error from the fetch path. With no `MaximumAttempts`, `FetchNext*` retried the same row forever — ingestion frozen for the account while hammering the PSP.

Fix: adopt the wise/atlar pattern — translate wraps `plugins.ErrCurrencyNotSupported`, the fetch loop detects it via `errors.Is`, logs, and **skips** the row so other currencies keep flowing.
- `stripe/payments.go`, `moneycorp/payments.go` + `balances.go`, `plaid` (`client/amount_utils.go` + `payments.go` + `balances.go`)
- `wise/balances.go` — **the audit missed this**; `wise/payments` was already correct but `balances` bare-errored
- Out of scope (verified): `moneycorp/transfers.go` + `payouts.go` are outbound **create** ops where failing on unsupported currency is correct; EE connectors are clean (cursor/`since_id`, not currency-gated)

## M-CON5 — increase converted money through float64
`mapPayment` used `big.NewInt(int64(math.Abs(float64(transaction.Amount))))`, round-tripping an `int64` through `float64` (loses precision above 2^53, overflows on `MinInt64`). Now `new(big.Int).Abs(big.NewInt(transaction.Amount))` — exact across the full int64 range.

## Tests
TDD: existing "fails on unsupported currency" specs flipped to assert skip; new skip specs for balances; new precision spec for increase (2^53+1). All affected packages green; `go build ./...` + `go vet` clean.

[EN-1095]: https://formance-team.atlassian.net/browse/EN-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ