### PR TITLE
fix(connectors): EN-1095 harmonize watermark pagination — keep same-timestamp rows (M-CON2, M-CON3)

### DIFF
--- a/ce/plugins/bankingcircle/payments.go
+++ b/ce/plugins/bankingcircle/payments.go
@@ -3,6 +3,7 @@ package bankingcircle
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -13,12 +14,15 @@ import (
 
 type paymentsState struct {
 	LatestStatusChangedTimestamp time.Time `json:"latestStatusChangedTimestamp"`
-	// LatestProcessedID is the PaymentID of the last payment emitted at exactly
-	// LatestStatusChangedTimestamp. It lets the watermark filter be inclusive
-	// (>=) without re-skipping distinct payments that share that timestamp: only
-	// the exact already-processed row is excluded, so the rest of a same-second
-	// group are kept (storage upserts dedup any harmless re-emission).
-	LatestProcessedID string `json:"latestProcessedID"`
+	// LatestProcessedIDs holds the PaymentIDs of ALL payments already emitted at
+	// exactly LatestStatusChangedTimestamp, accumulated across cycles while the
+	// watermark second is unchanged and reset when it advances. BankingCircle has
+	// no server-side time filter (we rescan the list from page 1 and filter
+	// client-side), so a single boundary ID is not enough: a same-second group
+	// larger than PageSize would re-emit earlier siblings and oscillate, never
+	// reaching later rows. Tracking the whole set lets the inclusive (>=) filter
+	// skip every already-emitted sibling so the scan reaches new rows.
+	LatestProcessedIDs []string `json:"latestProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -31,7 +35,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 
 	newState := paymentsState{
 		LatestStatusChangedTimestamp: oldState.LatestStatusChangedTimestamp,
-		LatestProcessedID:            oldState.LatestProcessedID,
+		LatestProcessedIDs:           oldState.LatestProcessedIDs,
 	}
 
 	var payments []models.PSPPayment
@@ -65,8 +69,24 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	if len(payments) > 0 {
-		newState.LatestStatusChangedTimestamp = latestStatusChangedTimestamps[len(latestStatusChangedTimestamps)-1]
-		newState.LatestProcessedID = payments[len(payments)-1].Reference
+		lastTimestamp := latestStatusChangedTimestamps[len(latestStatusChangedTimestamps)-1]
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i, ts := range latestStatusChangedTimestamps {
+			if ts.Equal(lastTimestamp) {
+				idsAtWatermark = append(idsAtWatermark, payments[i].Reference)
+			}
+		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if lastTimestamp.Equal(oldState.LatestStatusChangedTimestamp) {
+			newState.LatestProcessedIDs = append(oldState.LatestProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LatestProcessedIDs = idsAtWatermark
+		}
+		newState.LatestStatusChangedTimestamp = lastTimestamp
 	}
 
 	payload, err := json.Marshal(newState)
@@ -93,7 +113,7 @@ func fillPayments(
 		// payments sharing that timestamp are kept (M-CON2: equal-timestamp rows
 		// were previously dropped at page/cycle boundaries).
 		cmp := payment.LatestStatusChangedTimestamp.Compare(oldState.LatestStatusChangedTimestamp)
-		if cmp < 0 || (cmp == 0 && payment.PaymentID == oldState.LatestProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LatestProcessedIDs, payment.PaymentID)) {
 			continue
 		}
 

--- a/ce/plugins/bankingcircle/payments.go
+++ b/ce/plugins/bankingcircle/payments.go
@@ -13,6 +13,12 @@ import (
 
 type paymentsState struct {
 	LatestStatusChangedTimestamp time.Time `json:"latestStatusChangedTimestamp"`
+	// LatestProcessedID is the PaymentID of the last payment emitted at exactly
+	// LatestStatusChangedTimestamp. It lets the watermark filter be inclusive
+	// (>=) without re-skipping distinct payments that share that timestamp: only
+	// the exact already-processed row is excluded, so the rest of a same-second
+	// group are kept (storage upserts dedup any harmless re-emission).
+	LatestProcessedID string `json:"latestProcessedID"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -25,6 +31,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 
 	newState := paymentsState{
 		LatestStatusChangedTimestamp: oldState.LatestStatusChangedTimestamp,
+		LatestProcessedID:            oldState.LatestProcessedID,
 	}
 
 	var payments []models.PSPPayment
@@ -49,11 +56,17 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	if !needMore {
+		// Trim both slices in lockstep so the watermark and LatestProcessedID are
+		// taken from the last *emitted* payment. Trimming only payments would set
+		// the watermark from a fetched-but-dropped payment and silently skip the
+		// trimmed ones on the next call.
 		payments = payments[:req.PageSize]
+		latestStatusChangedTimestamps = latestStatusChangedTimestamps[:req.PageSize]
 	}
 
 	if len(payments) > 0 {
 		newState.LatestStatusChangedTimestamp = latestStatusChangedTimestamps[len(latestStatusChangedTimestamps)-1]
+		newState.LatestProcessedID = payments[len(payments)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -75,10 +88,13 @@ func fillPayments(
 	oldState paymentsState,
 ) ([]models.PSPPayment, []time.Time, error) {
 	for _, payment := range pagedPayments {
-		switch payment.LatestStatusChangedTimestamp.Compare(oldState.LatestStatusChangedTimestamp) {
-		case -1, 0:
+		// Inclusive watermark: skip payments strictly before the watermark, and
+		// the single already-processed payment at exactly the watermark. Distinct
+		// payments sharing that timestamp are kept (M-CON2: equal-timestamp rows
+		// were previously dropped at page/cycle boundaries).
+		cmp := payment.LatestStatusChangedTimestamp.Compare(oldState.LatestStatusChangedTimestamp)
+		if cmp < 0 || (cmp == 0 && payment.PaymentID == oldState.LatestProcessedID) {
 			continue
-		default:
 		}
 
 		p, err := translatePayment(payment)

--- a/ce/plugins/bankingcircle/payments_test.go
+++ b/ce/plugins/bankingcircle/payments_test.go
@@ -1,6 +1,7 @@
 package bankingcircle
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -156,7 +157,7 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"latestStatusChangedTimestamp": "%s", "latestProcessedID": "%s"}`,
+					`{"latestStatusChangedTimestamp": "%s", "latestProcessedIDs": ["%s"]}`,
 					samplePayments[38].LatestStatusChangedTimestamp.UTC().Format(time.RFC3339Nano),
 					samplePayments[38].PaymentID,
 				)),
@@ -184,7 +185,7 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
 			Expect(state.LatestStatusChangedTimestamp.UTC()).To(Equal(samplePayments[49].LatestStatusChangedTimestamp.UTC()))
-			Expect(state.LatestProcessedID).To(Equal(samplePayments[49].PaymentID))
+			Expect(state.LatestProcessedIDs).To(ConsistOf(samplePayments[49].PaymentID))
 		})
 
 		It("keeps distinct payments that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
@@ -204,7 +205,7 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 			// Watermark sits exactly on the shared timestamp, with "a" already processed.
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"latestStatusChangedTimestamp": "%s", "latestProcessedID": "a"}`,
+					`{"latestStatusChangedTimestamp": "%s", "latestProcessedIDs": ["a"]}`,
 					ts.Format(time.RFC3339Nano),
 				)),
 				PageSize: 40,
@@ -238,6 +239,59 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 			// Indices 38..49: the boundary (38) re-emitted plus 39..49.
 			Expect(resp.Payments).To(HaveLen(12))
 			Expect(resp.Payments[0].Reference).To(Equal(samplePayments[38].PaymentID))
+		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) client.Payment {
+				return client.Payment{
+					PaymentID:                    id,
+					Status:                       "Processed",
+					ProcessedTimestamp:           ts,
+					LatestStatusChangedTimestamp: ts,
+					DebtorInformation:            client.DebtorInformation{AccountID: "123"},
+					Transfer:                     client.Transfer{Amount: client.Amount{Currency: "EUR", Amount: "120"}},
+				}
+			}
+			all := []client.Payment{mk("p0"), mk("p1"), mk("p2"), mk("p3"), mk("p4")}
+			// BankingCircle has no server filter: it rescans from page 1 each cycle.
+			// Serve the full list page by page so the processed-ID set has to skip
+			// already-emitted siblings to make progress.
+			m.EXPECT().GetPayments(gomock.Any(), gomock.Any(), 2).DoAndReturn(
+				func(_ context.Context, page, _ int) ([]client.Payment, error) {
+					start := (page - 1) * 2
+					if start >= len(all) {
+						return []client.Payment{}, nil
+					}
+					end := start + 2
+					if end > len(all) {
+						end = len(all)
+					}
+					return all[start:end], nil
+				},
+			).AnyTimes()
+			refs := func(ps []models.PSPPayment) []string {
+				out := make([]string, len(ps))
+				for i := range ps {
+					out[i] = ps[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: page 1 -> p0, p1.
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"p0", "p1"}))
+
+			// Cycle 2: rescan skips p0,p1 (in set), page 2 -> p2, p3.
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ConsistOf("p2", "p3"))
+
+			// Cycle 3: page 3 -> p4 (group fully drained, no stall).
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElement("p4"))
 		})
 	})
 })

--- a/ce/plugins/bankingcircle/payments_test.go
+++ b/ce/plugins/bankingcircle/payments_test.go
@@ -155,7 +155,11 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
-				State:    []byte(fmt.Sprintf(`{"latestStatusChangedTimestamp": "%s"}`, samplePayments[38].LatestStatusChangedTimestamp.UTC().Format(time.RFC3339Nano))),
+				State: []byte(fmt.Sprintf(
+					`{"latestStatusChangedTimestamp": "%s", "latestProcessedID": "%s"}`,
+					samplePayments[38].LatestStatusChangedTimestamp.UTC().Format(time.RFC3339Nano),
+					samplePayments[38].PaymentID,
+				)),
 				PageSize: 40,
 			}
 
@@ -180,6 +184,60 @@ var _ = Describe("BankingCircle Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
 			Expect(state.LatestStatusChangedTimestamp.UTC()).To(Equal(samplePayments[49].LatestStatusChangedTimestamp.UTC()))
+			Expect(state.LatestProcessedID).To(Equal(samplePayments[49].PaymentID))
+		})
+
+		It("keeps distinct payments that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			sameSecond := make([]client.Payment, 0, 3)
+			for _, id := range []string{"a", "b", "c"} {
+				sameSecond = append(sameSecond, client.Payment{
+					PaymentID:                    id,
+					Status:                       "Processed",
+					ProcessedTimestamp:           ts,
+					LatestStatusChangedTimestamp: ts,
+					DebtorInformation:            client.DebtorInformation{AccountID: "123"},
+					Transfer:                     client.Transfer{Amount: client.Amount{Currency: "EUR", Amount: "120"}},
+				})
+			}
+
+			// Watermark sits exactly on the shared timestamp, with "a" already processed.
+			req := models.FetchNextPaymentsRequest{
+				State: []byte(fmt.Sprintf(
+					`{"latestStatusChangedTimestamp": "%s", "latestProcessedID": "a"}`,
+					ts.Format(time.RFC3339Nano),
+				)),
+				PageSize: 40,
+			}
+
+			m.EXPECT().GetPayments(gomock.Any(), 1, 40).Return(sameSecond, nil)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			// "a" is the already-processed boundary row; "b" and "c" share its
+			// timestamp and must NOT be dropped.
+			Expect(resp.Payments).To(HaveLen(2))
+			refs := []string{resp.Payments[0].Reference, resp.Payments[1].Reference}
+			Expect(refs).To(ConsistOf("b", "c"))
+		})
+
+		It("re-emits the boundary payment once when migrating state without latestProcessedID", func(ctx SpecContext) {
+			// Old-format state: watermark only, no latestProcessedID. The row at
+			// exactly the watermark is re-emitted once (idempotent via upsert);
+			// no recrawl.
+			req := models.FetchNextPaymentsRequest{
+				State:    []byte(fmt.Sprintf(`{"latestStatusChangedTimestamp": "%s"}`, samplePayments[38].LatestStatusChangedTimestamp.UTC().Format(time.RFC3339Nano))),
+				PageSize: 40,
+			}
+
+			m.EXPECT().GetPayments(gomock.Any(), 1, 40).Return(samplePayments[:40], nil)
+			m.EXPECT().GetPayments(gomock.Any(), 2, 40).Return(samplePayments[40:], nil)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			// Indices 38..49: the boundary (38) re-emitted plus 39..49.
+			Expect(resp.Payments).To(HaveLen(12))
+			Expect(resp.Payments[0].Reference).To(Equal(samplePayments[38].PaymentID))
 		})
 	})
 })

--- a/ce/plugins/currencycloud/accounts.go
+++ b/ce/plugins/currencycloud/accounts.go
@@ -12,6 +12,10 @@ import (
 type accountsState struct {
 	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
+	// LastProcessedID is the reference of the last account emitted at exactly
+	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
+	// already-processed row while keeping distinct same-timestamp accounts.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -27,8 +31,9 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	}
 
 	newState := accountsState{
-		LastPage:      oldState.LastPage,
-		LastCreatedAt: oldState.LastCreatedAt,
+		LastPage:        oldState.LastPage,
+		LastCreatedAt:   oldState.LastCreatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	var accounts []models.PSPAccount
@@ -61,6 +66,7 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	newState.LastPage = page
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -81,11 +87,12 @@ func fillAccounts(
 	oldState accountsState,
 ) ([]models.PSPAccount, error) {
 	for _, account := range pagedAccounts {
-		switch account.CreatedAt.Compare(oldState.LastCreatedAt) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip accounts strictly before it, and the single
+		// already-processed account at exactly the watermark. Distinct accounts
+		// sharing that timestamp are kept (M-CON2).
+		cmp := account.CreatedAt.Compare(oldState.LastCreatedAt)
+		if cmp < 0 || (cmp == 0 && account.ID == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(account)

--- a/ce/plugins/currencycloud/accounts.go
+++ b/ce/plugins/currencycloud/accounts.go
@@ -3,6 +3,7 @@ package currencycloud
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/currencycloud/client"
@@ -10,12 +11,18 @@ import (
 )
 
 type accountsState struct {
-	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
-	// LastProcessedID is the reference of the last account emitted at exactly
-	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
-	// already-processed row while keeping distinct same-timestamp accounts.
-	LastProcessedID string `json:"lastProcessedID"`
+	// LastProcessedIDs holds the references of ALL accounts already emitted at
+	// exactly LastCreatedAt, accumulated across cycles while the watermark second
+	// is unchanged and reset when it advances. Each cycle rescans from page 1 and
+	// skips this whole set: a same-second group larger than PageSize is walked
+	// across cycles without a drifting page cursor, and a multi-row final page
+	// cannot oscillate (every already-emitted sibling is skipped, not just one).
+	//
+	// Migration: the old singular lastProcessedID and lastPage fields are ignored.
+	// After deploy the watermark second is re-emitted once (idempotent via storage
+	// upserts), with no recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -26,20 +33,18 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		}
 	}
 
-	if oldState.LastPage == 0 {
-		oldState.LastPage = 1
-	}
-
 	newState := accountsState{
-		LastPage:        oldState.LastPage,
-		LastCreatedAt:   oldState.LastCreatedAt,
-		LastProcessedID: oldState.LastProcessedID,
+		LastCreatedAt:    oldState.LastCreatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var accounts []models.PSPAccount
 	hasMore := false
-	page := oldState.LastPage
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. We do NOT trim back to PageSize.
+	for page := 1; ; page++ {
 		pagedAccounts, nextPage, err := p.client.GetAccounts(ctx, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
@@ -55,18 +60,32 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		}
 
 		var needMore bool
-		needMore, hasMore, accounts = shouldFetchMore(accounts, nextPage, req.PageSize)
+		// Ignore shouldFetchMore's trimmed slice; keep the full over-fetch.
+		needMore, hasMore, _ = shouldFetchMore(accounts, nextPage, req.PageSize)
 		if !needMore {
 			break
 		}
-
-		page = nextPage
 	}
 
-	newState.LastPage = page
 	if len(accounts) > 0 {
-		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		last := accounts[len(accounts)-1].CreatedAt
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if accounts[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
+			}
+		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastCreatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -87,11 +106,11 @@ func fillAccounts(
 	oldState accountsState,
 ) ([]models.PSPAccount, error) {
 	for _, account := range pagedAccounts {
-		// Inclusive watermark: skip accounts strictly before it, and the single
-		// already-processed account at exactly the watermark. Distinct accounts
-		// sharing that timestamp are kept (M-CON2).
+		// Inclusive watermark: skip accounts strictly before it, and any
+		// already-emitted account at exactly the watermark second. Distinct
+		// accounts sharing that timestamp are kept (M-CON2).
 		cmp := account.CreatedAt.Compare(oldState.LastCreatedAt)
-		if cmp < 0 || (cmp == 0 && account.ID == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, account.ID)) {
 			continue
 		}
 

--- a/ce/plugins/currencycloud/accounts.go
+++ b/ce/plugins/currencycloud/accounts.go
@@ -11,17 +11,19 @@ import (
 )
 
 type accountsState struct {
+	// LastPage is a monotonic forward cursor. This endpoint has NO server-side
+	// time filter, so resuming the scan here (re-reading only the last page, not
+	// the whole history each poll) avoids a full historical rescan on every sync.
+	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
 	// LastProcessedIDs holds the references of ALL accounts already emitted at
-	// exactly LastCreatedAt, accumulated across cycles while the watermark second
-	// is unchanged and reset when it advances. Each cycle rescans from page 1 and
-	// skips this whole set: a same-second group larger than PageSize is walked
-	// across cycles without a drifting page cursor, and a multi-row final page
-	// cannot oscillate (every already-emitted sibling is skipped, not just one).
+	// exactly LastCreatedAt, accumulated while the watermark second is unchanged
+	// and reset when it advances. It dedups same-second rows on the re-read page,
+	// so a multi-row boundary settles to empty instead of oscillating (a single
+	// LastProcessedID could exclude only one of several tied rows).
 	//
-	// Migration: the old singular lastProcessedID and lastPage fields are ignored.
-	// After deploy the watermark second is re-emitted once (idempotent via storage
-	// upserts), with no recrawl.
+	// Migration: the old singular lastProcessedID is ignored; the watermark second
+	// is re-emitted once after deploy (idempotent via storage upserts), no recrawl.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
@@ -33,18 +35,24 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		}
 	}
 
+	if oldState.LastPage == 0 {
+		oldState.LastPage = 1
+	}
+
 	newState := accountsState{
+		LastPage:         oldState.LastPage,
 		LastCreatedAt:    oldState.LastCreatedAt,
 		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var accounts []models.PSPAccount
 	hasMore := false
-	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
-	// every already-emitted sibling at the watermark second, so a same-second
-	// group larger than PageSize is walked across cycles and a multi-row final
+	// No server-side time filter: resume the monotonic forward scan at the
+	// persisted page (re-reading only the last page, not the whole history) and
+	// skip already-emitted same-second rows via the ID set, so a multi-row final
 	// page cannot oscillate. We do NOT trim back to PageSize.
-	for page := 1; ; page++ {
+	page := oldState.LastPage
+	for {
 		pagedAccounts, nextPage, err := p.client.GetAccounts(ctx, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
@@ -65,7 +73,9 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		if !needMore {
 			break
 		}
+		page = nextPage
 	}
+	newState.LastPage = page
 
 	if len(accounts) > 0 {
 		last := accounts[len(accounts)-1].CreatedAt

--- a/ce/plugins/currencycloud/accounts.go
+++ b/ce/plugins/currencycloud/accounts.go
@@ -24,6 +24,11 @@ type accountsState struct {
 	//
 	// Migration: the old singular lastProcessedID is ignored; the watermark second
 	// is re-emitted once after deploy (idempotent via storage upserts), no recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/currencycloud/accounts_test.go
+++ b/ce/plugins/currencycloud/accounts_test.go
@@ -147,7 +147,7 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s"}`, 1, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s", "lastProcessedID": "%s"}`, 1, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].ID)),
 				PageSize: 40,
 			}
 

--- a/ce/plugins/currencycloud/accounts_test.go
+++ b/ce/plugins/currencycloud/accounts_test.go
@@ -90,7 +90,6 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt.IsZero()).To(BeTrue())
 		})
 
@@ -116,7 +115,6 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt).To(Equal(sampleAccounts[49].CreatedAt))
 		})
 
@@ -141,13 +139,12 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 			var state accountsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt).To(Equal(sampleAccounts[39].CreatedAt))
 		})
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s", "lastProcessedID": "%s"}`, 1, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].ID)),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedIDs": ["%s"]}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].ID)),
 				PageSize: 40,
 			}
 
@@ -173,8 +170,64 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(2))
 			Expect(state.LastCreatedAt).To(Equal(sampleAccounts[49].CreatedAt))
+		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			// Five accounts all sharing the same CreatedAt second, fetched three per
+			// page so the group spans page 1 (a0,a1,a2) and a SHORT final page 2
+			// (a3,a4). Each cycle rescans from page 1 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting a3/a4 forever) instead of settling and advancing.
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) *client.Account {
+				return &client.Account{
+					ID:          id,
+					AccountName: "name-" + id,
+					CreatedAt:   ts,
+					UpdatedAt:   ts,
+				}
+			}
+			all := []*client.Account{mk("a0"), mk("a1"), mk("a2"), mk("a3"), mk("a4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: fresh state, page 1 -> a0, a1, a2.
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1", "a2"}))
+			Expect(resp.HasMore).To(BeTrue())
+
+			// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> a3, a4.
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a3", "a4"}))
+
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing (anti-oscillation).
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(BeEmpty())
+
+			// Cycle 4: a newer-second account a5 appears on the (formerly short)
+			// page 2. The set skips a3/a4 and reaches a5 — no stranding.
+			ts2 := ts.Add(time.Second)
+			a5 := &client.Account{ID: "a5", AccountName: "name-a5", CreatedAt: ts2, UpdatedAt: ts2}
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 3).Return([]*client.Account{all[3], all[4], a5}, -1, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a5"}))
 		})
 	})
 })

--- a/ce/plugins/currencycloud/accounts_test.go
+++ b/ce/plugins/currencycloud/accounts_test.go
@@ -176,9 +176,10 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
 			// Five accounts all sharing the same CreatedAt second, fetched three per
 			// page so the group spans page 1 (a0,a1,a2) and a SHORT final page 2
-			// (a3,a4). Each cycle rescans from page 1 and skips the processed-ID set;
-			// a single LastProcessedID would oscillate on the multi-row final page
-			// (re-emitting a3/a4 forever) instead of settling and advancing.
+			// (a3,a4). The monotonic LastPage cursor resumes the forward scan (no
+			// full rescan from page 1 once past it) and the processed-ID set dedups
+			// the same-second rows on the re-read page; a single LastProcessedID
+			// would oscillate on the multi-row final page (re-emitting a3/a4 forever).
 			ts := now.Add(-time.Hour).UTC()
 			mk := func(id string) *client.Account {
 				return &client.Account{
@@ -211,19 +212,18 @@ var _ = Describe("CurrencyCloud Plugin Accounts", func() {
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Accounts)).To(Equal([]string{"a3", "a4"}))
 
-			// Cycle 3: group fully drained — every row is in the processed-ID set, so
-			// the rescan returns nothing (anti-oscillation).
-			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			// Cycle 3: LastPage is now 2, so we resume there (NOT page 1) and re-read
+			// only the last page. Every row is in the processed-ID set, so it returns
+			// nothing (anti-oscillation) — and crucially does not rescan history.
 			m.EXPECT().GetAccounts(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Accounts)).To(BeEmpty())
 
 			// Cycle 4: a newer-second account a5 appears on the (formerly short)
-			// page 2. The set skips a3/a4 and reaches a5 — no stranding.
+			// page 2. Resuming at page 2, the set skips a3/a4 and reaches a5.
 			ts2 := ts.Add(time.Second)
 			a5 := &client.Account{ID: "a5", AccountName: "name-a5", CreatedAt: ts2, UpdatedAt: ts2}
-			m.EXPECT().GetAccounts(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
 			m.EXPECT().GetAccounts(gomock.Any(), 2, 3).Return([]*client.Account{all[3], all[4], a5}, -1, nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())

--- a/ce/plugins/currencycloud/client/transactions.go
+++ b/ce/plugins/currencycloud/client/transactions.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/formancehq/payments/pkg/domain/metrics"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
+	"github.com/formancehq/payments/pkg/domain/metrics"
 )
 
 //nolint:tagliatelle // allow different styled tags in client
@@ -48,6 +48,13 @@ func (c *client) GetTransactions(ctx context.Context, page int, pageSize int, up
 	q.Add("page", fmt.Sprint(page))
 	q.Add("per_page", fmt.Sprint(pageSize))
 	if !updatedAtFrom.IsZero() {
+		// Day-granular server filter: it re-pulls the whole watermark day each
+		// cycle (an over-fetch), but this is correctness-safe — the caller applies
+		// an inclusive watermark + per-ID dedup (EN-1095 M-CON2), so same-second
+		// rows are never lost regardless of server granularity. Tightening this to
+		// a second/datetime filter requires confirming CurrencyCloud's
+		// updated_at_from accepts an ISO8601 datetime and its inclusivity; left as
+		// a follow-up rather than risk an unverified format on a live connector.
 		q.Add("updated_at_from", updatedAtFrom.Format(time.DateOnly))
 	}
 	q.Add("order", "updated_at")

--- a/ce/plugins/currencycloud/external_accounts.go
+++ b/ce/plugins/currencycloud/external_accounts.go
@@ -3,6 +3,7 @@ package currencycloud
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/currencycloud/client"
@@ -10,12 +11,18 @@ import (
 )
 
 type externalAccountsState struct {
-	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
-	// LastProcessedID is the reference of the last beneficiary emitted at exactly
-	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
-	// already-processed row while keeping distinct same-timestamp beneficiaries.
-	LastProcessedID string `json:"lastProcessedID"`
+	// LastProcessedIDs holds the IDs of ALL beneficiaries already emitted at
+	// exactly LastCreatedAt, accumulated across cycles while the watermark second
+	// is unchanged and reset when it advances. Each cycle rescans from page 1 and
+	// skips this whole set: a same-second group larger than PageSize is walked
+	// across cycles without a drifting page cursor, and a multi-row final page
+	// cannot oscillate (every already-emitted sibling is skipped, not just one).
+	//
+	// Migration: the old singular lastProcessedID and lastPage fields are ignored.
+	// After deploy the watermark second is re-emitted once (idempotent via storage
+	// upserts), with no recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -26,20 +33,18 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		}
 	}
 
-	if oldState.LastPage == 0 {
-		oldState.LastPage = 1
-	}
-
 	newState := externalAccountsState{
-		LastPage:        oldState.LastPage,
-		LastCreatedAt:   oldState.LastCreatedAt,
-		LastProcessedID: oldState.LastProcessedID,
+		LastCreatedAt:    oldState.LastCreatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var accounts []models.PSPAccount
 	hasMore := false
-	page := oldState.LastPage
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. We do NOT trim back to PageSize.
+	for page := 1; ; page++ {
 		pagedBeneficiaries, nextPage, err := p.client.GetBeneficiaries(ctx, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
@@ -55,18 +60,32 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		}
 
 		var needMore bool
-		needMore, hasMore, accounts = shouldFetchMore(accounts, nextPage, req.PageSize)
+		// Ignore shouldFetchMore's trimmed slice; keep the full over-fetch.
+		needMore, hasMore, _ = shouldFetchMore(accounts, nextPage, req.PageSize)
 		if !needMore {
 			break
 		}
-
-		page = nextPage
 	}
 
-	newState.LastPage = page
 	if len(accounts) > 0 {
-		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		last := accounts[len(accounts)-1].CreatedAt
+
+		// Collect the IDs emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if accounts[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
+			}
+		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastCreatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -87,11 +106,11 @@ func fillBeneficiaries(
 	oldState externalAccountsState,
 ) ([]models.PSPAccount, error) {
 	for _, beneficiary := range pagedBeneficiaries {
-		// Inclusive watermark: skip beneficiaries strictly before it, and the single
-		// already-processed beneficiary at exactly the watermark. Distinct
+		// Inclusive watermark: skip beneficiaries strictly before it, and any
+		// already-emitted beneficiary at exactly the watermark second. Distinct
 		// beneficiaries sharing that timestamp are kept (M-CON2).
 		cmp := beneficiary.CreatedAt.Compare(oldState.LastCreatedAt)
-		if cmp < 0 || (cmp == 0 && beneficiary.ID == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, beneficiary.ID)) {
 			continue
 		}
 

--- a/ce/plugins/currencycloud/external_accounts.go
+++ b/ce/plugins/currencycloud/external_accounts.go
@@ -24,6 +24,11 @@ type externalAccountsState struct {
 	//
 	// Migration: the old singular lastProcessedID is ignored; the watermark second
 	// is re-emitted once after deploy (idempotent via storage upserts), no recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/currencycloud/external_accounts.go
+++ b/ce/plugins/currencycloud/external_accounts.go
@@ -12,6 +12,10 @@ import (
 type externalAccountsState struct {
 	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
+	// LastProcessedID is the reference of the last beneficiary emitted at exactly
+	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
+	// already-processed row while keeping distinct same-timestamp beneficiaries.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -27,8 +31,9 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	}
 
 	newState := externalAccountsState{
-		LastPage:      oldState.LastPage,
-		LastCreatedAt: oldState.LastCreatedAt,
+		LastPage:        oldState.LastPage,
+		LastCreatedAt:   oldState.LastCreatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	var accounts []models.PSPAccount
@@ -61,6 +66,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	newState.LastPage = page
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -81,11 +87,12 @@ func fillBeneficiaries(
 	oldState externalAccountsState,
 ) ([]models.PSPAccount, error) {
 	for _, beneficiary := range pagedBeneficiaries {
-		switch beneficiary.CreatedAt.Compare(oldState.LastCreatedAt) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip beneficiaries strictly before it, and the single
+		// already-processed beneficiary at exactly the watermark. Distinct
+		// beneficiaries sharing that timestamp are kept (M-CON2).
+		cmp := beneficiary.CreatedAt.Compare(oldState.LastCreatedAt)
+		if cmp < 0 || (cmp == 0 && beneficiary.ID == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(beneficiary)

--- a/ce/plugins/currencycloud/external_accounts.go
+++ b/ce/plugins/currencycloud/external_accounts.go
@@ -11,17 +11,19 @@ import (
 )
 
 type externalAccountsState struct {
+	// LastPage is a monotonic forward cursor. This endpoint has NO server-side
+	// time filter, so resuming the scan here (re-reading only the last page, not
+	// the whole history each poll) avoids a full historical rescan on every sync.
+	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
 	// LastProcessedIDs holds the IDs of ALL beneficiaries already emitted at
-	// exactly LastCreatedAt, accumulated across cycles while the watermark second
-	// is unchanged and reset when it advances. Each cycle rescans from page 1 and
-	// skips this whole set: a same-second group larger than PageSize is walked
-	// across cycles without a drifting page cursor, and a multi-row final page
-	// cannot oscillate (every already-emitted sibling is skipped, not just one).
+	// exactly LastCreatedAt, accumulated while the watermark second is unchanged
+	// and reset when it advances. It dedups same-second rows on the re-read page,
+	// so a multi-row boundary settles to empty instead of oscillating (a single
+	// LastProcessedID could exclude only one of several tied rows).
 	//
-	// Migration: the old singular lastProcessedID and lastPage fields are ignored.
-	// After deploy the watermark second is re-emitted once (idempotent via storage
-	// upserts), with no recrawl.
+	// Migration: the old singular lastProcessedID is ignored; the watermark second
+	// is re-emitted once after deploy (idempotent via storage upserts), no recrawl.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
@@ -33,18 +35,24 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		}
 	}
 
+	if oldState.LastPage == 0 {
+		oldState.LastPage = 1
+	}
+
 	newState := externalAccountsState{
+		LastPage:         oldState.LastPage,
 		LastCreatedAt:    oldState.LastCreatedAt,
 		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var accounts []models.PSPAccount
 	hasMore := false
-	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
-	// every already-emitted sibling at the watermark second, so a same-second
-	// group larger than PageSize is walked across cycles and a multi-row final
+	// No server-side time filter: resume the monotonic forward scan at the
+	// persisted page (re-reading only the last page, not the whole history) and
+	// skip already-emitted same-second rows via the ID set, so a multi-row final
 	// page cannot oscillate. We do NOT trim back to PageSize.
-	for page := 1; ; page++ {
+	page := oldState.LastPage
+	for {
 		pagedBeneficiaries, nextPage, err := p.client.GetBeneficiaries(ctx, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
@@ -65,7 +73,9 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		if !needMore {
 			break
 		}
+		page = nextPage
 	}
+	newState.LastPage = page
 
 	if len(accounts) > 0 {
 		last := accounts[len(accounts)-1].CreatedAt

--- a/ce/plugins/currencycloud/external_accounts_test.go
+++ b/ce/plugins/currencycloud/external_accounts_test.go
@@ -92,7 +92,6 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt.IsZero()).To(BeTrue())
 		})
 
@@ -118,7 +117,6 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt).To(Equal(sampleBeneficiaries[49].CreatedAt))
 		})
 
@@ -143,13 +141,12 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 			var state externalAccountsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreatedAt).To(Equal(sampleBeneficiaries[39].CreatedAt))
 		})
 
 		It("should fetch next external accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s", "lastProcessedID": "%s"}`, 1, sampleBeneficiaries[38].CreatedAt.Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedIDs": ["%s"]}`, sampleBeneficiaries[38].CreatedAt.Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
 				PageSize: 40,
 			}
 
@@ -175,8 +172,65 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(2))
 			Expect(state.LastCreatedAt).To(Equal(sampleBeneficiaries[49].CreatedAt))
+		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			// Five beneficiaries all sharing the same CreatedAt second, fetched three
+			// per page so the group spans page 1 (b0,b1,b2) and a SHORT final page 2
+			// (b3,b4). Each cycle rescans from page 1 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting b3/b4 forever) instead of settling and advancing.
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) *client.Beneficiary {
+				return &client.Beneficiary{
+					ID:                    id,
+					BankAccountHolderName: "name-" + id,
+					Name:                  "name-" + id,
+					Currency:              "EUR",
+					CreatedAt:             ts,
+				}
+			}
+			all := []*client.Beneficiary{mk("b0"), mk("b1"), mk("b2"), mk("b3"), mk("b4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: fresh state, page 1 -> b0, b1, b2.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1", "b2"}))
+			Expect(resp.HasMore).To(BeTrue())
+
+			// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> b3, b4.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b3", "b4"}))
+
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing (anti-oscillation).
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
+
+			// Cycle 4: a newer-second beneficiary b5 appears on the (formerly short)
+			// page 2. The set skips b3/b4 and reaches b5 — no stranding.
+			ts2 := ts.Add(time.Second)
+			b5 := &client.Beneficiary{ID: "b5", BankAccountHolderName: "name-b5", Name: "name-b5", Currency: "EUR", CreatedAt: ts2}
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3).Return([]*client.Beneficiary{all[3], all[4], b5}, -1, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b5"}))
 		})
 	})
 })

--- a/ce/plugins/currencycloud/external_accounts_test.go
+++ b/ce/plugins/currencycloud/external_accounts_test.go
@@ -178,9 +178,10 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
 			// Five beneficiaries all sharing the same CreatedAt second, fetched three
 			// per page so the group spans page 1 (b0,b1,b2) and a SHORT final page 2
-			// (b3,b4). Each cycle rescans from page 1 and skips the processed-ID set;
-			// a single LastProcessedID would oscillate on the multi-row final page
-			// (re-emitting b3/b4 forever) instead of settling and advancing.
+			// (b3,b4). The monotonic LastPage cursor resumes the forward scan (no full
+			// rescan from page 1 once past it) and the processed-ID set dedups the
+			// same-second rows on the re-read page; a single LastProcessedID would
+			// oscillate on the multi-row final page (re-emitting b3/b4 forever).
 			ts := now.Add(-time.Hour).UTC()
 			mk := func(id string) *client.Beneficiary {
 				return &client.Beneficiary{
@@ -214,19 +215,18 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b3", "b4"}))
 
-			// Cycle 3: group fully drained — every row is in the processed-ID set, so
-			// the rescan returns nothing (anti-oscillation).
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
+			// Cycle 3: LastPage is now 2, so we resume there (NOT page 1) and re-read
+			// only the last page. Every row is in the processed-ID set, so it returns
+			// nothing (anti-oscillation) — and crucially does not rescan history.
 			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3).Return(all[3:5], -1, nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
 
 			// Cycle 4: a newer-second beneficiary b5 appears on the (formerly short)
-			// page 2. The set skips b3/b4 and reaches b5 — no stranding.
+			// page 2. Resuming at page 2, the set skips b3/b4 and reaches b5.
 			ts2 := ts.Add(time.Second)
 			b5 := &client.Beneficiary{ID: "b5", BankAccountHolderName: "name-b5", Name: "name-b5", Currency: "EUR", CreatedAt: ts2}
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3).Return(all[0:3], 2, nil)
 			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3).Return([]*client.Beneficiary{all[3], all[4], b5}, -1, nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())

--- a/ce/plugins/currencycloud/external_accounts_test.go
+++ b/ce/plugins/currencycloud/external_accounts_test.go
@@ -149,7 +149,7 @@ var _ = Describe("CurrencyCloud Plugin External Accounts", func() {
 
 		It("should fetch next external accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s"}`, 1, sampleBeneficiaries[38].CreatedAt.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s", "lastProcessedID": "%s"}`, 1, sampleBeneficiaries[38].CreatedAt.Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
 				PageSize: 40,
 			}
 

--- a/ce/plugins/currencycloud/payments.go
+++ b/ce/plugins/currencycloud/payments.go
@@ -12,6 +12,10 @@ import (
 
 type paymentsState struct {
 	LastUpdatedAt time.Time `json:"lastUpdatedAt"`
+	// LastProcessedID is the transaction ID of the last transaction emitted at
+	// exactly LastUpdatedAt, so the inclusive (>=) watermark filter excludes only
+	// that already-processed row while keeping distinct same-timestamp rows.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -23,15 +27,20 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	newState := paymentsState{
-		LastUpdatedAt: oldState.LastUpdatedAt,
+		LastUpdatedAt:   oldState.LastUpdatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	var payments []models.PSPPayment
 	var updatedAts []time.Time
+	var processedIDs []string
 	hasMore := false
 	page := 1
 	for {
-		pagedTransactions, nextPage, err := p.client.GetTransactions(ctx, page, req.PageSize, newState.LastUpdatedAt)
+		// Filter against the STABLE watermark from oldState for the whole drain.
+		// Advancing it mid-pagination (the previous behaviour) would drop rows
+		// sharing a second across a page boundary and mutate the server filter.
+		pagedTransactions, nextPage, err := p.client.GetTransactions(ctx, page, req.PageSize, oldState.LastUpdatedAt)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
@@ -40,7 +49,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			break
 		}
 
-		payments, updatedAts, err = fillPayments(payments, updatedAts, pagedTransactions, newState)
+		payments, updatedAts, processedIDs, err = fillPayments(payments, updatedAts, processedIDs, pagedTransactions, oldState)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
@@ -48,19 +57,18 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		var needMore bool
 		needMore, hasMore, payments = shouldFetchMore(payments, nextPage, req.PageSize)
 
-		if len(payments) > 0 {
-			newState.LastUpdatedAt = updatedAts[len(payments)-1]
-		}
-
 		if !needMore {
 			break
 		}
 
-		if len(payments) > 0 {
-			newState.LastUpdatedAt = updatedAts[len(payments)-1]
-		}
-
 		page = nextPage
+	}
+
+	// Watermark and dedup key come from the last EMITTED payment, computed once
+	// after the drain (updatedAts/processedIDs stay aligned with payments by index).
+	if len(payments) > 0 {
+		newState.LastUpdatedAt = updatedAts[len(payments)-1]
+		newState.LastProcessedID = processedIDs[len(payments)-1]
 	}
 
 	payload, err := json.Marshal(newState)
@@ -78,28 +86,33 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 func fillPayments(
 	payments []models.PSPPayment,
 	updatedAts []time.Time,
+	processedIDs []string,
 	pagedTransactions []client.Transaction,
-	newState paymentsState,
-) ([]models.PSPPayment, []time.Time, error) {
+	oldState paymentsState,
+) ([]models.PSPPayment, []time.Time, []string, error) {
 	for _, transaction := range pagedTransactions {
-		switch transaction.UpdatedAt.Compare(newState.LastUpdatedAt) {
-		case -1, 0:
+		// Inclusive watermark: skip transactions strictly before it, and the single
+		// already-processed transaction at exactly the watermark. Distinct
+		// transactions sharing that timestamp are kept (M-CON2). Keyed on
+		// transaction.ID, which differs from payment.Reference (RelatedEntityID).
+		cmp := transaction.UpdatedAt.Compare(oldState.LastUpdatedAt)
+		if cmp < 0 || (cmp == 0 && transaction.ID == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		payment, err := transactionToPayment(transaction)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		if payment != nil {
 			payments = append(payments, *payment)
 			updatedAts = append(updatedAts, transaction.UpdatedAt)
+			processedIDs = append(processedIDs, transaction.ID)
 		}
 	}
 
-	return payments, updatedAts, nil
+	return payments, updatedAts, processedIDs, nil
 }
 
 func transactionToPayment(transaction client.Transaction) (*models.PSPPayment, error) {

--- a/ce/plugins/currencycloud/payments.go
+++ b/ce/plugins/currencycloud/payments.go
@@ -16,6 +16,13 @@ type paymentsState struct {
 	// exactly LastUpdatedAt, so the inclusive (>=) watermark filter excludes only
 	// that already-processed row while keeping distinct same-timestamp rows.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastUpdatedAt second
+	// (1-indexed). It advances while the watermark second is unchanged (a
+	// same-second group larger than one page) and resets to 1 once the watermark
+	// moves to a newer second, so a same-second group spanning pages is walked
+	// without re-scanning from page 1 each cycle (which a single LastProcessedID
+	// cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -25,21 +32,28 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 	}
+	if oldState.Page < 1 {
+		oldState.Page = 1
+	}
 
 	newState := paymentsState{
 		LastUpdatedAt:   oldState.LastUpdatedAt,
 		LastProcessedID: oldState.LastProcessedID,
+		Page:            oldState.Page,
 	}
 
 	var payments []models.PSPPayment
 	var updatedAts []time.Time
 	var processedIDs []string
 	hasMore := false
-	page := 1
+	// Resume at the persisted page and walk forward. We filter against the STABLE
+	// oldState watermark for the whole drain (advancing it mid-pagination would
+	// drop rows sharing a second across a page boundary and mutate the server
+	// filter), and we do NOT trim back to PageSize — that would skip the trimmed
+	// rows when resuming at the advanced page. The page cursor below records how
+	// far we got.
+	page := oldState.Page
 	for {
-		// Filter against the STABLE watermark from oldState for the whole drain.
-		// Advancing it mid-pagination (the previous behaviour) would drop rows
-		// sharing a second across a page boundary and mutate the server filter.
 		pagedTransactions, nextPage, err := p.client.GetTransactions(ctx, page, req.PageSize, oldState.LastUpdatedAt)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -55,13 +69,15 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		}
 
 		var needMore bool
-		needMore, hasMore, payments = shouldFetchMore(payments, nextPage, req.PageSize)
+		// Ignore shouldFetchMore's trimmed slice; keep the full over-fetch so the
+		// page cursor can resume cleanly.
+		needMore, hasMore, _ = shouldFetchMore(payments, nextPage, req.PageSize)
 
 		if !needMore {
 			break
 		}
 
-		page = nextPage
+		page++
 	}
 
 	// Watermark and dedup key come from the last EMITTED payment, computed once
@@ -69,6 +85,13 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	if len(payments) > 0 {
 		newState.LastUpdatedAt = updatedAts[len(payments)-1]
 		newState.LastProcessedID = processedIDs[len(payments)-1]
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 1.
+		if newState.LastUpdatedAt.Equal(oldState.LastUpdatedAt) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 1
+		}
 	}
 
 	payload, err := json.Marshal(newState)

--- a/ce/plugins/currencycloud/payments.go
+++ b/ce/plugins/currencycloud/payments.go
@@ -85,10 +85,18 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	if len(payments) > 0 {
 		newState.LastUpdatedAt = updatedAts[len(payments)-1]
 		newState.LastProcessedID = processedIDs[len(payments)-1]
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 1.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 1.
 		if newState.LastUpdatedAt.Equal(oldState.LastUpdatedAt) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 1
 		}

--- a/ce/plugins/currencycloud/payments.go
+++ b/ce/plugins/currencycloud/payments.go
@@ -3,6 +3,7 @@ package currencycloud
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -12,17 +13,18 @@ import (
 
 type paymentsState struct {
 	LastUpdatedAt time.Time `json:"lastUpdatedAt"`
-	// LastProcessedID is the transaction ID of the last transaction emitted at
-	// exactly LastUpdatedAt, so the inclusive (>=) watermark filter excludes only
-	// that already-processed row while keeping distinct same-timestamp rows.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastUpdatedAt second
-	// (1-indexed). It advances while the watermark second is unchanged (a
-	// same-second group larger than one page) and resets to 1 once the watermark
-	// moves to a newer second, so a same-second group spanning pages is walked
-	// without re-scanning from page 1 each cycle (which a single LastProcessedID
-	// cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the transaction IDs of ALL transactions already
+	// emitted at exactly LastUpdatedAt, accumulated across cycles while the
+	// watermark second is unchanged and reset when it advances. The server filter
+	// is inclusive (>=), so each cycle rescans from page 1 and skips this whole
+	// set: a same-second group larger than PageSize is walked across cycles
+	// without a drifting page cursor, and a multi-row final page cannot oscillate
+	// (every already-emitted sibling is skipped, not just one).
+	//
+	// Migration: the old singular lastProcessedID and page/lastPage fields are
+	// ignored. After deploy the watermark second is re-emitted once (idempotent
+	// via storage upserts), with no recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -32,28 +34,22 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 	}
-	if oldState.Page < 1 {
-		oldState.Page = 1
-	}
 
 	newState := paymentsState{
-		LastUpdatedAt:   oldState.LastUpdatedAt,
-		LastProcessedID: oldState.LastProcessedID,
-		Page:            oldState.Page,
+		LastUpdatedAt:    oldState.LastUpdatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var payments []models.PSPPayment
 	var updatedAts []time.Time
 	var processedIDs []string
 	hasMore := false
-	// Resume at the persisted page and walk forward. We filter against the STABLE
-	// oldState watermark for the whole drain (advancing it mid-pagination would
-	// drop rows sharing a second across a page boundary and mutate the server
-	// filter), and we do NOT trim back to PageSize — that would skip the trimmed
-	// rows when resuming at the advanced page. The page cursor below records how
-	// far we got.
-	page := oldState.Page
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. We filter against the STABLE oldState watermark for
+	// the whole drain, and we do NOT trim back to PageSize.
+	for page := 1; ; page++ {
 		pagedTransactions, nextPage, err := p.client.GetTransactions(ctx, page, req.PageSize, oldState.LastUpdatedAt)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -69,37 +65,35 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		}
 
 		var needMore bool
-		// Ignore shouldFetchMore's trimmed slice; keep the full over-fetch so the
-		// page cursor can resume cleanly.
+		// Ignore shouldFetchMore's trimmed slice; keep the full over-fetch.
 		needMore, hasMore, _ = shouldFetchMore(payments, nextPage, req.PageSize)
 
 		if !needMore {
 			break
 		}
-
-		page++
 	}
 
-	// Watermark and dedup key come from the last EMITTED payment, computed once
+	// Watermark and dedup set come from the last EMITTED payment, computed once
 	// after the drain (updatedAts/processedIDs stay aligned with payments by index).
-	if len(payments) > 0 {
-		newState.LastUpdatedAt = updatedAts[len(payments)-1]
-		newState.LastProcessedID = processedIDs[len(payments)-1]
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 1.
-		if newState.LastUpdatedAt.Equal(oldState.LastUpdatedAt) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+	if len(updatedAts) > 0 {
+		last := updatedAts[len(updatedAts)-1]
+
+		// Collect the IDs emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range processedIDs {
+			if updatedAts[i].Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, processedIDs[i])
 			}
-		} else {
-			newState.Page = 1
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastUpdatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastUpdatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -122,12 +116,12 @@ func fillPayments(
 	oldState paymentsState,
 ) ([]models.PSPPayment, []time.Time, []string, error) {
 	for _, transaction := range pagedTransactions {
-		// Inclusive watermark: skip transactions strictly before it, and the single
-		// already-processed transaction at exactly the watermark. Distinct
+		// Inclusive watermark: skip transactions strictly before it, and any
+		// already-emitted transaction at exactly the watermark second. Distinct
 		// transactions sharing that timestamp are kept (M-CON2). Keyed on
 		// transaction.ID, which differs from payment.Reference (RelatedEntityID).
 		cmp := transaction.UpdatedAt.Compare(oldState.LastUpdatedAt)
-		if cmp < 0 || (cmp == 0 && transaction.ID == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, transaction.ID)) {
 			continue
 		}
 

--- a/ce/plugins/currencycloud/payments.go
+++ b/ce/plugins/currencycloud/payments.go
@@ -24,6 +24,11 @@ type paymentsState struct {
 	// Migration: the old singular lastProcessedID and page/lastPage fields are
 	// ignored. After deploy the watermark second is re-emitted once (idempotent
 	// via storage upserts), with no recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/currencycloud/payments_test.go
+++ b/ce/plugins/currencycloud/payments_test.go
@@ -253,14 +253,35 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 			m.EXPECT().GetTransactions(gomock.Any(), 2, 2, ts.UTC()).Return(all[2:4], 3, nil)
 			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(ContainElements("t2", "t3"))
-			Expect(refs(resp.Payments)).ToNot(ContainElement("t1"))
+			// Boundary t1 is deduped; t0 (a same-second sibling on the re-fetched
+			// page 1) is re-emitted by design — storage upserts dedup it. The exact
+			// assertion catches any unintended extra re-emission.
+			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t2", "t3"}))
 
-			// Cycle 3: page 3 -> t4 (group fully drained, no stall).
+			// Cycle 3: page 3 -> t4 (group fully drained on a short final page).
 			m.EXPECT().GetTransactions(gomock.Any(), 3, 2, ts.UTC()).Return(all[4:5], -1, nil)
 			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(ContainElement("t4"))
+			Expect(refs(resp.Payments)).To(Equal([]string{"t4"}))
+
+			// Cycle 4: a newer-second transaction t5 lands on the short last page
+			// (3). The cursor must stay on page 3 rather than advance to page 4, or
+			// t5 would be stranded forever behind an empty page.
+			ts2 := ts.Add(time.Second)
+			t5 := client.Transaction{
+				ID:        "t5",
+				AccountID: "acc",
+				Currency:  "EUR",
+				Type:      "credit",
+				Status:    "completed",
+				CreatedAt: ts2,
+				UpdatedAt: ts2,
+				Amount:    "100",
+			}
+			m.EXPECT().GetTransactions(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Transaction{all[4], t5}, -1, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"t5"}))
 		})
 	})
 })

--- a/ce/plugins/currencycloud/payments_test.go
+++ b/ce/plugins/currencycloud/payments_test.go
@@ -153,7 +153,7 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"lastUpdatedAt": "%s", "lastProcessedID": "%s"}`,
+					`{"lastUpdatedAt": "%s", "lastProcessedIDs": ["%s"]}`,
 					sampleTransactions[38].UpdatedAt.Format(time.RFC3339Nano),
 					sampleTransactions[38].ID,
 				)),
@@ -202,7 +202,7 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 			}
 
 			req := models.FetchNextPaymentsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastUpdatedAt": "%s", "lastProcessedID": "a"}`, ts.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastUpdatedAt": "%s", "lastProcessedIDs": ["a"]}`, ts.Format(time.RFC3339Nano))),
 				PageSize: 40,
 			}
 			m.EXPECT().GetTransactions(gomock.Any(), 1, 40, ts.UTC()).Return(
@@ -220,6 +220,11 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 		})
 
 		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			// Five transactions all sharing the same UpdatedAt second, fetched three
+			// per page so the group spans page 1 (t0,t1,t2) and a SHORT final page 2
+			// (t3,t4). Each cycle rescans from page 1 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting t3/t4 forever) instead of settling and advancing.
 			ts := now.Add(-time.Hour).UTC()
 			mk := func(id string) client.Transaction {
 				return client.Transaction{
@@ -242,31 +247,31 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 				return out
 			}
 
-			// Cycle 1: page 1 -> t0, t1.
-			m.EXPECT().GetTransactions(gomock.Any(), 1, 2, time.Time{}).Return(all[0:2], 2, nil)
-			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2})
+			// Cycle 1: fresh state, page 1 -> t0, t1, t2.
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 3, time.Time{}).Return(all[0:3], 2, nil)
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t1"}))
+			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t1", "t2"}))
+			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 1 re-fetched (t1 deduped) then page 2 -> t2, t3.
-			m.EXPECT().GetTransactions(gomock.Any(), 1, 2, ts.UTC()).Return(all[0:2], 2, nil)
-			m.EXPECT().GetTransactions(gomock.Any(), 2, 2, ts.UTC()).Return(all[2:4], 3, nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> t3, t4.
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 3, ts.UTC()).Return(all[0:3], 2, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), 2, 3, ts.UTC()).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			// Boundary t1 is deduped; t0 (a same-second sibling on the re-fetched
-			// page 1) is re-emitted by design — storage upserts dedup it. The exact
-			// assertion catches any unintended extra re-emission.
-			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t2", "t3"}))
+			Expect(refs(resp.Payments)).To(Equal([]string{"t3", "t4"}))
 
-			// Cycle 3: page 3 -> t4 (group fully drained on a short final page).
-			m.EXPECT().GetTransactions(gomock.Any(), 3, 2, ts.UTC()).Return(all[4:5], -1, nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing. A single LastProcessedID would re-emit t3 or
+			// t4 here and oscillate; the set settles to empty.
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 3, ts.UTC()).Return(all[0:3], 2, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), 2, 3, ts.UTC()).Return(all[3:5], -1, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(Equal([]string{"t4"}))
+			Expect(refs(resp.Payments)).To(BeEmpty())
 
-			// Cycle 4: a newer-second transaction t5 lands on the short last page
-			// (3). The cursor must stay on page 3 rather than advance to page 4, or
-			// t5 would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second transaction t5 appears on the (formerly short)
+			// page 2. The set skips t3/t4 and reaches t5 — no stranding.
 			ts2 := ts.Add(time.Second)
 			t5 := client.Transaction{
 				ID:        "t5",
@@ -278,8 +283,9 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 				UpdatedAt: ts2,
 				Amount:    "100",
 			}
-			m.EXPECT().GetTransactions(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Transaction{all[4], t5}, -1, nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 3, ts.UTC()).Return(all[0:3], 2, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), 2, 3, ts.UTC()).Return([]client.Transaction{all[3], all[4], t5}, -1, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Payments)).To(Equal([]string{"t5"}))
 		})

--- a/ce/plugins/currencycloud/payments_test.go
+++ b/ce/plugins/currencycloud/payments_test.go
@@ -168,14 +168,14 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 			)
 
 			m.EXPECT().GetTransactions(gomock.Any(), 2, 40, sampleTransactions[38].UpdatedAt.UTC()).Return(
-				sampleTransactions[41:],
+				sampleTransactions[40:],
 				-1,
 				nil,
 			)
 
 			resp, err := plg.FetchNextPayments(ctx, req)
 			Expect(err).To(BeNil())
-			Expect(resp.Payments).To(HaveLen(10))
+			Expect(resp.Payments).To(HaveLen(11))
 			Expect(resp.HasMore).To(BeFalse())
 			Expect(resp.NewState).ToNot(BeNil())
 

--- a/ce/plugins/currencycloud/payments_test.go
+++ b/ce/plugins/currencycloud/payments_test.go
@@ -218,6 +218,50 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 			Expect(resp.Payments).To(HaveLen(2))
 			Expect([]string{resp.Payments[0].Reference, resp.Payments[1].Reference}).To(ConsistOf("b", "c"))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) client.Transaction {
+				return client.Transaction{
+					ID:        id,
+					AccountID: "acc",
+					Currency:  "EUR",
+					Type:      "credit",
+					Status:    "completed",
+					CreatedAt: ts,
+					UpdatedAt: ts,
+					Amount:    "100",
+				}
+			}
+			all := []client.Transaction{mk("t0"), mk("t1"), mk("t2"), mk("t3"), mk("t4")}
+			refs := func(ps []models.PSPPayment) []string {
+				out := make([]string, len(ps))
+				for i := range ps {
+					out[i] = ps[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: page 1 -> t0, t1.
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 2, time.Time{}).Return(all[0:2], 2, nil)
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t1"}))
+
+			// Cycle 2: page 1 re-fetched (t1 deduped) then page 2 -> t2, t3.
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 2, ts.UTC()).Return(all[0:2], 2, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), 2, 2, ts.UTC()).Return(all[2:4], 3, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElements("t2", "t3"))
+			Expect(refs(resp.Payments)).ToNot(ContainElement("t1"))
+
+			// Cycle 3: page 3 -> t4 (group fully drained, no stall).
+			m.EXPECT().GetTransactions(gomock.Any(), 3, 2, ts.UTC()).Return(all[4:5], -1, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElement("t4"))
+		})
 	})
 })
 

--- a/ce/plugins/currencycloud/payments_test.go
+++ b/ce/plugins/currencycloud/payments_test.go
@@ -152,17 +152,22 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastUpdatedAt": "%s"}`, sampleTransactions[38].UpdatedAt.Format(time.RFC3339Nano))),
+				State: []byte(fmt.Sprintf(
+					`{"lastUpdatedAt": "%s", "lastProcessedID": "%s"}`,
+					sampleTransactions[38].UpdatedAt.Format(time.RFC3339Nano),
+					sampleTransactions[38].ID,
+				)),
 				PageSize: 40,
 			}
 
+			// Both pages query with the STABLE oldState watermark (no mid-pagination mutation).
 			m.EXPECT().GetTransactions(gomock.Any(), 1, 40, sampleTransactions[38].UpdatedAt.UTC()).Return(
 				sampleTransactions[:40],
 				2,
 				nil,
 			)
 
-			m.EXPECT().GetTransactions(gomock.Any(), 2, 40, sampleTransactions[39].UpdatedAt.UTC()).Return(
+			m.EXPECT().GetTransactions(gomock.Any(), 2, 40, sampleTransactions[38].UpdatedAt.UTC()).Return(
 				sampleTransactions[41:],
 				-1,
 				nil,
@@ -179,6 +184,39 @@ var _ = Describe("CurrencyCloud Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
 			Expect(state.LastUpdatedAt).To(Equal(sampleTransactions[49].UpdatedAt))
+		})
+
+		It("keeps distinct transactions that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) client.Transaction {
+				return client.Transaction{
+					ID:        id,
+					AccountID: "acc",
+					Currency:  "EUR",
+					Type:      "credit",
+					Status:    "completed",
+					CreatedAt: ts,
+					UpdatedAt: ts,
+					Amount:    "100",
+				}
+			}
+
+			req := models.FetchNextPaymentsRequest{
+				State:    []byte(fmt.Sprintf(`{"lastUpdatedAt": "%s", "lastProcessedID": "a"}`, ts.Format(time.RFC3339Nano))),
+				PageSize: 40,
+			}
+			m.EXPECT().GetTransactions(gomock.Any(), 1, 40, ts.UTC()).Return(
+				[]client.Transaction{mk("a"), mk("b"), mk("c")},
+				-1,
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			// "a" was the already-processed boundary row; "b" and "c" share its
+			// timestamp and must NOT be dropped.
+			Expect(resp.Payments).To(HaveLen(2))
+			Expect([]string{resp.Payments[0].Reference, resp.Payments[1].Reference}).To(ConsistOf("b", "c"))
 		})
 	})
 })

--- a/ce/plugins/generic/accounts.go
+++ b/ce/plugins/generic/accounts.go
@@ -68,10 +68,18 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 1.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 1.
 		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 1
 		}

--- a/ce/plugins/generic/accounts.go
+++ b/ce/plugins/generic/accounts.go
@@ -12,6 +12,10 @@ import (
 
 type accountsState struct {
 	LastCreatedAtFrom time.Time `json:"lastCreatedAtFrom"`
+	// LastProcessedID is the reference of the last account emitted at exactly
+	// LastCreatedAtFrom, so the inclusive (>=) watermark filter can exclude only
+	// that already-processed row while keeping distinct same-timestamp accounts.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -24,6 +28,7 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 
 	newState := accountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
+		LastProcessedID:   oldState.LastProcessedID,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
@@ -52,6 +57,7 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -72,11 +78,12 @@ func fillAccounts(
 	oldState accountsState,
 ) ([]models.PSPAccount, error) {
 	for _, account := range pagedAccounts {
-		switch account.CreatedAt.Compare(oldState.LastCreatedAtFrom) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip accounts strictly before it, and the single
+		// already-processed account at exactly the watermark. Distinct accounts
+		// sharing that timestamp are kept (M-CON2).
+		cmp := account.CreatedAt.Compare(oldState.LastCreatedAtFrom)
+		if cmp < 0 || (cmp == 0 && account.Id == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(account)

--- a/ce/plugins/generic/accounts.go
+++ b/ce/plugins/generic/accounts.go
@@ -16,6 +16,12 @@ type accountsState struct {
 	// LastCreatedAtFrom, so the inclusive (>=) watermark filter can exclude only
 	// that already-processed row while keeping distinct same-timestamp accounts.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastCreatedAtFrom second.
+	// It advances while the watermark second is unchanged (a same-second group
+	// larger than one page) and resets to 1 once the watermark moves to a newer
+	// second, so a same-second group spanning pages is walked without re-scanning
+	// from page 1 each cycle (which a single LastProcessedID cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -25,16 +31,23 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 			return models.FetchNextAccountsResponse{}, err
 		}
 	}
+	if oldState.Page < 1 {
+		oldState.Page = 1
+	}
 
 	newState := accountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
 		LastProcessedID:   oldState.LastProcessedID,
+		Page:              oldState.Page,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
 	needMore := false
 	hasMore := false
-	for page := 1; ; page++ {
+	// Resume at the persisted page and walk forward (no trim-and-restart, which
+	// would skip the trimmed rows); the page cursor below records how far we got.
+	page := oldState.Page
+	for {
 		pagedAccounts, err := p.client.ListAccounts(ctx, int64(page), int64(req.PageSize), oldState.LastCreatedAtFrom)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
@@ -49,15 +62,19 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		accounts = accounts[:req.PageSize]
+		page++
 	}
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 1.
+		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 1
+		}
 	}
 
 	payload, err := json.Marshal(newState)

--- a/ce/plugins/generic/accounts.go
+++ b/ce/plugins/generic/accounts.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/generic/client/generated"
@@ -12,16 +13,18 @@ import (
 
 type accountsState struct {
 	LastCreatedAtFrom time.Time `json:"lastCreatedAtFrom"`
-	// LastProcessedID is the reference of the last account emitted at exactly
-	// LastCreatedAtFrom, so the inclusive (>=) watermark filter can exclude only
-	// that already-processed row while keeping distinct same-timestamp accounts.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastCreatedAtFrom second.
-	// It advances while the watermark second is unchanged (a same-second group
-	// larger than one page) and resets to 1 once the watermark moves to a newer
-	// second, so a same-second group spanning pages is walked without re-scanning
-	// from page 1 each cycle (which a single LastProcessedID cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the references of ALL accounts already emitted at
+	// exactly LastCreatedAtFrom, accumulated across cycles while the watermark
+	// second is unchanged and reset when it advances. The server filter is
+	// inclusive (>=), so each cycle rescans from page 1 and skips this whole set:
+	// a same-second group larger than PageSize is walked across cycles without a
+	// drifting page cursor, and a multi-row final page cannot oscillate (every
+	// already-emitted sibling is skipped, not just one).
+	//
+	// Migration note: the old singular lastProcessedID and page fields are
+	// ignored on first decode after deploy, so the watermark second's group is
+	// re-emitted once. This is idempotent via storage upsert — no recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -31,29 +34,28 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 			return models.FetchNextAccountsResponse{}, err
 		}
 	}
-	if oldState.Page < 1 {
-		oldState.Page = 1
-	}
 
 	newState := accountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
-		LastProcessedID:   oldState.LastProcessedID,
-		Page:              oldState.Page,
+		LastProcessedIDs:  oldState.LastProcessedIDs,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
+	createdAts := make([]time.Time, 0)
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward (no trim-and-restart, which
-	// would skip the trimmed rows); the page cursor below records how far we got.
-	page := oldState.Page
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 1
+	// re-includes the watermark second.
+	for page := 1; ; page++ {
 		pagedAccounts, err := p.client.ListAccounts(ctx, int64(page), int64(req.PageSize), oldState.LastCreatedAtFrom)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
 		}
 
-		accounts, err = fillAccounts(pagedAccounts, accounts, oldState)
+		accounts, createdAts, err = fillAccounts(pagedAccounts, accounts, createdAts, oldState)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
 		}
@@ -62,27 +64,27 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
-	if len(accounts) > 0 {
-		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 1.
-		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+	if len(createdAts) > 0 {
+		lastCreatedAt := createdAts[len(createdAts)-1]
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if createdAts[i].Equal(lastCreatedAt) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
 			}
-		} else {
-			newState.Page = 1
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if lastCreatedAt.Equal(oldState.LastCreatedAtFrom) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAtFrom = lastCreatedAt
 	}
 
 	payload, err := json.Marshal(newState)
@@ -100,20 +102,21 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 func fillAccounts(
 	pagedAccounts []genericclient.Account,
 	accounts []models.PSPAccount,
+	createdAts []time.Time,
 	oldState accountsState,
-) ([]models.PSPAccount, error) {
+) ([]models.PSPAccount, []time.Time, error) {
 	for _, account := range pagedAccounts {
-		// Inclusive watermark: skip accounts strictly before it, and the single
-		// already-processed account at exactly the watermark. Distinct accounts
+		// Inclusive watermark: skip accounts strictly before it, and any already-
+		// emitted account at exactly the watermark second. Distinct accounts
 		// sharing that timestamp are kept (M-CON2).
 		cmp := account.CreatedAt.Compare(oldState.LastCreatedAtFrom)
-		if cmp < 0 || (cmp == 0 && account.Id == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, account.Id)) {
 			continue
 		}
 
 		raw, err := json.Marshal(account)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		accounts = append(accounts, models.PSPAccount{
@@ -123,7 +126,8 @@ func fillAccounts(
 			Metadata:  account.Metadata,
 			Raw:       raw,
 		})
+		createdAts = append(createdAts, account.CreatedAt)
 	}
 
-	return accounts, nil
+	return accounts, createdAts, nil
 }

--- a/ce/plugins/generic/accounts.go
+++ b/ce/plugins/generic/accounts.go
@@ -24,6 +24,11 @@ type accountsState struct {
 	// Migration note: the old singular lastProcessedID and page fields are
 	// ignored on first decode after deploy, so the watermark second's group is
 	// re-emitted once. This is idempotent via storage upsert — no recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/generic/accounts_test.go
+++ b/ce/plugins/generic/accounts_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Generic Plugin Accounts", func() {
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedID": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedIDs": ["%s"]}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
 				PageSize: 40,
 			}
 
@@ -171,6 +171,11 @@ var _ = Describe("Generic Plugin Accounts", func() {
 		})
 
 		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			// Five accounts all sharing the same CreatedAt second, fetched three per
+			// page so the group spans page 1 (a0,a1,a2) and a SHORT final page 2
+			// (a3,a4). Each cycle rescans from page 1 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting a3/a4 forever) instead of settling and advancing.
 			ts := now.Add(-time.Hour).UTC()
 			mk := func(id string) genericclient.Account {
 				return genericclient.Account{Id: id, AccountName: "name-" + id, CreatedAt: ts}
@@ -184,37 +189,37 @@ var _ = Describe("Generic Plugin Accounts", func() {
 				return out
 			}
 
-			// Cycle 1: fresh state, page 1 -> a0, a1.
-			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
-			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			// Cycle 1: fresh state, page 1 -> a0, a1, a2.
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(3), time.Time{}).Return(all[0:3], nil)
+			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1"}))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1", "a2"}))
 			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 1 re-fetched then page 2 -> a2, a3. The boundary a1 is
-			// deduped; a0 (a same-second sibling on the re-fetched page 1) is
-			// re-emitted by design — storage upserts dedup it. Asserting the exact
-			// set catches any unintended extra re-emission.
-			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
-			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> a3, a4.
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a2", "a3"}))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a3", "a4"}))
 
-			// Cycle 3: page 3 -> a4 (group fully drained on a short final page).
-			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing. A single LastProcessedID would re-emit a3 or
+			// a4 here and oscillate; the set settles to empty.
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a4"}))
+			Expect(refs(resp.Accounts)).To(BeEmpty())
 
-			// Cycle 4: a newer-second account a5 lands on the short last page (3).
-			// The cursor must stay on page 3 rather than advance to page 4, or a5
-			// would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second account a5 appears on the (formerly short)
+			// page 2. The set skips a3/a4 and reaches a5 — no stranding.
 			ts2 := ts.Add(time.Second)
 			a5 := genericclient.Account{Id: "a5", AccountName: "name-a5", CreatedAt: ts2}
-			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Account{all[4], a5}, nil)
-			m.EXPECT().ListAccounts(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Account{}, nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(3), ts).Return([]genericclient.Account{all[3], all[4], a5}, nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(3), ts).Return([]genericclient.Account{}, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Accounts)).To(Equal([]string{"a5"}))
 		})

--- a/ce/plugins/generic/accounts_test.go
+++ b/ce/plugins/generic/accounts_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Generic Plugin Accounts", func() {
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedID": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
 				PageSize: 40,
 			}
 

--- a/ce/plugins/generic/accounts_test.go
+++ b/ce/plugins/generic/accounts_test.go
@@ -191,19 +191,32 @@ var _ = Describe("Generic Plugin Accounts", func() {
 			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1"}))
 			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 1 re-fetched (a1 deduped) then page 2 -> a2, a3.
+			// Cycle 2: page 1 re-fetched then page 2 -> a2, a3. The boundary a1 is
+			// deduped; a0 (a same-second sibling on the re-fetched page 1) is
+			// re-emitted by design — storage upserts dedup it. Asserting the exact
+			// set catches any unintended extra re-emission.
 			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
 			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(ContainElements("a2", "a3"))
-			Expect(refs(resp.Accounts)).ToNot(ContainElement("a1"))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a2", "a3"}))
 
-			// Cycle 3: page 3 -> a4 (group fully drained, no stall).
+			// Cycle 3: page 3 -> a4 (group fully drained on a short final page).
 			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(ContainElement("a4"))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a4"}))
+
+			// Cycle 4: a newer-second account a5 lands on the short last page (3).
+			// The cursor must stay on page 3 rather than advance to page 4, or a5
+			// would be stranded forever behind an empty page.
+			ts2 := ts.Add(time.Second)
+			a5 := genericclient.Account{Id: "a5", AccountName: "name-a5", CreatedAt: ts2}
+			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Account{all[4], a5}, nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Account{}, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a5"}))
 		})
 	})
 })

--- a/ce/plugins/generic/accounts_test.go
+++ b/ce/plugins/generic/accounts_test.go
@@ -169,5 +169,41 @@ var _ = Describe("Generic Plugin Accounts", func() {
 			// We fetched everything, state should be resetted
 			Expect(state.LastCreatedAtFrom.UTC()).To(Equal(sampleAccounts[49].CreatedAt.UTC()))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) genericclient.Account {
+				return genericclient.Account{Id: id, AccountName: "name-" + id, CreatedAt: ts}
+			}
+			all := []genericclient.Account{mk("a0"), mk("a1"), mk("a2"), mk("a3"), mk("a4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: fresh state, page 1 -> a0, a1.
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
+			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1"}))
+			Expect(resp.HasMore).To(BeTrue())
+
+			// Cycle 2: page 1 re-fetched (a1 deduped) then page 2 -> a2, a3.
+			m.EXPECT().ListAccounts(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
+			m.EXPECT().ListAccounts(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(ContainElements("a2", "a3"))
+			Expect(refs(resp.Accounts)).ToNot(ContainElement("a1"))
+
+			// Cycle 3: page 3 -> a4 (group fully drained, no stall).
+			m.EXPECT().ListAccounts(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(ContainElement("a4"))
+		})
 	})
 })

--- a/ce/plugins/generic/external_accounts.go
+++ b/ce/plugins/generic/external_accounts.go
@@ -68,10 +68,18 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 1.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 1.
 		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 1
 		}

--- a/ce/plugins/generic/external_accounts.go
+++ b/ce/plugins/generic/external_accounts.go
@@ -24,6 +24,11 @@ type externalAccountsState struct {
 	// Migration note: the old singular lastProcessedID and page fields are
 	// ignored on first decode after deploy, so the watermark second's group is
 	// re-emitted once. This is idempotent via storage upsert — no recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/generic/external_accounts.go
+++ b/ce/plugins/generic/external_accounts.go
@@ -16,6 +16,12 @@ type externalAccountsState struct {
 	// exactly LastCreatedAtFrom, so the inclusive (>=) watermark filter excludes
 	// only that already-processed row while keeping distinct same-timestamp ones.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastCreatedAtFrom second.
+	// It advances while the watermark second is unchanged (a same-second group
+	// larger than one page) and resets to 1 once the watermark moves to a newer
+	// second, so a same-second group spanning pages is walked without re-scanning
+	// from page 1 each cycle (which a single LastProcessedID cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -25,16 +31,23 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 	}
+	if oldState.Page < 1 {
+		oldState.Page = 1
+	}
 
 	newState := externalAccountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
 		LastProcessedID:   oldState.LastProcessedID,
+		Page:              oldState.Page,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
 	needMore := false
 	hasMore := false
-	for page := 1; ; page++ {
+	// Resume at the persisted page and walk forward (no trim-and-restart, which
+	// would skip the trimmed rows); the page cursor below records how far we got.
+	page := oldState.Page
+	for {
 		pagedExternalAccounts, err := p.client.ListBeneficiaries(ctx, int64(page), int64(req.PageSize), oldState.LastCreatedAtFrom)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
@@ -49,15 +62,19 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		accounts = accounts[:req.PageSize]
+		page++
 	}
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 1.
+		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 1
+		}
 	}
 
 	payload, err := json.Marshal(newState)

--- a/ce/plugins/generic/external_accounts.go
+++ b/ce/plugins/generic/external_accounts.go
@@ -12,6 +12,10 @@ import (
 
 type externalAccountsState struct {
 	LastCreatedAtFrom time.Time `json:"lastCreatedAtFrom"`
+	// LastProcessedID is the reference of the last external account emitted at
+	// exactly LastCreatedAtFrom, so the inclusive (>=) watermark filter excludes
+	// only that already-processed row while keeping distinct same-timestamp ones.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -24,6 +28,7 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 
 	newState := externalAccountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
+		LastProcessedID:   oldState.LastProcessedID,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
@@ -52,6 +57,7 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -72,11 +78,12 @@ func fillExternalAccounts(
 	oldState externalAccountsState,
 ) ([]models.PSPAccount, error) {
 	for _, account := range pagedExternalAccounts {
-		switch account.CreatedAt.Compare(oldState.LastCreatedAtFrom) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip accounts strictly before it, and the single
+		// already-processed account at exactly the watermark. Distinct accounts
+		// sharing that timestamp are kept (M-CON2).
+		cmp := account.CreatedAt.Compare(oldState.LastCreatedAtFrom)
+		if cmp < 0 || (cmp == 0 && account.Id == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(account)

--- a/ce/plugins/generic/external_accounts.go
+++ b/ce/plugins/generic/external_accounts.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/generic/client/generated"
@@ -12,16 +13,18 @@ import (
 
 type externalAccountsState struct {
 	LastCreatedAtFrom time.Time `json:"lastCreatedAtFrom"`
-	// LastProcessedID is the reference of the last external account emitted at
-	// exactly LastCreatedAtFrom, so the inclusive (>=) watermark filter excludes
-	// only that already-processed row while keeping distinct same-timestamp ones.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastCreatedAtFrom second.
-	// It advances while the watermark second is unchanged (a same-second group
-	// larger than one page) and resets to 1 once the watermark moves to a newer
-	// second, so a same-second group spanning pages is walked without re-scanning
-	// from page 1 each cycle (which a single LastProcessedID cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the references of ALL external accounts already
+	// emitted at exactly LastCreatedAtFrom, accumulated across cycles while the
+	// watermark second is unchanged and reset when it advances. The server filter
+	// is inclusive (>=), so each cycle rescans from page 1 and skips this whole
+	// set: a same-second group larger than PageSize is walked across cycles
+	// without a drifting page cursor, and a multi-row final page cannot oscillate
+	// (every already-emitted sibling is skipped, not just one).
+	//
+	// Migration note: the old singular lastProcessedID and page fields are
+	// ignored on first decode after deploy, so the watermark second's group is
+	// re-emitted once. This is idempotent via storage upsert — no recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -31,29 +34,28 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 	}
-	if oldState.Page < 1 {
-		oldState.Page = 1
-	}
 
 	newState := externalAccountsState{
 		LastCreatedAtFrom: oldState.LastCreatedAtFrom,
-		LastProcessedID:   oldState.LastProcessedID,
-		Page:              oldState.Page,
+		LastProcessedIDs:  oldState.LastProcessedIDs,
 	}
 
 	accounts := make([]models.PSPAccount, 0)
+	createdAts := make([]time.Time, 0)
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward (no trim-and-restart, which
-	// would skip the trimmed rows); the page cursor below records how far we got.
-	page := oldState.Page
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 1
+	// re-includes the watermark second.
+	for page := 1; ; page++ {
 		pagedExternalAccounts, err := p.client.ListBeneficiaries(ctx, int64(page), int64(req.PageSize), oldState.LastCreatedAtFrom)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 
-		accounts, err = fillExternalAccounts(pagedExternalAccounts, accounts, oldState)
+		accounts, createdAts, err = fillExternalAccounts(pagedExternalAccounts, accounts, createdAts, oldState)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
@@ -62,27 +64,27 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
-	if len(accounts) > 0 {
-		newState.LastCreatedAtFrom = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 1.
-		if newState.LastCreatedAtFrom.Equal(oldState.LastCreatedAtFrom) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+	if len(createdAts) > 0 {
+		lastCreatedAt := createdAts[len(createdAts)-1]
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if createdAts[i].Equal(lastCreatedAt) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
 			}
-		} else {
-			newState.Page = 1
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if lastCreatedAt.Equal(oldState.LastCreatedAtFrom) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAtFrom = lastCreatedAt
 	}
 
 	payload, err := json.Marshal(newState)
@@ -100,20 +102,21 @@ func (p *Plugin) fetchExternalAccounts(ctx context.Context, req models.FetchNext
 func fillExternalAccounts(
 	pagedExternalAccounts []genericclient.Beneficiary,
 	accounts []models.PSPAccount,
+	createdAts []time.Time,
 	oldState externalAccountsState,
-) ([]models.PSPAccount, error) {
+) ([]models.PSPAccount, []time.Time, error) {
 	for _, account := range pagedExternalAccounts {
-		// Inclusive watermark: skip accounts strictly before it, and the single
-		// already-processed account at exactly the watermark. Distinct accounts
+		// Inclusive watermark: skip accounts strictly before it, and any already-
+		// emitted account at exactly the watermark second. Distinct accounts
 		// sharing that timestamp are kept (M-CON2).
 		cmp := account.CreatedAt.Compare(oldState.LastCreatedAtFrom)
-		if cmp < 0 || (cmp == 0 && account.Id == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, account.Id)) {
 			continue
 		}
 
 		raw, err := json.Marshal(account)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		accounts = append(accounts, models.PSPAccount{
@@ -123,7 +126,8 @@ func fillExternalAccounts(
 			Metadata:  account.Metadata,
 			Raw:       raw,
 		})
+		createdAts = append(createdAts, account.CreatedAt)
 	}
 
-	return accounts, nil
+	return accounts, createdAts, nil
 }

--- a/ce/plugins/generic/external_accounts_test.go
+++ b/ce/plugins/generic/external_accounts_test.go
@@ -189,19 +189,32 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1"}))
 			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 1 re-fetched (b1 deduped) then page 2 -> b2, b3.
+			// Cycle 2: page 1 re-fetched then page 2 -> b2, b3. The boundary b1 is
+			// deduped; b0 (a same-second sibling on the re-fetched page 1) is
+			// re-emitted by design — storage upserts dedup it. Asserting the exact
+			// set catches any unintended extra re-emission.
 			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
 			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(ContainElements("b2", "b3"))
-			Expect(refs(resp.ExternalAccounts)).ToNot(ContainElement("b1"))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b2", "b3"}))
 
-			// Cycle 3: page 3 -> b4 (group fully drained, no stall).
+			// Cycle 3: page 3 -> b4 (group fully drained on a short final page).
 			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(ContainElement("b4"))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b4"}))
+
+			// Cycle 4: a newer-second beneficiary b5 lands on the short last page
+			// (3). The cursor must stay on page 3 rather than advance to page 4, or
+			// b5 would be stranded forever behind an empty page.
+			ts2 := ts.Add(time.Second)
+			b5 := genericclient.Beneficiary{Id: "b5", OwnerName: "owner-b5", CreatedAt: ts2}
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Beneficiary{all[4], b5}, nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Beneficiary{}, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b5"}))
 		})
 	})
 })

--- a/ce/plugins/generic/external_accounts_test.go
+++ b/ce/plugins/generic/external_accounts_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedID": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
 				PageSize: 40,
 			}
 

--- a/ce/plugins/generic/external_accounts_test.go
+++ b/ce/plugins/generic/external_accounts_test.go
@@ -167,5 +167,41 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 			// We fetched everything, state should be resetted
 			Expect(state.LastCreatedAtFrom.UTC()).To(Equal(sampleAccounts[49].CreatedAt.UTC()))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			mk := func(id string) genericclient.Beneficiary {
+				return genericclient.Beneficiary{Id: id, OwnerName: "owner-" + id, CreatedAt: ts}
+			}
+			all := []genericclient.Beneficiary{mk("b0"), mk("b1"), mk("b2"), mk("b3"), mk("b4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: fresh state, page 1 -> b0, b1.
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1"}))
+			Expect(resp.HasMore).To(BeTrue())
+
+			// Cycle 2: page 1 re-fetched (b1 deduped) then page 2 -> b2, b3.
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(ContainElements("b2", "b3"))
+			Expect(refs(resp.ExternalAccounts)).ToNot(ContainElement("b1"))
+
+			// Cycle 3: page 3 -> b4 (group fully drained, no stall).
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(ContainElement("b4"))
+		})
 	})
 })

--- a/ce/plugins/generic/external_accounts_test.go
+++ b/ce/plugins/generic/external_accounts_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedID": "%s"}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAtFrom": "%s", "lastProcessedIDs": ["%s"]}`, sampleAccounts[38].CreatedAt.Format(time.RFC3339Nano), sampleAccounts[38].Id)),
 				PageSize: 40,
 			}
 
@@ -169,6 +169,11 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 		})
 
 		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			// Five beneficiaries all sharing the same CreatedAt second, fetched three
+			// per page so the group spans page 1 (b0,b1,b2) and a SHORT final page 2
+			// (b3,b4). Each cycle rescans from page 1 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting b3/b4 forever) instead of settling and advancing.
 			ts := now.Add(-time.Hour).UTC()
 			mk := func(id string) genericclient.Beneficiary {
 				return genericclient.Beneficiary{Id: id, OwnerName: "owner-" + id, CreatedAt: ts}
@@ -182,37 +187,37 @@ var _ = Describe("Generic Plugin External Accounts", func() {
 				return out
 			}
 
-			// Cycle 1: fresh state, page 1 -> b0, b1.
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
-			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			// Cycle 1: fresh state, page 1 -> b0, b1, b2.
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(3), time.Time{}).Return(all[0:3], nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1"}))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1", "b2"}))
 			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 1 re-fetched then page 2 -> b2, b3. The boundary b1 is
-			// deduped; b0 (a same-second sibling on the re-fetched page 1) is
-			// re-emitted by design — storage upserts dedup it. Asserting the exact
-			// set catches any unintended extra re-emission.
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> b3, b4.
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b2", "b3"}))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b3", "b4"}))
 
-			// Cycle 3: page 3 -> b4 (group fully drained on a short final page).
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing. A single LastProcessedID would re-emit b3 or
+			// b4 here and oscillate; the set settles to empty.
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b4"}))
+			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
 
-			// Cycle 4: a newer-second beneficiary b5 lands on the short last page
-			// (3). The cursor must stay on page 3 rather than advance to page 4, or
-			// b5 would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second beneficiary b5 appears on the (formerly short)
+			// page 2. The set skips b3/b4 and reaches b5 — no stranding.
 			ts2 := ts.Add(time.Second)
 			b5 := genericclient.Beneficiary{Id: "b5", OwnerName: "owner-b5", CreatedAt: ts2}
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Beneficiary{all[4], b5}, nil)
-			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Beneficiary{}, nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(2), int64(3), ts).Return([]genericclient.Beneficiary{all[3], all[4], b5}, nil)
+			m.EXPECT().ListBeneficiaries(gomock.Any(), int64(3), int64(3), ts).Return([]genericclient.Beneficiary{}, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b5"}))
 		})

--- a/ce/plugins/generic/payments.go
+++ b/ce/plugins/generic/payments.go
@@ -14,6 +14,10 @@ import (
 
 type paymentsState struct {
 	LastUpdatedAtFrom time.Time `json:"lastUpdatedAtFrom"`
+	// LastProcessedID is the reference of the last payment emitted at exactly
+	// LastUpdatedAtFrom, so the inclusive (>=) watermark filter can exclude only
+	// that already-processed row while keeping distinct same-timestamp payments.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -26,6 +30,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 
 	newState := paymentsState{
 		LastUpdatedAtFrom: oldState.LastUpdatedAtFrom,
+		LastProcessedID:   oldState.LastProcessedID,
 	}
 
 	payments := make([]models.PSPPayment, 0)
@@ -55,7 +60,8 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	if len(updatedAts) > 0 {
-		newState.LastUpdatedAtFrom = updatedAts[len(payments)-1]
+		newState.LastUpdatedAtFrom = updatedAts[len(updatedAts)-1]
+		newState.LastProcessedID = payments[len(payments)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -77,11 +83,12 @@ func fillPayments(
 	oldState paymentsState,
 ) ([]models.PSPPayment, []time.Time, error) {
 	for _, payment := range pagedPayments {
-		switch payment.UpdatedAt.Compare(oldState.LastUpdatedAtFrom) {
-		case -1, 0:
-			// Payment already ingested, skip
+		// Inclusive watermark: skip payments strictly before it, and the single
+		// already-processed payment at exactly the watermark. Distinct payments
+		// sharing that timestamp are kept (M-CON2).
+		cmp := payment.UpdatedAt.Compare(oldState.LastUpdatedAtFrom)
+		if cmp < 0 || (cmp == 0 && payment.Id == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(payment)

--- a/ce/plugins/generic/payments.go
+++ b/ce/plugins/generic/payments.go
@@ -18,6 +18,12 @@ type paymentsState struct {
 	// LastUpdatedAtFrom, so the inclusive (>=) watermark filter can exclude only
 	// that already-processed row while keeping distinct same-timestamp payments.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastUpdatedAtFrom second.
+	// It advances while the watermark second is unchanged (a same-second group
+	// larger than one page) and resets to 1 once the watermark moves to a newer
+	// second, so a same-second group spanning pages is walked without re-scanning
+	// from page 1 each cycle (which a single LastProcessedID cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -27,17 +33,25 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 	}
+	if oldState.Page < 1 {
+		oldState.Page = 1
+	}
 
 	newState := paymentsState{
 		LastUpdatedAtFrom: oldState.LastUpdatedAtFrom,
 		LastProcessedID:   oldState.LastProcessedID,
+		Page:              oldState.Page,
 	}
 
 	payments := make([]models.PSPPayment, 0)
 	updatedAts := make([]time.Time, 0)
 	needMore := false
 	hasMore := false
-	for page := 1; ; page++ {
+	// Resume at the persisted page and walk forward. We do NOT trim back to
+	// PageSize and restart at page 1 next cycle: that would skip the trimmed
+	// rows. Instead the page cursor (below) records how far we got.
+	page := oldState.Page
+	for {
 		pagedPayments, err := p.client.ListTransactions(ctx, int64(page), int64(req.PageSize), oldState.LastUpdatedAtFrom)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -52,16 +66,20 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		payments = payments[:req.PageSize]
-		updatedAts = updatedAts[:req.PageSize]
+		page++
 	}
 
 	if len(updatedAts) > 0 {
 		newState.LastUpdatedAtFrom = updatedAts[len(updatedAts)-1]
 		newState.LastProcessedID = payments[len(payments)-1].Reference
+		// If the watermark second did not advance, the whole batch was inside one
+		// same-second group; resume after the pages we just consumed. Otherwise the
+		// watermark moved to a newer second, so re-anchor pagination at page 1.
+		if newState.LastUpdatedAtFrom.Equal(oldState.LastUpdatedAtFrom) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 1
+		}
 	}
 
 	payload, err := json.Marshal(newState)

--- a/ce/plugins/generic/payments.go
+++ b/ce/plugins/generic/payments.go
@@ -22,6 +22,11 @@ type paymentsState struct {
 	// a same-second group larger than PageSize is walked across cycles without a
 	// drifting page cursor, and a multi-row final page cannot oscillate (every
 	// already-emitted sibling is skipped, not just one).
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/generic/payments.go
+++ b/ce/plugins/generic/payments.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/generic/client/generated"
@@ -14,16 +15,14 @@ import (
 
 type paymentsState struct {
 	LastUpdatedAtFrom time.Time `json:"lastUpdatedAtFrom"`
-	// LastProcessedID is the reference of the last payment emitted at exactly
-	// LastUpdatedAtFrom, so the inclusive (>=) watermark filter can exclude only
-	// that already-processed row while keeping distinct same-timestamp payments.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastUpdatedAtFrom second.
-	// It advances while the watermark second is unchanged (a same-second group
-	// larger than one page) and resets to 1 once the watermark moves to a newer
-	// second, so a same-second group spanning pages is walked without re-scanning
-	// from page 1 each cycle (which a single LastProcessedID cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the references of ALL payments already emitted at
+	// exactly LastUpdatedAtFrom, accumulated across cycles while the watermark
+	// second is unchanged and reset when it advances. The server filter is
+	// inclusive (>=), so each cycle rescans from page 1 and skips this whole set:
+	// a same-second group larger than PageSize is walked across cycles without a
+	// drifting page cursor, and a multi-row final page cannot oscillate (every
+	// already-emitted sibling is skipped, not just one).
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -33,25 +32,22 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 	}
-	if oldState.Page < 1 {
-		oldState.Page = 1
-	}
 
 	newState := paymentsState{
 		LastUpdatedAtFrom: oldState.LastUpdatedAtFrom,
-		LastProcessedID:   oldState.LastProcessedID,
-		Page:              oldState.Page,
+		LastProcessedIDs:  oldState.LastProcessedIDs,
 	}
 
 	payments := make([]models.PSPPayment, 0)
 	updatedAts := make([]time.Time, 0)
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward. We do NOT trim back to
-	// PageSize and restart at page 1 next cycle: that would skip the trimmed
-	// rows. Instead the page cursor (below) records how far we got.
-	page := oldState.Page
-	for {
+	// Rescan from page 1 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 1
+	// re-includes the watermark second.
+	for page := 1; ; page++ {
 		pagedPayments, err := p.client.ListTransactions(ctx, int64(page), int64(req.PageSize), oldState.LastUpdatedAtFrom)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -66,27 +62,27 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
 	if len(updatedAts) > 0 {
-		newState.LastUpdatedAtFrom = updatedAts[len(updatedAts)-1]
-		newState.LastProcessedID = payments[len(payments)-1].Reference
-		// While the watermark second is unchanged the batch was one same-second
-		// group: advance past the consumed pages only if there is definitely a
-		// full next page (hasMore). If it drained on a short final page, keep the
-		// cursor there — a newer row appended to that second's >= watermark query
-		// lands on this very page, so advancing past it would strand it forever.
-		// When the watermark moved to a newer second, re-anchor at page 1.
-		if newState.LastUpdatedAtFrom.Equal(oldState.LastUpdatedAtFrom) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+		lastUpdatedAt := updatedAts[len(updatedAts)-1]
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range payments {
+			if updatedAts[i].Equal(lastUpdatedAt) {
+				idsAtWatermark = append(idsAtWatermark, payments[i].Reference)
 			}
-		} else {
-			newState.Page = 1
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if lastUpdatedAt.Equal(oldState.LastUpdatedAtFrom) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastUpdatedAtFrom = lastUpdatedAt
 	}
 
 	payload, err := json.Marshal(newState)
@@ -108,11 +104,11 @@ func fillPayments(
 	oldState paymentsState,
 ) ([]models.PSPPayment, []time.Time, error) {
 	for _, payment := range pagedPayments {
-		// Inclusive watermark: skip payments strictly before it, and the single
-		// already-processed payment at exactly the watermark. Distinct payments
+		// Inclusive watermark: skip payments strictly before it, and any already-
+		// emitted payment at exactly the watermark second. Distinct payments
 		// sharing that timestamp are kept (M-CON2).
 		cmp := payment.UpdatedAt.Compare(oldState.LastUpdatedAtFrom)
-		if cmp < 0 || (cmp == 0 && payment.Id == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, payment.Id)) {
 			continue
 		}
 

--- a/ce/plugins/generic/payments.go
+++ b/ce/plugins/generic/payments.go
@@ -72,11 +72,18 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	if len(updatedAts) > 0 {
 		newState.LastUpdatedAtFrom = updatedAts[len(updatedAts)-1]
 		newState.LastProcessedID = payments[len(payments)-1].Reference
-		// If the watermark second did not advance, the whole batch was inside one
-		// same-second group; resume after the pages we just consumed. Otherwise the
-		// watermark moved to a newer second, so re-anchor pagination at page 1.
+		// While the watermark second is unchanged the batch was one same-second
+		// group: advance past the consumed pages only if there is definitely a
+		// full next page (hasMore). If it drained on a short final page, keep the
+		// cursor there — a newer row appended to that second's >= watermark query
+		// lands on this very page, so advancing past it would strand it forever.
+		// When the watermark moved to a newer second, re-anchor at page 1.
 		if newState.LastUpdatedAtFrom.Equal(oldState.LastUpdatedAtFrom) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 1
 		}

--- a/ce/plugins/generic/payments_test.go
+++ b/ce/plugins/generic/payments_test.go
@@ -609,17 +609,38 @@ func TestFetchNextPayments_WalksLargeSameSecondGroup(t *testing.T) {
 	require.Equal(t, []string{"id0", "id1"}, refs(resp.Payments))
 	require.True(t, resp.HasMore)
 
-	// Cycle 2: page 1 re-fetched (id1 deduped) then page 2 -> id2, id3 (progress).
+	// Cycle 2: page 1 re-fetched then page 2 -> id2, id3. The boundary id1 is
+	// deduped; id0 (a same-second sibling on the re-fetched page 1) is re-emitted
+	// by design — storage upserts dedup it. Asserting the exact set catches any
+	// unintended extra re-emission.
 	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
 	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
 	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
 	require.NoError(t, err)
-	require.Subset(t, refs(resp.Payments), []string{"id2", "id3"})
-	require.NotContains(t, refs(resp.Payments), "id1") // exact boundary deduped, not lost
+	require.Equal(t, []string{"id0", "id2", "id3"}, refs(resp.Payments))
 
-	// Cycle 3: page 3 -> id4. The group is fully drained without stalling.
+	// Cycle 3: page 3 -> id4 (group fully drained on a short final page).
 	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
 	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
 	require.NoError(t, err)
-	require.Contains(t, refs(resp.Payments), "id4")
+	require.Equal(t, []string{"id4"}, refs(resp.Payments))
+
+	// Cycle 4: a newer-second transaction id5 lands on the short last page (3).
+	// The cursor must stay on page 3 rather than advance to page 4, or id5 would
+	// be stranded forever behind an empty page.
+	ts2 := ts.Add(time.Second)
+	id5 := genericclient.Transaction{
+		Id:        "id5",
+		CreatedAt: ts2,
+		UpdatedAt: ts2,
+		Currency:  "EUR/2",
+		Type:      genericclient.PAYIN,
+		Status:    genericclient.SUCCEEDED,
+		Amount:    "1000",
+	}
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Transaction{all[4], id5}, nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Transaction{}, nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id5"}, refs(resp.Payments))
 }

--- a/ce/plugins/generic/payments_test.go
+++ b/ce/plugins/generic/payments_test.go
@@ -567,3 +567,59 @@ func TestPaymentsState_Marshaling(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, state.LastUpdatedAtFrom.Equal(decoded.LastUpdatedAtFrom))
 }
+
+func TestFetchNextPayments_WalksLargeSameSecondGroup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := client.NewMockClient(ctrl)
+	plugin := &Plugin{client: mockClient}
+
+	// Five transactions all sharing the same UpdatedAt second, fetched two per
+	// page. A single LastProcessedID without a page cursor oscillates and never
+	// reaches id3/id4; the page cursor must walk through the whole group.
+	ts := time.Now().UTC().Add(-time.Hour)
+	mk := func(id string) genericclient.Transaction {
+		return genericclient.Transaction{
+			Id:        id,
+			CreatedAt: ts,
+			UpdatedAt: ts,
+			Currency:  "EUR/2",
+			Type:      genericclient.PAYIN,
+			Status:    genericclient.SUCCEEDED,
+			Amount:    "1000",
+		}
+	}
+	all := []genericclient.Transaction{mk("id0"), mk("id1"), mk("id2"), mk("id3"), mk("id4")}
+
+	refs := func(ps []models.PSPPayment) []string {
+		out := make([]string, len(ps))
+		for i := range ps {
+			out[i] = ps[i].Reference
+		}
+		return out
+	}
+
+	// Cycle 1: fresh state, page 1 -> id0, id1.
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
+	resp, err := plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id0", "id1"}, refs(resp.Payments))
+	require.True(t, resp.HasMore)
+
+	// Cycle 2: page 1 re-fetched (id1 deduped) then page 2 -> id2, id3 (progress).
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	require.NoError(t, err)
+	require.Subset(t, refs(resp.Payments), []string{"id2", "id3"})
+	require.NotContains(t, refs(resp.Payments), "id1") // exact boundary deduped, not lost
+
+	// Cycle 3: page 3 -> id4. The group is fully drained without stalling.
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	require.NoError(t, err)
+	require.Contains(t, refs(resp.Payments), "id4")
+}

--- a/ce/plugins/generic/payments_test.go
+++ b/ce/plugins/generic/payments_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Generic Plugin Payments", func() {
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"lastUpdatedAtFrom": "%s", "lastProcessedID": "%s"}`,
+					`{"lastUpdatedAtFrom": "%s", "lastProcessedIDs": ["%s"]}`,
 					samplePayments[38].UpdatedAt.Format(time.RFC3339Nano),
 					samplePayments[38].Id,
 				)),
@@ -198,7 +198,7 @@ var _ = Describe("Generic Plugin Payments", func() {
 			}
 
 			req := models.FetchNextPaymentsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastUpdatedAtFrom": "%s", "lastProcessedID": "a"}`, ts.Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastUpdatedAtFrom": "%s", "lastProcessedIDs": ["a"]}`, ts.Format(time.RFC3339Nano))),
 				PageSize: 40,
 			}
 			m.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(40), ts).Return(sameSecond, nil)
@@ -577,9 +577,11 @@ func TestFetchNextPayments_WalksLargeSameSecondGroup(t *testing.T) {
 	mockClient := client.NewMockClient(ctrl)
 	plugin := &Plugin{client: mockClient}
 
-	// Five transactions all sharing the same UpdatedAt second, fetched two per
-	// page. A single LastProcessedID without a page cursor oscillates and never
-	// reaches id3/id4; the page cursor must walk through the whole group.
+	// Five transactions all sharing the same UpdatedAt second, fetched three per
+	// page so the group spans pages 1 (id0,id1,id2) and a SHORT final page 2
+	// (id3,id4). Each cycle rescans from page 1 and skips the processed-ID set;
+	// a single LastProcessedID would oscillate on the multi-row final page
+	// (re-emitting id3/id4 forever) instead of settling and advancing.
 	ts := time.Now().UTC().Add(-time.Hour)
 	mk := func(id string) genericclient.Transaction {
 		return genericclient.Transaction{
@@ -602,32 +604,31 @@ func TestFetchNextPayments_WalksLargeSameSecondGroup(t *testing.T) {
 		return out
 	}
 
-	// Cycle 1: fresh state, page 1 -> id0, id1.
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(2), time.Time{}).Return(all[0:2], nil)
-	resp, err := plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2})
+	// Cycle 1: fresh state, page 1 -> id0, id1, id2.
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(3), time.Time{}).Return(all[0:3], nil)
+	resp, err := plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 3})
 	require.NoError(t, err)
-	require.Equal(t, []string{"id0", "id1"}, refs(resp.Payments))
+	require.Equal(t, []string{"id0", "id1", "id2"}, refs(resp.Payments))
 	require.True(t, resp.HasMore)
 
-	// Cycle 2: page 1 re-fetched then page 2 -> id2, id3. The boundary id1 is
-	// deduped; id0 (a same-second sibling on the re-fetched page 1) is re-emitted
-	// by design — storage upserts dedup it. Asserting the exact set catches any
-	// unintended extra re-emission.
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(2), ts).Return(all[0:2], nil)
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(2), ts).Return(all[2:4], nil)
-	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	// Cycle 2: rescan page 1 (all skipped via the set) then page 2 -> id3, id4.
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 	require.NoError(t, err)
-	require.Equal(t, []string{"id0", "id2", "id3"}, refs(resp.Payments))
+	require.Equal(t, []string{"id3", "id4"}, refs(resp.Payments))
 
-	// Cycle 3: page 3 -> id4 (group fully drained on a short final page).
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(2), ts).Return(all[4:5], nil)
-	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	// Cycle 3: group fully drained — every row is in the processed-ID set, so the
+	// rescan returns nothing. A single LastProcessedID would re-emit id3 or id4
+	// here and oscillate; the set settles to empty.
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(3), ts).Return(all[3:5], nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 	require.NoError(t, err)
-	require.Equal(t, []string{"id4"}, refs(resp.Payments))
+	require.Empty(t, refs(resp.Payments))
 
-	// Cycle 4: a newer-second transaction id5 lands on the short last page (3).
-	// The cursor must stay on page 3 rather than advance to page 4, or id5 would
-	// be stranded forever behind an empty page.
+	// Cycle 4: a newer-second transaction id5 appears on the (formerly short)
+	// page 2. The set skips id3/id4 and reaches id5 — no stranding.
 	ts2 := ts.Add(time.Second)
 	id5 := genericclient.Transaction{
 		Id:        "id5",
@@ -638,9 +639,10 @@ func TestFetchNextPayments_WalksLargeSameSecondGroup(t *testing.T) {
 		Status:    genericclient.SUCCEEDED,
 		Amount:    "1000",
 	}
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(2), ts).Return([]genericclient.Transaction{all[4], id5}, nil)
-	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(4), int64(2), ts).Return([]genericclient.Transaction{}, nil)
-	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2})
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(3), ts).Return(all[0:3], nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(2), int64(3), ts).Return([]genericclient.Transaction{all[3], all[4], id5}, nil)
+	mockClient.EXPECT().ListTransactions(gomock.Any(), int64(3), int64(3), ts).Return([]genericclient.Transaction{}, nil)
+	resp, err = plugin.fetchNextPayments(context.Background(), models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3})
 	require.NoError(t, err)
 	require.Equal(t, []string{"id5"}, refs(resp.Payments))
 }

--- a/ce/plugins/generic/payments_test.go
+++ b/ce/plugins/generic/payments_test.go
@@ -151,7 +151,11 @@ var _ = Describe("Generic Plugin Payments", func() {
 
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			req := models.FetchNextPaymentsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastUpdatedAtFrom": "%s"}`, samplePayments[38].UpdatedAt.Format(time.RFC3339Nano))),
+				State: []byte(fmt.Sprintf(
+					`{"lastUpdatedAtFrom": "%s", "lastProcessedID": "%s"}`,
+					samplePayments[38].UpdatedAt.Format(time.RFC3339Nano),
+					samplePayments[38].Id,
+				)),
 				PageSize: 40,
 			}
 
@@ -176,6 +180,35 @@ var _ = Describe("Generic Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
 			Expect(state.LastUpdatedAtFrom.UTC()).To(Equal(samplePayments[49].UpdatedAt.UTC()))
+		})
+
+		It("keeps distinct payments that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
+			ts := now.Add(-time.Hour).UTC()
+			sameSecond := make([]genericclient.Transaction, 0, 3)
+			for _, id := range []string{"a", "b", "c"} {
+				sameSecond = append(sameSecond, genericclient.Transaction{
+					Id:        id,
+					CreatedAt: ts,
+					UpdatedAt: ts,
+					Currency:  "EUR/2",
+					Type:      genericclient.PAYIN,
+					Status:    genericclient.SUCCEEDED,
+					Amount:    "1000",
+				})
+			}
+
+			req := models.FetchNextPaymentsRequest{
+				State:    []byte(fmt.Sprintf(`{"lastUpdatedAtFrom": "%s", "lastProcessedID": "a"}`, ts.Format(time.RFC3339Nano))),
+				PageSize: 40,
+			}
+			m.EXPECT().ListTransactions(gomock.Any(), int64(1), int64(40), ts).Return(sameSecond, nil)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			// "a" was the already-processed boundary row; "b" and "c" share its
+			// timestamp and must NOT be dropped.
+			Expect(resp.Payments).To(HaveLen(2))
+			Expect([]string{resp.Payments[0].Reference, resp.Payments[1].Reference}).To(ConsistOf("b", "c"))
 		})
 	})
 })

--- a/ce/plugins/mangopay/payments.go
+++ b/ce/plugins/mangopay/payments.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -15,8 +16,17 @@ import (
 )
 
 type paymentsState struct {
-	LastPage         int       `json:"lastPage"`
 	LastCreationDate time.Time `json:"lastCreationDate"`
+	// LastProcessedIDs holds the IDs of all transactions already emitted at exactly
+	// LastCreationDate (second precision), accumulated across cycles while the
+	// watermark second is unchanged and reset when it advances.
+	//
+	// Mangopay's AfterDate server filter is EXCLUSIVE second-precision, so we query
+	// watermark-1s to re-include the watermark second (M-CON3). Combined with a
+	// client-side skip of this set (and a rescan from page 1 each cycle), a
+	// same-second group larger than PageSize is walked without a drifting page
+	// cursor: every already-emitted sibling is skipped so the scan reaches new rows.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -24,10 +34,6 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	if req.State != nil {
 		if err := json.Unmarshal(req.State, &oldState); err != nil {
 			return models.FetchNextPaymentsResponse{}, err
-		}
-	} else {
-		oldState = paymentsState{
-			LastPage: 1,
 		}
 	}
 
@@ -40,15 +46,14 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	newState := paymentsState{
-		LastPage:         oldState.LastPage,
 		LastCreationDate: oldState.LastCreationDate,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	// Mangopay's AfterDate is an EXCLUSIVE, second-precision server filter. Querying
 	// with the raw watermark drops every transaction in the watermark's own second
-	// (M-CON3). Subtract one second so that second is returned; the LastPage counter
-	// then pages through any same-second group across cycles (mangopay's equivalent
-	// of qonto's Page-based dedup; storage upserts dedup harmless re-emission).
+	// (M-CON3). Subtract one second so that second is returned; fillPayments then
+	// skips rows already emitted (LastProcessedIDs) so the rescan reaches new rows.
 	afterDate := oldState.LastCreationDate
 	if !afterDate.IsZero() {
 		afterDate = afterDate.Add(-time.Second)
@@ -57,14 +62,15 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	var payments []models.PSPPayment
 	needMore := false
 	hasMore := false
-	page := oldState.LastPage
-	for {
+	// Rescan from page 1 each cycle (no drifting page cursor): the processed-ID set
+	// skips already-emitted siblings, so the scan always reaches unseen rows.
+	for page := 1; ; page++ {
 		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, afterDate)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
 
-		payments, err = fillPayments(pagedTransactions, payments)
+		payments, err = fillPayments(pagedTransactions, payments, oldState)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
@@ -73,24 +79,30 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		if !needMore || !hasMore {
 			break
 		}
-
-		page++
 	}
 
 	// Note that we are NOT trimming data as in other connectors to respect the pageSize; doing so would mean we could
 	// lose data as we switch to the next page. We would go over the req.PageSize by max 2x
-	//if !needMore {
-	//	payments = payments[:req.PageSize]
-	//}
 
 	if len(payments) > 0 {
-		if oldState.LastCreationDate.Equal(payments[len(payments)-1].CreatedAt) {
-			newState.LastPage = page + 1
-		} else {
-			newState.LastPage = 1
-		}
-		newState.LastCreationDate = payments[len(payments)-1].CreatedAt
+		lastCreationDate := payments[len(payments)-1].CreatedAt
 
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range payments {
+			if payments[i].CreatedAt.Equal(lastCreationDate) {
+				idsAtWatermark = append(idsAtWatermark, payments[i].Reference)
+			}
+		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if lastCreationDate.Equal(oldState.LastCreationDate) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreationDate = lastCreationDate
 	}
 
 	payload, err := json.Marshal(newState)
@@ -108,8 +120,18 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 func fillPayments(
 	pagedTransactions []client.Payment,
 	payments []models.PSPPayment,
+	oldState paymentsState,
 ) ([]models.PSPPayment, error) {
 	for _, transaction := range pagedTransactions {
+		// Inclusive watermark: skip transactions strictly before it (over-fetched
+		// via AfterDate-1s), and any already-emitted transaction at exactly the
+		// watermark second. Distinct same-second transactions are kept (M-CON3).
+		createdAt := time.Unix(transaction.CreationDate, 0)
+		cmp := createdAt.Compare(oldState.LastCreationDate)
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, transaction.Id)) {
+			continue
+		}
+
 		payment, err := transactionToPayment(transaction)
 		if err != nil {
 			return nil, err

--- a/ce/plugins/mangopay/payments.go
+++ b/ce/plugins/mangopay/payments.go
@@ -44,12 +44,22 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		LastCreationDate: oldState.LastCreationDate,
 	}
 
+	// Mangopay's AfterDate is an EXCLUSIVE, second-precision server filter. Querying
+	// with the raw watermark drops every transaction in the watermark's own second
+	// (M-CON3). Subtract one second so that second is returned; the LastPage counter
+	// then pages through any same-second group across cycles (mangopay's equivalent
+	// of qonto's Page-based dedup; storage upserts dedup harmless re-emission).
+	afterDate := oldState.LastCreationDate
+	if !afterDate.IsZero() {
+		afterDate = afterDate.Add(-time.Second)
+	}
+
 	var payments []models.PSPPayment
 	needMore := false
 	hasMore := false
 	page := oldState.LastPage
 	for {
-		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, oldState.LastCreationDate)
+		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, afterDate)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}

--- a/ce/plugins/mangopay/payments_test.go
+++ b/ce/plugins/mangopay/payments_test.go
@@ -1,6 +1,7 @@
 package mangopay
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,7 +95,6 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreationDate.IsZero()).To(BeTrue())
 		})
 
@@ -120,7 +120,6 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
 			createdTime := time.Unix(sampleTransactions[49].CreationDate, 0)
-			Expect(state.LastPage).To(Equal(1))
 			Expect(state.LastCreationDate.UTC()).To(Equal(createdTime.UTC()))
 		})
 
@@ -144,7 +143,6 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			var state paymentsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			Expect(state.LastPage).To(Equal(1))
 			createdTime := time.Unix(sampleTransactions[39].CreationDate, 0)
 			Expect(state.LastCreationDate.UTC()).To(Equal(createdTime.UTC()))
 		})
@@ -172,22 +170,22 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			createdTime := time.Unix(sampleTransactions[48].CreationDate, 0)
 			Expect(state.LastCreationDate.UTC()).To(Equal(createdTime.UTC()))
 		})
 
-		It("should fetch next payments - when last account in current page updatedAt == oldState.updatedAt, we need to fetch next page", func(ctx SpecContext) {
-			// Given
+		It("accumulates the processed-ID set when the batch stays in the watermark second", func(ctx SpecContext) {
+			// Given: the watermark already sits on the shared second, and the next
+			// batch is entirely within it.
 			lastCreatedAt := time.Unix(sampleTransactions[4].CreationDate, 0).UTC()
 
 			req := models.FetchNextPaymentsRequest{
-				State:       []byte(fmt.Sprintf(`{"lastPage": 1, "lastCreationDate": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano))),
+				State:       []byte(fmt.Sprintf(`{"lastCreationDate": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano))),
 				PageSize:    5,
 				FromPayload: json.RawMessage(`{"Reference": "test"}`),
 			}
 
-			// Set all transactions to have the same updatedAt
+			// Set all transactions to have the same CreationDate as the watermark.
 			for i := range sampleTransactions {
 				sampleTransactions[i].CreationDate = sampleTransactions[4].CreationDate
 			}
@@ -209,9 +207,10 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			var state paymentsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(2))
 			Expect(state.LastCreationDate.UTC()).To(Equal(lastCreatedAt))
+			// Watermark second unchanged -> the emitted IDs are tracked so the next
+			// cycle skips them.
+			Expect(state.LastProcessedIDs).To(ConsistOf("5", "6", "7", "8", "9"))
 		})
 
 		It("includes a transaction at exactly the watermark second (M-CON3)", func(ctx SpecContext) {
@@ -244,6 +243,61 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			Expect(err).To(BeNil())
 			Expect(resp.Payments).To(HaveLen(1))
 			Expect(resp.Payments[0].Reference).To(Equal("same-second"))
+		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			ts := time.Now().UTC().Add(-time.Hour)
+			mk := func(id string) client.Payment {
+				return client.Payment{
+					Id:               id,
+					CreationDate:     ts.Unix(),
+					DebitedFunds:     client.Funds{Currency: "USD", Amount: "100"},
+					Status:           "SUCCEEDED",
+					Type:             "PAYIN",
+					CreditedWalletID: "acc2",
+					DebitedWalletID:  "acc1",
+				}
+			}
+			all := []client.Payment{mk("t0"), mk("t1"), mk("t2"), mk("t3"), mk("t4")}
+			// Mangopay rescans from page 1 each cycle (AfterDate re-includes the
+			// watermark second); serve the list page by page so the processed-ID set
+			// has to skip already-emitted siblings to make progress.
+			m.EXPECT().GetTransactions(gomock.Any(), "test", gomock.Any(), 2, gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ string, page, _ int, _ time.Time) ([]client.Payment, error) {
+					start := (page - 1) * 2
+					if start >= len(all) {
+						return []client.Payment{}, nil
+					}
+					end := start + 2
+					if end > len(all) {
+						end = len(all)
+					}
+					return all[start:end], nil
+				},
+			).AnyTimes()
+			refs := func(ps []models.PSPPayment) []string {
+				out := make([]string, len(ps))
+				for i := range ps {
+					out[i] = ps[i].Reference
+				}
+				return out
+			}
+			fromPayload := json.RawMessage(`{"Reference": "test"}`)
+
+			// Cycle 1: page 1 -> t0, t1.
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"t0", "t1"}))
+
+			// Cycle 2: rescan skips t0,t1 (in set), page 2 -> t2, t3.
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ConsistOf("t2", "t3"))
+
+			// Cycle 3: page 3 -> t4 (group fully drained, no stall).
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElement("t4"))
 		})
 	})
 })

--- a/ce/plugins/mangopay/payments_test.go
+++ b/ce/plugins/mangopay/payments_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 				FromPayload: json.RawMessage(`{"Reference": "test"}`),
 			}
 
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 10, lastCreatedAt.UTC()).Return(
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 10, lastCreatedAt.UTC().Add(-time.Second)).Return(
 				sampleTransactions[39:49],
 				nil,
 			)
@@ -192,7 +192,7 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 				sampleTransactions[i].CreationDate = sampleTransactions[4].CreationDate
 			}
 			transactionsReturnedByClient := sampleTransactions[5:10]
-			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 5, lastCreatedAt).Times(1).Return(
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 5, lastCreatedAt.Add(-time.Second)).Times(1).Return(
 				transactionsReturnedByClient,
 				nil,
 			)
@@ -212,6 +212,38 @@ var _ = Describe("Mangopay Plugin Payments", func() {
 			// We fetched everything, state should be resetted
 			Expect(state.LastPage).To(Equal(2))
 			Expect(state.LastCreationDate.UTC()).To(Equal(lastCreatedAt))
+		})
+
+		It("includes a transaction at exactly the watermark second (M-CON3)", func(ctx SpecContext) {
+			watermark := time.Unix(sampleTransactions[10].CreationDate, 0).UTC()
+			req := models.FetchNextPaymentsRequest{
+				State:       []byte(fmt.Sprintf(`{"lastPage": 1, "lastCreationDate": "%s"}`, watermark.Format(time.RFC3339Nano))),
+				PageSize:    60,
+				FromPayload: json.RawMessage(`{"Reference": "test"}`),
+			}
+
+			// A transaction created in the SAME second as the watermark would be
+			// dropped by an exclusive AfterDate=watermark filter. The fix queries
+			// AfterDate=watermark-1s, so the server returns the watermark second and
+			// this row is emitted instead of lost.
+			atWatermark := client.Payment{
+				Id:               "same-second",
+				CreationDate:     watermark.Unix(),
+				DebitedFunds:     client.Funds{Currency: "USD", Amount: "100"},
+				Status:           "SUCCEEDED",
+				Type:             "PAYIN",
+				CreditedWalletID: "acc2",
+				DebitedWalletID:  "acc1",
+			}
+			m.EXPECT().GetTransactions(gomock.Any(), "test", 1, 60, watermark.Add(-time.Second)).Return(
+				[]client.Payment{atWatermark},
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp.Payments).To(HaveLen(1))
+			Expect(resp.Payments[0].Reference).To(Equal("same-second"))
 		})
 	})
 })

--- a/ce/plugins/modulr/accounts.go
+++ b/ce/plugins/modulr/accounts.go
@@ -28,6 +28,11 @@ type accountsState struct {
 	// JSON keys simply don't bind). The watermark second is re-emitted once after
 	// deploy, which is idempotent (storage upserts dedup it) and triggers no
 	// recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/modulr/accounts.go
+++ b/ce/plugins/modulr/accounts.go
@@ -18,6 +18,13 @@ type accountsState struct {
 	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
 	// already-processed row while keeping distinct same-timestamp accounts.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastCreatedAt second
+	// (0-indexed). It advances while the watermark second is unchanged (a
+	// same-second group larger than one page) and resets to 0 once the watermark
+	// moves to a newer second, so a same-second group spanning pages is walked
+	// without re-scanning from page 0 each cycle (which a single LastProcessedID
+	// cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -31,18 +38,23 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	newState := accountsState{
 		LastCreatedAt:   oldState.LastCreatedAt,
 		LastProcessedID: oldState.LastProcessedID,
+		Page:            oldState.Page,
 	}
 
 	var accounts []models.PSPAccount
 	needMore := false
 	hasMore := false
-	for page := 0; ; page++ {
+	// Resume at the persisted page and walk forward; the page cursor below
+	// records how far we got. We consume each page fully (no PageSize cap or
+	// trim) so resuming at the next page cannot skip rows.
+	page := oldState.Page
+	for {
 		pagedAccounts, err := p.client.GetAccounts(ctx, page, req.PageSize, oldState.LastCreatedAt)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
 		}
 
-		accounts, err = fillAccounts(pagedAccounts, accounts, oldState, req.PageSize)
+		accounts, err = fillAccounts(pagedAccounts, accounts, oldState)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
 		}
@@ -51,15 +63,19 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		accounts = accounts[:req.PageSize]
+		page++
 	}
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 0.
+		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 0
+		}
 	}
 
 	payload, err := json.Marshal(newState)
@@ -78,13 +94,8 @@ func fillAccounts(
 	pagedAccounts []client.Account,
 	accounts []models.PSPAccount,
 	oldState accountsState,
-	pageSize int,
 ) ([]models.PSPAccount, error) {
 	for _, account := range pagedAccounts {
-		if len(accounts) >= pageSize {
-			break
-		}
-
 		createdTime, err := time.Parse("2006-01-02T15:04:05.999-0700", account.CreatedDate)
 		if err != nil {
 			return nil, err

--- a/ce/plugins/modulr/accounts.go
+++ b/ce/plugins/modulr/accounts.go
@@ -69,10 +69,18 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 0.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 0.
 		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 0
 		}

--- a/ce/plugins/modulr/accounts.go
+++ b/ce/plugins/modulr/accounts.go
@@ -3,6 +3,7 @@ package modulr
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -14,17 +15,20 @@ import (
 
 type accountsState struct {
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
-	// LastProcessedID is the reference of the last account emitted at exactly
-	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
-	// already-processed row while keeping distinct same-timestamp accounts.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastCreatedAt second
-	// (0-indexed). It advances while the watermark second is unchanged (a
-	// same-second group larger than one page) and resets to 0 once the watermark
-	// moves to a newer second, so a same-second group spanning pages is walked
-	// without re-scanning from page 0 each cycle (which a single LastProcessedID
-	// cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the references of ALL accounts already emitted at
+	// exactly LastCreatedAt, accumulated across cycles while the watermark second
+	// is unchanged and reset when it advances. The server filter is inclusive
+	// (>=), so each cycle rescans from page 0 and skips this whole set: a
+	// same-second group larger than PageSize is walked across cycles without a
+	// drifting page cursor, and a multi-row final page cannot oscillate (every
+	// already-emitted sibling is skipped, not just one).
+	//
+	// Migration note: the previous schema used a singular LastProcessedID plus a
+	// Page cursor; both are ignored on the first decode after deploy (the old
+	// JSON keys simply don't bind). The watermark second is re-emitted once after
+	// deploy, which is idempotent (storage upserts dedup it) and triggers no
+	// recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -36,19 +40,19 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	}
 
 	newState := accountsState{
-		LastCreatedAt:   oldState.LastCreatedAt,
-		LastProcessedID: oldState.LastProcessedID,
-		Page:            oldState.Page,
+		LastCreatedAt:    oldState.LastCreatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	var accounts []models.PSPAccount
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward; the page cursor below
-	// records how far we got. We consume each page fully (no PageSize cap or
-	// trim) so resuming at the next page cannot skip rows.
-	page := oldState.Page
-	for {
+	// Rescan from page 0 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 0
+	// re-includes the watermark second.
+	for page := 0; ; page++ {
 		pagedAccounts, err := p.client.GetAccounts(ctx, page, req.PageSize, oldState.LastCreatedAt)
 		if err != nil {
 			return models.FetchNextAccountsResponse{}, err
@@ -63,27 +67,27 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
 	if len(accounts) > 0 {
-		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 0.
-		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+		last := accounts[len(accounts)-1].CreatedAt
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if accounts[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
 			}
-		} else {
-			newState.Page = 0
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastCreatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -109,11 +113,11 @@ func fillAccounts(
 			return nil, err
 		}
 
-		// Inclusive watermark: skip accounts strictly before it, and the single
-		// already-processed account at exactly the watermark. Distinct accounts
+		// Inclusive watermark: skip accounts strictly before it, and any already-
+		// emitted account at exactly the watermark second. Distinct accounts
 		// sharing that timestamp are kept (M-CON2).
 		cmp := createdTime.Compare(oldState.LastCreatedAt)
-		if cmp < 0 || (cmp == 0 && account.ID == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, account.ID)) {
 			continue
 		}
 

--- a/ce/plugins/modulr/accounts.go
+++ b/ce/plugins/modulr/accounts.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/ce/plugins/modulr/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/pkg/domain/pagination"
@@ -14,6 +14,10 @@ import (
 
 type accountsState struct {
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
+	// LastProcessedID is the reference of the last account emitted at exactly
+	// LastCreatedAt, so the inclusive (>=) watermark filter excludes only that
+	// already-processed row while keeping distinct same-timestamp accounts.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAccountsRequest) (models.FetchNextAccountsResponse, error) {
@@ -25,7 +29,8 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 	}
 
 	newState := accountsState{
-		LastCreatedAt: oldState.LastCreatedAt,
+		LastCreatedAt:   oldState.LastCreatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	var accounts []models.PSPAccount
@@ -54,6 +59,7 @@ func (p *Plugin) fetchNextAccounts(ctx context.Context, req models.FetchNextAcco
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -84,11 +90,12 @@ func fillAccounts(
 			return nil, err
 		}
 
-		switch createdTime.Compare(oldState.LastCreatedAt) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip accounts strictly before it, and the single
+		// already-processed account at exactly the watermark. Distinct accounts
+		// sharing that timestamp are kept (M-CON2).
+		cmp := createdTime.Compare(oldState.LastCreatedAt)
+		if cmp < 0 || (cmp == 0 && account.ID == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(account)

--- a/ce/plugins/modulr/accounts_test.go
+++ b/ce/plugins/modulr/accounts_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			lastCreatedAt, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleAccounts[38].CreatedDate)
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedID": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleAccounts[38].ID)),
 				PageSize: 40,
 			}
 
@@ -169,6 +169,33 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 			// We fetched everything, state should be resetted
 			createdTime, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleAccounts[49].CreatedDate)
 			Expect(state.LastCreatedAt.UTC()).To(Equal(createdTime.UTC()))
+		})
+
+		It("keeps distinct accounts that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
+			createdDate := now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999-0700")
+			ts, _ := time.Parse("2006-01-02T15:04:05.999-0700", createdDate)
+			sameSecond := make([]client.Account, 0, 3)
+			for _, id := range []string{"a", "b", "c"} {
+				sameSecond = append(sameSecond, client.Account{
+					ID:          id,
+					Name:        "acc " + id,
+					Currency:    "USD",
+					CreatedDate: createdDate,
+				})
+			}
+
+			req := models.FetchNextAccountsRequest{
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedID": "a"}`, ts.UTC().Format(time.RFC3339Nano))),
+				PageSize: 40,
+			}
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 40, ts.UTC()).Return(sameSecond, nil)
+
+			resp, err := plg.FetchNextAccounts(ctx, req)
+			Expect(err).To(BeNil())
+			// "a" was the already-processed boundary row; "b" and "c" share its
+			// timestamp and must NOT be dropped.
+			Expect(resp.Accounts).To(HaveLen(2))
+			Expect([]string{resp.Accounts[0].Reference, resp.Accounts[1].Reference}).To(ConsistOf("b", "c"))
 		})
 	})
 })

--- a/ce/plugins/modulr/accounts_test.go
+++ b/ce/plugins/modulr/accounts_test.go
@@ -197,5 +197,41 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 			Expect(resp.Accounts).To(HaveLen(2))
 			Expect([]string{resp.Accounts[0].Reference, resp.Accounts[1].Reference}).To(ConsistOf("b", "c"))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			createdDate := now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999-0700")
+			ts, _ := time.Parse("2006-01-02T15:04:05.999-0700", createdDate)
+			mk := func(id string) client.Account {
+				return client.Account{ID: id, Name: "acc " + id, Currency: "USD", CreatedDate: createdDate}
+			}
+			all := []client.Account{mk("a0"), mk("a1"), mk("a2"), mk("a3"), mk("a4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: page 0 -> a0, a1.
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 2, time.Time{}).Return(all[0:2], nil)
+			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1"}))
+
+			// Cycle 2: page 0 re-fetched (a1 deduped) then page 1 -> a2, a3.
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 2, ts.UTC()).Return(all[0:2], nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(ContainElements("a2", "a3"))
+			Expect(refs(resp.Accounts)).ToNot(ContainElement("a1"))
+
+			// Cycle 3: page 2 -> a4 (group fully drained, no stall).
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(ContainElement("a4"))
+		})
 	})
 })

--- a/ce/plugins/modulr/accounts_test.go
+++ b/ce/plugins/modulr/accounts_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 		It("should fetch next accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			lastCreatedAt, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleAccounts[38].CreatedDate)
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedID": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleAccounts[38].ID)),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedIDs": ["%s"]}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleAccounts[38].ID)),
 				PageSize: 40,
 			}
 
@@ -185,7 +185,7 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 			}
 
 			req := models.FetchNextAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedID": "a"}`, ts.UTC().Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastCreatedAt": "%s", "lastProcessedIDs": ["a"]}`, ts.UTC().Format(time.RFC3339Nano))),
 				PageSize: 40,
 			}
 			m.EXPECT().GetAccounts(gomock.Any(), 0, 40, ts.UTC()).Return(sameSecond, nil)
@@ -204,6 +204,11 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 			mk := func(id string) client.Account {
 				return client.Account{ID: id, Name: "acc " + id, Currency: "USD", CreatedDate: createdDate}
 			}
+			// Five accounts all sharing the same CreatedDate second, fetched three
+			// per page so the group spans page 0 (a0,a1,a2) and a SHORT final page 1
+			// (a3,a4). Each cycle rescans from page 0 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting a3/a4 forever) instead of settling and advancing.
 			all := []client.Account{mk("a0"), mk("a1"), mk("a2"), mk("a3"), mk("a4")}
 			refs := func(as []models.PSPAccount) []string {
 				out := make([]string, len(as))
@@ -213,36 +218,37 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 				return out
 			}
 
-			// Cycle 1: page 0 -> a0, a1.
-			m.EXPECT().GetAccounts(gomock.Any(), 0, 2, time.Time{}).Return(all[0:2], nil)
-			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			// Cycle 1: fresh state, page 0 -> a0, a1, a2.
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 3, time.Time{}).Return(all[0:3], nil)
+			resp, err := plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: []byte(`{}`), PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1"}))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a1", "a2"}))
+			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 0 re-fetched (a1 deduped) then page 1 -> a2, a3.
-			m.EXPECT().GetAccounts(gomock.Any(), 0, 2, ts.UTC()).Return(all[0:2], nil)
-			m.EXPECT().GetAccounts(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 2: rescan page 0 (all skipped via the set) then page 1 -> a3, a4.
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			// Boundary a1 is deduped; a0 (a same-second sibling on the re-fetched
-			// page 0) is re-emitted by design — storage upserts dedup it. The exact
-			// assertion catches any unintended extra re-emission.
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a2", "a3"}))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a3", "a4"}))
 
-			// Cycle 3: page 2 -> a4 (group fully drained on a short final page).
-			m.EXPECT().GetAccounts(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing. A single LastProcessedID would re-emit a3 or
+			// a4 here and oscillate; the set settles to empty.
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(Equal([]string{"a4"}))
+			Expect(refs(resp.Accounts)).To(BeEmpty())
 
-			// Cycle 4: a newer-second account a5 lands on the short last page (2).
-			// The cursor must stay on page 2 rather than advance to page 3, or a5
-			// would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second account a5 appears on the (formerly short) page
+			// 1. The set skips a3/a4 and reaches a5 — no stranding.
 			ts2 := ts.Add(time.Second)
 			a5 := client.Account{ID: "a5", Name: "acc a5", Currency: "USD", CreatedDate: ts2.Format("2006-01-02T15:04:05.999-0700")}
-			m.EXPECT().GetAccounts(gomock.Any(), 2, 2, ts.UTC()).Return([]client.Account{all[4], a5}, nil)
-			m.EXPECT().GetAccounts(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Account{}, nil)
-			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			m.EXPECT().GetAccounts(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 1, 3, ts.UTC()).Return([]client.Account{all[3], all[4], a5}, nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 3, ts.UTC()).Return([]client.Account{}, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Accounts)).To(Equal([]string{"a5"}))
 		})

--- a/ce/plugins/modulr/accounts_test.go
+++ b/ce/plugins/modulr/accounts_test.go
@@ -224,14 +224,27 @@ var _ = Describe("Modulr Plugin Accounts", func() {
 			m.EXPECT().GetAccounts(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(ContainElements("a2", "a3"))
-			Expect(refs(resp.Accounts)).ToNot(ContainElement("a1"))
+			// Boundary a1 is deduped; a0 (a same-second sibling on the re-fetched
+			// page 0) is re-emitted by design — storage upserts dedup it. The exact
+			// assertion catches any unintended extra re-emission.
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a0", "a2", "a3"}))
 
-			// Cycle 3: page 2 -> a4 (group fully drained, no stall).
+			// Cycle 3: page 2 -> a4 (group fully drained on a short final page).
 			m.EXPECT().GetAccounts(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
 			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Accounts)).To(ContainElement("a4"))
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a4"}))
+
+			// Cycle 4: a newer-second account a5 lands on the short last page (2).
+			// The cursor must stay on page 2 rather than advance to page 3, or a5
+			// would be stranded forever behind an empty page.
+			ts2 := ts.Add(time.Second)
+			a5 := client.Account{ID: "a5", Name: "acc a5", Currency: "USD", CreatedDate: ts2.Format("2006-01-02T15:04:05.999-0700")}
+			m.EXPECT().GetAccounts(gomock.Any(), 2, 2, ts.UTC()).Return([]client.Account{all[4], a5}, nil)
+			m.EXPECT().GetAccounts(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Account{}, nil)
+			resp, err = plg.FetchNextAccounts(ctx, models.FetchNextAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Accounts)).To(Equal([]string{"a5"}))
 		})
 	})
 })

--- a/ce/plugins/modulr/external_accounts.go
+++ b/ce/plugins/modulr/external_accounts.go
@@ -3,6 +3,7 @@ package modulr
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/formancehq/payments/ce/plugins/modulr/client"
@@ -12,17 +13,20 @@ import (
 
 type externalAccountsState struct {
 	LastModifiedSince time.Time `json:"lastModifiedSince"`
-	// LastProcessedID is the reference of the last beneficiary emitted at exactly
-	// LastModifiedSince, so the inclusive (>=) watermark filter excludes only that
-	// already-processed row while keeping distinct same-timestamp beneficiaries.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastModifiedSince second
-	// (0-indexed). It advances while the watermark second is unchanged (a
-	// same-second group larger than one page) and resets to 0 once the watermark
-	// moves to a newer second, so a same-second group spanning pages is walked
-	// without re-scanning from page 0 each cycle (which a single LastProcessedID
-	// cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the references of ALL beneficiaries already emitted
+	// at exactly LastModifiedSince, accumulated across cycles while the watermark
+	// second is unchanged and reset when it advances. The server filter is
+	// inclusive (>=), so each cycle rescans from page 0 and skips this whole set:
+	// a same-second group larger than PageSize is walked across cycles without a
+	// drifting page cursor, and a multi-row final page cannot oscillate (every
+	// already-emitted sibling is skipped, not just one).
+	//
+	// Migration note: the previous schema used a singular LastProcessedID plus a
+	// Page cursor; both are ignored on the first decode after deploy (the old
+	// JSON keys simply don't bind). The watermark second is re-emitted once after
+	// deploy, which is idempotent (storage upserts dedup it) and triggers no
+	// recrawl.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -35,18 +39,18 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 	newState := externalAccountsState{
 		LastModifiedSince: oldState.LastModifiedSince,
-		LastProcessedID:   oldState.LastProcessedID,
-		Page:              oldState.Page,
+		LastProcessedIDs:  oldState.LastProcessedIDs,
 	}
 
 	accounts := make([]models.PSPAccount, 0, req.PageSize)
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward; the page cursor below
-	// records how far we got. We consume each page fully (no PageSize cap or
-	// trim) so resuming at the next page cannot skip rows.
-	page := oldState.Page
-	for {
+	// Rescan from page 0 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 0
+	// re-includes the watermark second.
+	for page := 0; ; page++ {
 		pagedBeneficiaries, err := p.client.GetBeneficiaries(ctx, page, req.PageSize, oldState.LastModifiedSince)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
@@ -61,27 +65,27 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
 	if len(accounts) > 0 {
-		newState.LastModifiedSince = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 0.
-		if newState.LastModifiedSince.Equal(oldState.LastModifiedSince) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+		last := accounts[len(accounts)-1].CreatedAt
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if accounts[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
 			}
-		} else {
-			newState.Page = 0
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastModifiedSince) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastModifiedSince = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -107,11 +111,11 @@ func fillBeneficiaries(
 			return nil, err
 		}
 
-		// Inclusive watermark: skip beneficiaries strictly before it, and the single
-		// already-processed beneficiary at exactly the watermark. Distinct
+		// Inclusive watermark: skip beneficiaries strictly before it, and any
+		// already-emitted beneficiary at exactly the watermark second. Distinct
 		// beneficiaries sharing that timestamp are kept (M-CON2).
 		cmp := createdTime.Compare(oldState.LastModifiedSince)
-		if cmp < 0 || (cmp == 0 && beneficiary.ID == oldState.LastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(oldState.LastProcessedIDs, beneficiary.ID)) {
 			continue
 		}
 

--- a/ce/plugins/modulr/external_accounts.go
+++ b/ce/plugins/modulr/external_accounts.go
@@ -67,10 +67,18 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	if len(accounts) > 0 {
 		newState.LastModifiedSince = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 0.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 0.
 		if newState.LastModifiedSince.Equal(oldState.LastModifiedSince) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 0
 		}

--- a/ce/plugins/modulr/external_accounts.go
+++ b/ce/plugins/modulr/external_accounts.go
@@ -12,6 +12,10 @@ import (
 
 type externalAccountsState struct {
 	LastModifiedSince time.Time `json:"lastModifiedSince"`
+	// LastProcessedID is the reference of the last beneficiary emitted at exactly
+	// LastModifiedSince, so the inclusive (>=) watermark filter excludes only that
+	// already-processed row while keeping distinct same-timestamp beneficiaries.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -24,6 +28,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 	newState := externalAccountsState{
 		LastModifiedSince: oldState.LastModifiedSince,
+		LastProcessedID:   oldState.LastProcessedID,
 	}
 
 	accounts := make([]models.PSPAccount, 0, req.PageSize)
@@ -52,6 +57,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 	if len(accounts) > 0 {
 		newState.LastModifiedSince = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -82,11 +88,12 @@ func fillBeneficiaries(
 			return nil, err
 		}
 
-		switch createdTime.Compare(oldState.LastModifiedSince) {
-		case -1, 0:
-			// Account already ingested, skip
+		// Inclusive watermark: skip beneficiaries strictly before it, and the single
+		// already-processed beneficiary at exactly the watermark. Distinct
+		// beneficiaries sharing that timestamp are kept (M-CON2).
+		cmp := createdTime.Compare(oldState.LastModifiedSince)
+		if cmp < 0 || (cmp == 0 && beneficiary.ID == oldState.LastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(beneficiary)

--- a/ce/plugins/modulr/external_accounts.go
+++ b/ce/plugins/modulr/external_accounts.go
@@ -16,6 +16,13 @@ type externalAccountsState struct {
 	// LastModifiedSince, so the inclusive (>=) watermark filter excludes only that
 	// already-processed row while keeping distinct same-timestamp beneficiaries.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastModifiedSince second
+	// (0-indexed). It advances while the watermark second is unchanged (a
+	// same-second group larger than one page) and resets to 0 once the watermark
+	// moves to a newer second, so a same-second group spanning pages is walked
+	// without re-scanning from page 0 each cycle (which a single LastProcessedID
+	// cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -29,18 +36,23 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	newState := externalAccountsState{
 		LastModifiedSince: oldState.LastModifiedSince,
 		LastProcessedID:   oldState.LastProcessedID,
+		Page:              oldState.Page,
 	}
 
 	accounts := make([]models.PSPAccount, 0, req.PageSize)
 	needMore := false
 	hasMore := false
-	for page := 0; ; page++ {
+	// Resume at the persisted page and walk forward; the page cursor below
+	// records how far we got. We consume each page fully (no PageSize cap or
+	// trim) so resuming at the next page cannot skip rows.
+	page := oldState.Page
+	for {
 		pagedBeneficiaries, err := p.client.GetBeneficiaries(ctx, page, req.PageSize, oldState.LastModifiedSince)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 
-		accounts, err = fillBeneficiaries(pagedBeneficiaries, accounts, oldState, req.PageSize)
+		accounts, err = fillBeneficiaries(pagedBeneficiaries, accounts, oldState)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
@@ -49,15 +61,19 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		accounts = accounts[:req.PageSize]
+		page++
 	}
 
 	if len(accounts) > 0 {
 		newState.LastModifiedSince = accounts[len(accounts)-1].CreatedAt
 		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 0.
+		if newState.LastModifiedSince.Equal(oldState.LastModifiedSince) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 0
+		}
 	}
 
 	payload, err := json.Marshal(newState)
@@ -76,13 +92,8 @@ func fillBeneficiaries(
 	pagedBeneficiaries []client.Beneficiary,
 	accounts []models.PSPAccount,
 	oldState externalAccountsState,
-	pageSize int,
 ) ([]models.PSPAccount, error) {
 	for _, beneficiary := range pagedBeneficiaries {
-		if len(accounts) >= pageSize {
-			break
-		}
-
 		createdTime, err := time.Parse("2006-01-02T15:04:05.999-0700", beneficiary.Created)
 		if err != nil {
 			return nil, err

--- a/ce/plugins/modulr/external_accounts.go
+++ b/ce/plugins/modulr/external_accounts.go
@@ -26,6 +26,11 @@ type externalAccountsState struct {
 	// JSON keys simply don't bind). The watermark second is re-emitted once after
 	// deploy, which is idempotent (storage upserts dedup it) and triggers no
 	// recrawl.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/modulr/external_accounts_test.go
+++ b/ce/plugins/modulr/external_accounts_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 		It("should fetch next external accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			lastCreatedAt, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleBeneficiaries[38].Created)
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastModifiedSince": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano))),
+				State:    []byte(fmt.Sprintf(`{"lastModifiedSince": "%s", "lastProcessedID": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
 				PageSize: 40,
 			}
 

--- a/ce/plugins/modulr/external_accounts_test.go
+++ b/ce/plugins/modulr/external_accounts_test.go
@@ -196,14 +196,27 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(ContainElements("b2", "b3"))
-			Expect(refs(resp.ExternalAccounts)).ToNot(ContainElement("b1"))
+			// Boundary b1 is deduped; b0 (a same-second sibling on the re-fetched
+			// page 0) is re-emitted by design — storage upserts dedup it. The exact
+			// assertion catches any unintended extra re-emission.
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b2", "b3"}))
 
-			// Cycle 3: page 2 -> b4 (group fully drained, no stall).
+			// Cycle 3: page 2 -> b4 (group fully drained on a short final page).
 			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(ContainElement("b4"))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b4"}))
+
+			// Cycle 4: a newer-second beneficiary b5 lands on the short last page
+			// (2). The cursor must stay on page 2 rather than advance to page 3, or
+			// b5 would be stranded forever behind an empty page.
+			ts2 := ts.Add(time.Second)
+			b5 := client.Beneficiary{ID: "b5", Name: "ben b5", Created: ts2.Format("2006-01-02T15:04:05.999-0700")}
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 2, ts.UTC()).Return([]client.Beneficiary{all[4], b5}, nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Beneficiary{}, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b5"}))
 		})
 	})
 })

--- a/ce/plugins/modulr/external_accounts_test.go
+++ b/ce/plugins/modulr/external_accounts_test.go
@@ -169,5 +169,41 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 			createdTime, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleBeneficiaries[49].Created)
 			Expect(state.LastModifiedSince.UTC()).To(Equal(createdTime.UTC()))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			createdDate := now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999-0700")
+			ts, _ := time.Parse("2006-01-02T15:04:05.999-0700", createdDate)
+			mk := func(id string) client.Beneficiary {
+				return client.Beneficiary{ID: id, Name: "ben " + id, Created: createdDate}
+			}
+			all := []client.Beneficiary{mk("b0"), mk("b1"), mk("b2"), mk("b3"), mk("b4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+
+			// Cycle 1: page 0 -> b0, b1.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 2, time.Time{}).Return(all[0:2], nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1"}))
+
+			// Cycle 2: page 0 re-fetched (b1 deduped) then page 1 -> b2, b3.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 2, ts.UTC()).Return(all[0:2], nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(ContainElements("b2", "b3"))
+			Expect(refs(resp.ExternalAccounts)).ToNot(ContainElement("b1"))
+
+			// Cycle 3: page 2 -> b4 (group fully drained, no stall).
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(ContainElement("b4"))
+		})
 	})
 })

--- a/ce/plugins/modulr/external_accounts_test.go
+++ b/ce/plugins/modulr/external_accounts_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 		It("should fetch next external accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			lastCreatedAt, _ := time.Parse("2006-01-02T15:04:05.999-0700", sampleBeneficiaries[38].Created)
 			req := models.FetchNextExternalAccountsRequest{
-				State:    []byte(fmt.Sprintf(`{"lastModifiedSince": "%s", "lastProcessedID": "%s"}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
+				State:    []byte(fmt.Sprintf(`{"lastModifiedSince": "%s", "lastProcessedIDs": ["%s"]}`, lastCreatedAt.UTC().Format(time.RFC3339Nano), sampleBeneficiaries[38].ID)),
 				PageSize: 40,
 			}
 
@@ -176,6 +176,11 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 			mk := func(id string) client.Beneficiary {
 				return client.Beneficiary{ID: id, Name: "ben " + id, Created: createdDate}
 			}
+			// Five beneficiaries all sharing the same Created second, fetched three
+			// per page so the group spans page 0 (b0,b1,b2) and a SHORT final page 1
+			// (b3,b4). Each cycle rescans from page 0 and skips the processed-ID set;
+			// a single LastProcessedID would oscillate on the multi-row final page
+			// (re-emitting b3/b4 forever) instead of settling and advancing.
 			all := []client.Beneficiary{mk("b0"), mk("b1"), mk("b2"), mk("b3"), mk("b4")}
 			refs := func(as []models.PSPAccount) []string {
 				out := make([]string, len(as))
@@ -185,36 +190,37 @@ var _ = Describe("Modulr Plugin External Accounts", func() {
 				return out
 			}
 
-			// Cycle 1: page 0 -> b0, b1.
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 2, time.Time{}).Return(all[0:2], nil)
-			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 2})
+			// Cycle 1: fresh state, page 0 -> b0, b1, b2.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 3, time.Time{}).Return(all[0:3], nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1"}))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b1", "b2"}))
+			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 0 re-fetched (b1 deduped) then page 1 -> b2, b3.
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 2, ts.UTC()).Return(all[0:2], nil)
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 2, ts.UTC()).Return(all[2:4], nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 2: rescan page 0 (all skipped via the set) then page 1 -> b3, b4.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			// Boundary b1 is deduped; b0 (a same-second sibling on the re-fetched
-			// page 0) is re-emitted by design — storage upserts dedup it. The exact
-			// assertion catches any unintended extra re-emission.
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b0", "b2", "b3"}))
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b3", "b4"}))
 
-			// Cycle 3: page 2 -> b4 (group fully drained on a short final page).
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 2, ts.UTC()).Return(all[4:5], nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing. A single LastProcessedID would re-emit b3 or
+			// b4 here and oscillate; the set settles to empty.
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b4"}))
+			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
 
-			// Cycle 4: a newer-second beneficiary b5 lands on the short last page
-			// (2). The cursor must stay on page 2 rather than advance to page 3, or
-			// b5 would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second beneficiary b5 appears on the (formerly short)
+			// page 1. The set skips b3/b4 and reaches b5 — no stranding.
 			ts2 := ts.Add(time.Second)
 			b5 := client.Beneficiary{ID: "b5", Name: "ben b5", Created: ts2.Format("2006-01-02T15:04:05.999-0700")}
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 2, ts.UTC()).Return([]client.Beneficiary{all[4], b5}, nil)
-			m.EXPECT().GetBeneficiaries(gomock.Any(), 3, 2, ts.UTC()).Return([]client.Beneficiary{}, nil)
-			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 2})
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 1, 3, ts.UTC()).Return([]client.Beneficiary{all[3], all[4], b5}, nil)
+			m.EXPECT().GetBeneficiaries(gomock.Any(), 2, 3, ts.UTC()).Return([]client.Beneficiary{}, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"b5"}))
 		})

--- a/ce/plugins/moneycorp/external_accounts.go
+++ b/ce/plugins/moneycorp/external_accounts.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/payments/ce/plugins/moneycorp/client"
 	"github.com/formancehq/payments/pkg/domain/models"
 	"github.com/formancehq/payments/pkg/domain/pagination"
@@ -16,6 +16,10 @@ import (
 type externalAccountsState struct {
 	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"LastCreatedAt"`
+	// LastProcessedID is the reference (recipient ID) of the last account emitted
+	// at exactly LastCreatedAt, so the inclusive (>=) watermark filter excludes
+	// only that already-processed row while keeping distinct same-timestamp ones.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -35,8 +39,9 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	}
 
 	newState := externalAccountsState{
-		LastPage:      oldState.LastPage,
-		LastCreatedAt: oldState.LastCreatedAt,
+		LastPage:        oldState.LastPage,
+		LastCreatedAt:   oldState.LastCreatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	needMore := false
@@ -50,7 +55,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 
-		accounts, err = recipientToPSPAccounts(oldState.LastCreatedAt, accounts, pagedRecipients)
+		accounts, err = recipientToPSPAccounts(oldState.LastCreatedAt, oldState.LastProcessedID, accounts, pagedRecipients)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
@@ -67,6 +72,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 	if len(accounts) > 0 {
 		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
+		newState.LastProcessedID = accounts[len(accounts)-1].Reference
 	}
 
 	payload, err := json.Marshal(newState)
@@ -83,6 +89,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 func recipientToPSPAccounts(
 	lastCreatedAt time.Time,
+	lastProcessedID string,
 	accounts []models.PSPAccount,
 	pagedAccounts []*client.Recipient,
 ) ([]models.PSPAccount, error) {
@@ -92,10 +99,12 @@ func recipientToPSPAccounts(
 			return accounts, fmt.Errorf("failed to parse transaction date: %v", err)
 		}
 
-		switch createdAt.Compare(lastCreatedAt) {
-		case -1, 0:
+		// Inclusive watermark: skip recipients strictly before it, and the single
+		// already-processed recipient at exactly the watermark. Distinct recipients
+		// sharing that timestamp are kept (M-CON2).
+		cmp := createdAt.Compare(lastCreatedAt)
+		if cmp < 0 || (cmp == 0 && recipient.ID == lastProcessedID) {
 			continue
-		default:
 		}
 
 		raw, err := json.Marshal(recipient)

--- a/ce/plugins/moneycorp/external_accounts.go
+++ b/ce/plugins/moneycorp/external_accounts.go
@@ -15,18 +15,21 @@ import (
 )
 
 type externalAccountsState struct {
+	// LastPage is a monotonic forward cursor. This endpoint has NO server-side
+	// time filter, so resuming the scan here (re-reading only the last page, not
+	// the whole history each poll) avoids a full historical rescan on every sync.
+	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"LastCreatedAt"`
 	// LastProcessedIDs holds the references (recipient IDs) of ALL accounts
-	// already emitted at exactly LastCreatedAt, accumulated across cycles while
-	// the watermark second is unchanged and reset when it advances. Each cycle
-	// rescans from page 0 and skips this whole set: a same-second group larger
-	// than PageSize is walked across cycles without a drifting page cursor, and a
-	// multi-row final page cannot oscillate (every already-emitted sibling is
-	// skipped, not just one).
+	// already emitted at exactly LastCreatedAt, accumulated while the watermark
+	// second is unchanged and reset when it advances. It dedups same-second rows
+	// on the re-read page, so a multi-row boundary settles to empty instead of
+	// oscillating (a single LastProcessedID could exclude only one of several
+	// tied rows).
 	//
-	// Migration note: the old singular lastProcessedID and lastPage fields are
-	// ignored. After deploy the watermark second is re-emitted once (idempotent —
-	// storage upserts dedup it) and no recrawl occurs.
+	// Migration note: the old singular lastProcessedID is ignored. After deploy
+	// the watermark second is re-emitted once (idempotent — storage upserts dedup
+	// it) and no recrawl occurs.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
@@ -47,6 +50,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	}
 
 	newState := externalAccountsState{
+		LastPage:         oldState.LastPage,
 		LastCreatedAt:    oldState.LastCreatedAt,
 		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
@@ -54,12 +58,12 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	needMore := false
 	hasMore := false
 	accounts := make([]models.PSPAccount, 0, req.PageSize)
-	// Rescan from page 0 each cycle (no page cursor): the processed-ID set skips
-	// every already-emitted sibling at the watermark second, so a same-second
-	// group larger than PageSize is walked across cycles and a multi-row final
-	// page cannot oscillate. There is no server-side time filter, so the skip is
-	// applied client-side in recipientToPSPAccounts.
-	for page := 0; ; page++ {
+	// No server-side time filter: resume the monotonic forward scan at the
+	// persisted page (re-reading only the last page, not the whole history) and
+	// skip already-emitted same-second rows via the ID set (client-side, in
+	// recipientToPSPAccounts), so a multi-row final page cannot oscillate.
+	page := oldState.LastPage
+	for {
 		pagedRecipients, err := p.client.GetRecipients(ctx, from.Reference, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
@@ -74,7 +78,9 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		if !needMore || !hasMore {
 			break
 		}
+		page++
 	}
+	newState.LastPage = page
 
 	if len(accounts) > 0 {
 		last := accounts[len(accounts)-1].CreatedAt

--- a/ce/plugins/moneycorp/external_accounts.go
+++ b/ce/plugins/moneycorp/external_accounts.go
@@ -30,6 +30,11 @@ type externalAccountsState struct {
 	// Migration note: the old singular lastProcessedID is ignored. After deploy
 	// the watermark second is re-emitted once (idempotent — storage upserts dedup
 	// it) and no recrawl occurs.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/moneycorp/external_accounts.go
+++ b/ce/plugins/moneycorp/external_accounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/currency"
@@ -14,12 +15,19 @@ import (
 )
 
 type externalAccountsState struct {
-	LastPage      int       `json:"lastPage"`
 	LastCreatedAt time.Time `json:"LastCreatedAt"`
-	// LastProcessedID is the reference (recipient ID) of the last account emitted
-	// at exactly LastCreatedAt, so the inclusive (>=) watermark filter excludes
-	// only that already-processed row while keeping distinct same-timestamp ones.
-	LastProcessedID string `json:"lastProcessedID"`
+	// LastProcessedIDs holds the references (recipient IDs) of ALL accounts
+	// already emitted at exactly LastCreatedAt, accumulated across cycles while
+	// the watermark second is unchanged and reset when it advances. Each cycle
+	// rescans from page 0 and skips this whole set: a same-second group larger
+	// than PageSize is walked across cycles without a drifting page cursor, and a
+	// multi-row final page cannot oscillate (every already-emitted sibling is
+	// skipped, not just one).
+	//
+	// Migration note: the old singular lastProcessedID and lastPage fields are
+	// ignored. After deploy the watermark second is re-emitted once (idempotent —
+	// storage upserts dedup it) and no recrawl occurs.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.FetchNextExternalAccountsRequest) (models.FetchNextExternalAccountsResponse, error) {
@@ -39,23 +47,25 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 	}
 
 	newState := externalAccountsState{
-		LastPage:        oldState.LastPage,
-		LastCreatedAt:   oldState.LastCreatedAt,
-		LastProcessedID: oldState.LastProcessedID,
+		LastCreatedAt:    oldState.LastCreatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	needMore := false
 	hasMore := false
 	accounts := make([]models.PSPAccount, 0, req.PageSize)
-	for page := oldState.LastPage; ; page++ {
-		newState.LastPage = page
-
+	// Rescan from page 0 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. There is no server-side time filter, so the skip is
+	// applied client-side in recipientToPSPAccounts.
+	for page := 0; ; page++ {
 		pagedRecipients, err := p.client.GetRecipients(ctx, from.Reference, page, req.PageSize)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
 
-		accounts, err = recipientToPSPAccounts(oldState.LastCreatedAt, oldState.LastProcessedID, accounts, pagedRecipients)
+		accounts, err = recipientToPSPAccounts(oldState.LastCreatedAt, oldState.LastProcessedIDs, accounts, pagedRecipients)
 		if err != nil {
 			return models.FetchNextExternalAccountsResponse{}, err
 		}
@@ -66,13 +76,25 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 		}
 	}
 
-	if !needMore {
-		accounts = accounts[:req.PageSize]
-	}
-
 	if len(accounts) > 0 {
-		newState.LastCreatedAt = accounts[len(accounts)-1].CreatedAt
-		newState.LastProcessedID = accounts[len(accounts)-1].Reference
+		last := accounts[len(accounts)-1].CreatedAt
+
+		// Collect the references emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range accounts {
+			if accounts[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, accounts[i].Reference)
+			}
+		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastCreatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -89,7 +111,7 @@ func (p *Plugin) fetchNextExternalAccounts(ctx context.Context, req models.Fetch
 
 func recipientToPSPAccounts(
 	lastCreatedAt time.Time,
-	lastProcessedID string,
+	lastProcessedIDs []string,
 	accounts []models.PSPAccount,
 	pagedAccounts []*client.Recipient,
 ) ([]models.PSPAccount, error) {
@@ -99,11 +121,11 @@ func recipientToPSPAccounts(
 			return accounts, fmt.Errorf("failed to parse transaction date: %v", err)
 		}
 
-		// Inclusive watermark: skip recipients strictly before it, and the single
-		// already-processed recipient at exactly the watermark. Distinct recipients
-		// sharing that timestamp are kept (M-CON2).
+		// Inclusive watermark: skip recipients strictly before it, and any
+		// already-emitted recipient at exactly the watermark second. Distinct
+		// recipients sharing that timestamp are kept (M-CON2).
 		cmp := createdAt.Compare(lastCreatedAt)
-		if cmp < 0 || (cmp == 0 && recipient.ID == lastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(lastProcessedIDs, recipient.ID)) {
 			continue
 		}
 

--- a/ce/plugins/moneycorp/external_accounts_test.go
+++ b/ce/plugins/moneycorp/external_accounts_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			sampleExternalAccounts = make([]*client.Recipient, 0)
 			for i := 0; i < 50; i++ {
 				sampleExternalAccounts = append(sampleExternalAccounts, &client.Recipient{
+					ID: fmt.Sprintf("recipient-%d", i),
 					Attributes: client.RecipientAttributes{
 						BankAccountCurrency: "JPY",
 						CreatedAt:           strings.TrimSuffix(now.Add(-time.Duration(60-i)*time.Minute).UTC().Format(time.RFC3339Nano), "Z"),
@@ -104,7 +105,6 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(0))
 			Expect(state.LastCreatedAt.IsZero()).To(BeTrue())
 		})
 
@@ -130,7 +130,6 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(0))
 			createdAtTime, _ := time.Parse(time.RFC3339Nano, sampleExternalAccounts[49].Attributes.CreatedAt+"Z")
 			Expect(state.LastCreatedAt.UTC()).To(Equal(createdAtTime.UTC()))
 		})
@@ -156,7 +155,6 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			var state externalAccountsState
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
-			Expect(state.LastPage).To(Equal(0))
 			createdAtTime, _ := time.Parse(time.RFC3339Nano, sampleExternalAccounts[39].Attributes.CreatedAt+"Z")
 			Expect(state.LastCreatedAt.UTC()).To(Equal(createdAtTime.UTC()))
 		})
@@ -164,7 +162,11 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 		It("should fetch next external accounts - with state pageSize < total accounts", func(ctx SpecContext) {
 			lastCreaatedAt, _ := time.Parse(time.RFC3339Nano, sampleExternalAccounts[38].Attributes.CreatedAt+"Z")
 			req := models.FetchNextExternalAccountsRequest{
-				State:       []byte(fmt.Sprintf(`{"lastPage": %d, "lastCreatedAt": "%s"}`, 0, lastCreaatedAt.Format(time.RFC3339Nano))),
+				State: []byte(fmt.Sprintf(
+					`{"LastCreatedAt": "%s", "lastProcessedIDs": ["%s"]}`,
+					lastCreaatedAt.Format(time.RFC3339Nano),
+					sampleExternalAccounts[38].ID,
+				)),
 				PageSize:    40,
 				FromPayload: []byte(`{"reference": "baseAcc"}`),
 			}
@@ -189,9 +191,74 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			err = json.Unmarshal(resp.NewState, &state)
 			Expect(err).To(BeNil())
 			// We fetched everything, state should be resetted
-			Expect(state.LastPage).To(Equal(1))
 			createdAtTime, _ := time.Parse(time.RFC3339Nano, sampleExternalAccounts[49].Attributes.CreatedAt+"Z")
 			Expect(state.LastCreatedAt.UTC()).To(Equal(createdAtTime.UTC()))
+		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			const createdAtStr = "2024-02-02T00:00:00"
+			mk := func(id string) *client.Recipient {
+				return &client.Recipient{
+					ID: id,
+					Attributes: client.RecipientAttributes{
+						BankAccountCurrency: "JPY",
+						CreatedAt:           createdAtStr,
+						BankAccountName:     "jpy account",
+					},
+				}
+			}
+			// Five recipients sharing the same second, fetched three per page so the
+			// group spans page 0 (m0,m1,m2) and a SHORT final page 1 (m3,m4). Each
+			// cycle rescans from page 0 and skips the processed-ID set.
+			all := []*client.Recipient{mk("m0"), mk("m1"), mk("m2"), mk("m3"), mk("m4")}
+			refs := func(as []models.PSPAccount) []string {
+				out := make([]string, len(as))
+				for i := range as {
+					out[i] = as[i].Reference
+				}
+				return out
+			}
+			accRef := "baseAcc"
+			fromPayload := json.RawMessage(`{"reference": "baseAcc"}`)
+
+			// Cycle 1: fresh state, page 0 -> m0, m1, m2.
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
+			resp, err := plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: []byte(`{}`), PageSize: 3, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"m0", "m1", "m2"}))
+			Expect(resp.HasMore).To(BeTrue())
+
+			// Cycle 2: rescan page 0 (all skipped via the set) then page 1 -> m3, m4.
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 1, 3).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"m3", "m4"}))
+
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing (anti-oscillation).
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 1, 3).Return(all[3:5], nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
+
+			// Cycle 4: a newer-second recipient m5 appears on the (formerly short)
+			// page 1. The set skips m3/m4 and reaches m5 — no stranding.
+			m5 := &client.Recipient{
+				ID: "m5",
+				Attributes: client.RecipientAttributes{
+					BankAccountCurrency: "JPY",
+					CreatedAt:           "2024-02-02T00:00:01",
+					BankAccountName:     "jpy account",
+				},
+			}
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 1, 3).Return([]*client.Recipient{all[3], all[4], m5}, nil)
+			m.EXPECT().GetRecipients(gomock.Any(), accRef, 2, 3).Return([]*client.Recipient{}, nil)
+			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"m5"}))
 		})
 	})
 })

--- a/ce/plugins/moneycorp/external_accounts_test.go
+++ b/ce/plugins/moneycorp/external_accounts_test.go
@@ -208,8 +208,11 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 				}
 			}
 			// Five recipients sharing the same second, fetched three per page so the
-			// group spans page 0 (m0,m1,m2) and a SHORT final page 1 (m3,m4). Each
-			// cycle rescans from page 0 and skips the processed-ID set.
+			// group spans page 0 (m0,m1,m2) and a SHORT final page 1 (m3,m4). The
+			// monotonic LastPage cursor resumes the forward scan (no full rescan from
+			// page 0 once past it) and the processed-ID set dedups the same-second
+			// rows on the re-read page; a single LastProcessedID would oscillate on
+			// the multi-row final page (re-emitting m3/m4 forever).
 			all := []*client.Recipient{mk("m0"), mk("m1"), mk("m2"), mk("m3"), mk("m4")}
 			refs := func(as []models.PSPAccount) []string {
 				out := make([]string, len(as))
@@ -235,16 +238,17 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(Equal([]string{"m3", "m4"}))
 
-			// Cycle 3: group fully drained — every row is in the processed-ID set, so
-			// the rescan returns nothing (anti-oscillation).
-			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
+			// Cycle 3: LastPage is now 1, so we resume there (NOT page 0) and re-read
+			// only the last page. Every row is in the processed-ID set, so it returns
+			// nothing (anti-oscillation) — and crucially does not rescan history.
 			m.EXPECT().GetRecipients(gomock.Any(), accRef, 1, 3).Return(all[3:5], nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.ExternalAccounts)).To(BeEmpty())
 
 			// Cycle 4: a newer-second recipient m5 appears on the (formerly short)
-			// page 1. The set skips m3/m4 and reaches m5 — no stranding.
+			// page 1. Resuming at page 1, the set skips m3/m4 and reaches m5; the
+			// fetch then advances to the now-empty page 2 and stops.
 			m5 := &client.Recipient{
 				ID: "m5",
 				Attributes: client.RecipientAttributes{
@@ -253,7 +257,6 @@ var _ = Describe("Moneycorp *Plugin ExternalAccounts", func() {
 					BankAccountName:     "jpy account",
 				},
 			}
-			m.EXPECT().GetRecipients(gomock.Any(), accRef, 0, 3).Return(all[0:3], nil)
 			m.EXPECT().GetRecipients(gomock.Any(), accRef, 1, 3).Return([]*client.Recipient{all[3], all[4], m5}, nil)
 			m.EXPECT().GetRecipients(gomock.Any(), accRef, 2, 3).Return([]*client.Recipient{}, nil)
 			resp, err = plg.FetchNextExternalAccounts(ctx, models.FetchNextExternalAccountsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})

--- a/ce/plugins/moneycorp/payments.go
+++ b/ce/plugins/moneycorp/payments.go
@@ -84,10 +84,18 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	if len(payments) > 0 {
 		newState.LastCreatedAt = payments[len(payments)-1].CreatedAt
 		newState.LastProcessedID = processedIDs[len(processedIDs)-1]
-		// Same-second group still draining -> resume after consumed pages; else
-		// the watermark moved to a newer second, so re-anchor at page 0.
+		// Advance past the consumed pages only while there is definitely a full
+		// next page (hasMore). If the same-second group drained on a short final
+		// page, keep the cursor there — a newer row appended to that second's
+		// >= watermark query lands on this very page, so advancing past it would
+		// strand it forever. When the watermark moved to a newer second, re-anchor
+		// at page 0.
 		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
-			newState.Page = page + 1
+			if hasMore {
+				newState.Page = page + 1
+			} else {
+				newState.Page = page
+			}
 		} else {
 			newState.Page = 0
 		}

--- a/ce/plugins/moneycorp/payments.go
+++ b/ce/plugins/moneycorp/payments.go
@@ -25,6 +25,13 @@ type paymentsState struct {
 	// iteration identity), which differs from payment.Reference for "Payment"
 	// types.
 	LastProcessedID string `json:"lastProcessedID"`
+	// Page is the next page to fetch within the current LastCreatedAt second
+	// (0-indexed). It advances while the watermark second is unchanged (a
+	// same-second group larger than one page) and resets to 0 once the watermark
+	// moves to a newer second, so a same-second group spanning pages is walked
+	// without re-scanning from page 0 each cycle (which a single LastProcessedID
+	// cannot do).
+	Page int `json:"page"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -46,13 +53,17 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	newState := paymentsState{
 		LastCreatedAt:   oldState.LastCreatedAt,
 		LastProcessedID: oldState.LastProcessedID,
+		Page:            oldState.Page,
 	}
 
 	payments := make([]models.PSPPayment, 0, req.PageSize)
 	processedIDs := make([]string, 0, req.PageSize)
 	needMore := false
 	hasMore := false
-	for page := 0; ; page++ {
+	// Resume at the persisted page and walk forward (no trim-and-restart, which
+	// would skip the trimmed rows); the page cursor below records how far we got.
+	page := oldState.Page
+	for {
 		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, oldState.LastCreatedAt)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
@@ -67,18 +78,19 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		if !needMore || !hasMore {
 			break
 		}
-	}
-
-	if !needMore {
-		// Trim both slices in lockstep so the watermark and LastProcessedID come
-		// from the last EMITTED payment.
-		payments = payments[:req.PageSize]
-		processedIDs = processedIDs[:req.PageSize]
+		page++
 	}
 
 	if len(payments) > 0 {
 		newState.LastCreatedAt = payments[len(payments)-1].CreatedAt
 		newState.LastProcessedID = processedIDs[len(processedIDs)-1]
+		// Same-second group still draining -> resume after consumed pages; else
+		// the watermark moved to a newer second, so re-anchor at page 0.
+		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
+			newState.Page = page + 1
+		} else {
+			newState.Page = 0
+		}
 	}
 
 	payload, err := json.Marshal(newState)

--- a/ce/plugins/moneycorp/payments.go
+++ b/ce/plugins/moneycorp/payments.go
@@ -32,6 +32,11 @@ type paymentsState struct {
 	// Migration note: the old singular lastProcessedID and page fields are
 	// ignored. After deploy the watermark second is re-emitted once (idempotent —
 	// storage upserts dedup it) and no recrawl occurs.
+	//
+	// Precision: comparison and the ID set use the exact timestamp the API
+	// returns (full precision, as in the qonto reference), not a truncated
+	// second; "same-second" above is shorthand because these PSPs report
+	// timestamps at second granularity, so equal values represent the same second.
 	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 

--- a/ce/plugins/moneycorp/payments.go
+++ b/ce/plugins/moneycorp/payments.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -18,20 +19,20 @@ import (
 
 type paymentsState struct {
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
-	// LastProcessedID is the transaction ID of the last transaction emitted at
-	// exactly LastCreatedAt. It lets the watermark filter be inclusive (>=)
-	// without re-skipping distinct transactions that share that timestamp: only
-	// the exact already-processed row is excluded. Keyed on transaction.ID (the
-	// iteration identity), which differs from payment.Reference for "Payment"
-	// types.
-	LastProcessedID string `json:"lastProcessedID"`
-	// Page is the next page to fetch within the current LastCreatedAt second
-	// (0-indexed). It advances while the watermark second is unchanged (a
-	// same-second group larger than one page) and resets to 0 once the watermark
-	// moves to a newer second, so a same-second group spanning pages is walked
-	// without re-scanning from page 0 each cycle (which a single LastProcessedID
-	// cannot do).
-	Page int `json:"page"`
+	// LastProcessedIDs holds the transaction IDs of ALL transactions already
+	// emitted at exactly LastCreatedAt, accumulated across cycles while the
+	// watermark second is unchanged and reset when it advances. The server filter
+	// is inclusive (>=), so each cycle rescans from page 0 and skips this whole
+	// set: a same-second group larger than PageSize is walked across cycles
+	// without a drifting page cursor, and a multi-row final page cannot oscillate
+	// (every already-emitted sibling is skipped, not just one). Keyed on
+	// transaction.ID (the iteration identity), which differs from
+	// payment.Reference for "Payment" types.
+	//
+	// Migration note: the old singular lastProcessedID and page fields are
+	// ignored. After deploy the watermark second is re-emitted once (idempotent —
+	// storage upserts dedup it) and no recrawl occurs.
+	LastProcessedIDs []string `json:"lastProcessedIDs"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -51,25 +52,26 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	newState := paymentsState{
-		LastCreatedAt:   oldState.LastCreatedAt,
-		LastProcessedID: oldState.LastProcessedID,
-		Page:            oldState.Page,
+		LastCreatedAt:    oldState.LastCreatedAt,
+		LastProcessedIDs: oldState.LastProcessedIDs,
 	}
 
 	payments := make([]models.PSPPayment, 0, req.PageSize)
 	processedIDs := make([]string, 0, req.PageSize)
 	needMore := false
 	hasMore := false
-	// Resume at the persisted page and walk forward (no trim-and-restart, which
-	// would skip the trimmed rows); the page cursor below records how far we got.
-	page := oldState.Page
-	for {
+	// Rescan from page 0 each cycle (no page cursor): the processed-ID set skips
+	// every already-emitted sibling at the watermark second, so a same-second
+	// group larger than PageSize is walked across cycles and a multi-row final
+	// page cannot oscillate. The server filter is inclusive (>=), so page 0
+	// re-includes the watermark second.
+	for page := 0; ; page++ {
 		pagedTransactions, err := p.client.GetTransactions(ctx, from.Reference, page, req.PageSize, oldState.LastCreatedAt)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
 
-		payments, processedIDs, err = p.toPSPPayments(ctx, oldState.LastCreatedAt, oldState.LastProcessedID, payments, processedIDs, pagedTransactions)
+		payments, processedIDs, err = p.toPSPPayments(ctx, oldState.LastCreatedAt, oldState.LastProcessedIDs, payments, processedIDs, pagedTransactions)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
@@ -78,27 +80,27 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 		if !needMore || !hasMore {
 			break
 		}
-		page++
 	}
 
 	if len(payments) > 0 {
-		newState.LastCreatedAt = payments[len(payments)-1].CreatedAt
-		newState.LastProcessedID = processedIDs[len(processedIDs)-1]
-		// Advance past the consumed pages only while there is definitely a full
-		// next page (hasMore). If the same-second group drained on a short final
-		// page, keep the cursor there — a newer row appended to that second's
-		// >= watermark query lands on this very page, so advancing past it would
-		// strand it forever. When the watermark moved to a newer second, re-anchor
-		// at page 0.
-		if newState.LastCreatedAt.Equal(oldState.LastCreatedAt) {
-			if hasMore {
-				newState.Page = page + 1
-			} else {
-				newState.Page = page
+		last := payments[len(payments)-1].CreatedAt
+
+		// Collect the transaction IDs emitted at exactly the new watermark second.
+		idsAtWatermark := make([]string, 0)
+		for i := range payments {
+			if payments[i].CreatedAt.Equal(last) {
+				idsAtWatermark = append(idsAtWatermark, processedIDs[i])
 			}
-		} else {
-			newState.Page = 0
 		}
+
+		// Accumulate the processed-ID set while still inside the same watermark
+		// second; reset it when the watermark advances to a newer second.
+		if last.Equal(oldState.LastCreatedAt) {
+			newState.LastProcessedIDs = append(oldState.LastProcessedIDs, idsAtWatermark...)
+		} else {
+			newState.LastProcessedIDs = idsAtWatermark
+		}
+		newState.LastCreatedAt = last
 	}
 
 	payload, err := json.Marshal(newState)
@@ -116,7 +118,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 func (p *Plugin) toPSPPayments(
 	ctx context.Context,
 	lastCreatedAt time.Time,
-	lastProcessedID string,
+	lastProcessedIDs []string,
 	payments []models.PSPPayment,
 	processedIDs []string,
 	transactions []*client.Transaction,
@@ -127,11 +129,11 @@ func (p *Plugin) toPSPPayments(
 			return payments, processedIDs, fmt.Errorf("failed to parse transaction date: %v", err)
 		}
 
-		// Inclusive watermark: skip transactions strictly before it, and the
-		// single already-processed transaction at exactly the watermark. Distinct
+		// Inclusive watermark: skip transactions strictly before it, and any
+		// already-emitted transaction at exactly the watermark second. Distinct
 		// transactions sharing that timestamp are kept (M-CON2).
 		cmp := createdAt.Compare(lastCreatedAt)
-		if cmp < 0 || (cmp == 0 && transaction.ID == lastProcessedID) {
+		if cmp < 0 || (cmp == 0 && slices.Contains(lastProcessedIDs, transaction.ID)) {
 			continue
 		}
 

--- a/ce/plugins/moneycorp/payments.go
+++ b/ce/plugins/moneycorp/payments.go
@@ -18,6 +18,13 @@ import (
 
 type paymentsState struct {
 	LastCreatedAt time.Time `json:"lastCreatedAt"`
+	// LastProcessedID is the transaction ID of the last transaction emitted at
+	// exactly LastCreatedAt. It lets the watermark filter be inclusive (>=)
+	// without re-skipping distinct transactions that share that timestamp: only
+	// the exact already-processed row is excluded. Keyed on transaction.ID (the
+	// iteration identity), which differs from payment.Reference for "Payment"
+	// types.
+	LastProcessedID string `json:"lastProcessedID"`
 }
 
 func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaymentsRequest) (models.FetchNextPaymentsResponse, error) {
@@ -37,10 +44,12 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	newState := paymentsState{
-		LastCreatedAt: oldState.LastCreatedAt,
+		LastCreatedAt:   oldState.LastCreatedAt,
+		LastProcessedID: oldState.LastProcessedID,
 	}
 
 	payments := make([]models.PSPPayment, 0, req.PageSize)
+	processedIDs := make([]string, 0, req.PageSize)
 	needMore := false
 	hasMore := false
 	for page := 0; ; page++ {
@@ -49,7 +58,7 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 			return models.FetchNextPaymentsResponse{}, err
 		}
 
-		payments, err = p.toPSPPayments(ctx, oldState.LastCreatedAt, payments, pagedTransactions)
+		payments, processedIDs, err = p.toPSPPayments(ctx, oldState.LastCreatedAt, oldState.LastProcessedID, payments, processedIDs, pagedTransactions)
 		if err != nil {
 			return models.FetchNextPaymentsResponse{}, err
 		}
@@ -61,11 +70,15 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 	}
 
 	if !needMore {
+		// Trim both slices in lockstep so the watermark and LastProcessedID come
+		// from the last EMITTED payment.
 		payments = payments[:req.PageSize]
+		processedIDs = processedIDs[:req.PageSize]
 	}
 
 	if len(payments) > 0 {
 		newState.LastCreatedAt = payments[len(payments)-1].CreatedAt
+		newState.LastProcessedID = processedIDs[len(processedIDs)-1]
 	}
 
 	payload, err := json.Marshal(newState)
@@ -83,19 +96,23 @@ func (p *Plugin) fetchNextPayments(ctx context.Context, req models.FetchNextPaym
 func (p *Plugin) toPSPPayments(
 	ctx context.Context,
 	lastCreatedAt time.Time,
+	lastProcessedID string,
 	payments []models.PSPPayment,
+	processedIDs []string,
 	transactions []*client.Transaction,
-) ([]models.PSPPayment, error) {
+) ([]models.PSPPayment, []string, error) {
 	for _, transaction := range transactions {
 		createdAt, err := time.Parse("2006-01-02T15:04:05.999999999", transaction.Attributes.CreatedAt)
 		if err != nil {
-			return payments, fmt.Errorf("failed to parse transaction date: %v", err)
+			return payments, processedIDs, fmt.Errorf("failed to parse transaction date: %v", err)
 		}
 
-		switch createdAt.Compare(lastCreatedAt) {
-		case -1, 0:
+		// Inclusive watermark: skip transactions strictly before it, and the
+		// single already-processed transaction at exactly the watermark. Distinct
+		// transactions sharing that timestamp are kept (M-CON2).
+		cmp := createdAt.Compare(lastCreatedAt)
+		if cmp < 0 || (cmp == 0 && transaction.ID == lastProcessedID) {
 			continue
-		default:
 		}
 
 		payment, err := p.transactionToPayment(ctx, transaction)
@@ -106,15 +123,16 @@ func (p *Plugin) toPSPPayments(
 				p.logger.WithField("transaction_id", transaction.ID).Info("skipping transaction with unsupported currency")
 				continue
 			}
-			return payments, err
+			return payments, processedIDs, err
 		}
 		if payment == nil {
 			continue
 		}
 
 		payments = append(payments, *payment)
+		processedIDs = append(processedIDs, transaction.ID)
 	}
-	return payments, nil
+	return payments, processedIDs, nil
 }
 
 func (p *Plugin) transactionToPayment(ctx context.Context, transaction *client.Transaction) (*models.PSPPayment, error) {

--- a/ce/plugins/moneycorp/payments_test.go
+++ b/ce/plugins/moneycorp/payments_test.go
@@ -537,14 +537,36 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 2, ts.UTC()).Return(all[2:4], nil)
 			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(ContainElements("m2", "m3"))
-			Expect(refs(resp.Payments)).ToNot(ContainElement("m1"))
+			// Boundary m1 is deduped; m0 (a same-second sibling on the re-fetched
+			// page 0) is re-emitted by design — storage upserts dedup it. The exact
+			// assertion catches any unintended extra re-emission.
+			Expect(refs(resp.Payments)).To(Equal([]string{"m0", "m2", "m3"}))
 
-			// Cycle 3: page 2 -> m4 (group fully drained, no stall).
+			// Cycle 3: page 2 -> m4 (group fully drained on a short final page).
 			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 2, ts.UTC()).Return(all[4:5], nil)
 			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(ContainElement("m4"))
+			Expect(refs(resp.Payments)).To(Equal([]string{"m4"}))
+
+			// Cycle 4: a newer-second transaction m5 lands on the short last page
+			// (2). The cursor must stay on page 2 rather than advance to page 3, or
+			// m5 would be stranded forever behind an empty page.
+			m5 := &client.Transaction{
+				ID: "m5",
+				Attributes: client.TransactionAttributes{
+					AccountID: accRef,
+					Type:      "Charge",
+					Direction: "Credit",
+					Currency:  "MAD",
+					Amount:    json.Number("100"),
+					CreatedAt: "2024-02-02T00:00:01",
+				},
+			}
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 2, ts.UTC()).Return([]*client.Transaction{all[4], m5}, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 3, 2, ts.UTC()).Return([]*client.Transaction{}, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"m5"}))
 		})
 	})
 })

--- a/ce/plugins/moneycorp/payments_test.go
+++ b/ce/plugins/moneycorp/payments_test.go
@@ -498,5 +498,53 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 			Expect(resp.Payments).To(HaveLen(2))
 			Expect([]string{resp.Payments[0].Reference, resp.Payments[1].Reference}).To(ConsistOf("b", "c"))
 		})
+
+		It("walks a same-second group larger than PageSize across cycles without stalling", func(ctx SpecContext) {
+			const createdAtStr = "2024-02-02T00:00:00"
+			ts, _ := time.Parse("2006-01-02T15:04:05.999999999", createdAtStr)
+			mk := func(id string) *client.Transaction {
+				return &client.Transaction{
+					ID: id,
+					Attributes: client.TransactionAttributes{
+						AccountID: accRef,
+						Type:      "Charge",
+						Direction: "Credit",
+						Currency:  "MAD",
+						Amount:    json.Number("100"),
+						CreatedAt: createdAtStr,
+					},
+				}
+			}
+			all := []*client.Transaction{mk("m0"), mk("m1"), mk("m2"), mk("m3"), mk("m4")}
+			refs := func(ps []models.PSPPayment) []string {
+				out := make([]string, len(ps))
+				for i := range ps {
+					out[i] = ps[i].Reference
+				}
+				return out
+			}
+			ref := fmt.Sprintf("%d", accRef)
+			fromPayload := json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef))
+
+			// Cycle 1: page 0 -> m0, m1.
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 2, time.Time{}).Return(all[0:2], nil)
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(Equal([]string{"m0", "m1"}))
+
+			// Cycle 2: page 0 re-fetched (m1 deduped) then page 1 -> m2, m3.
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 2, ts.UTC()).Return(all[0:2], nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 2, ts.UTC()).Return(all[2:4], nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElements("m2", "m3"))
+			Expect(refs(resp.Payments)).ToNot(ContainElement("m1"))
+
+			// Cycle 3: page 2 -> m4 (group fully drained, no stall).
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 2, ts.UTC()).Return(all[4:5], nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			Expect(err).To(BeNil())
+			Expect(refs(resp.Payments)).To(ContainElement("m4"))
+		})
 	})
 })

--- a/ce/plugins/moneycorp/payments_test.go
+++ b/ce/plugins/moneycorp/payments_test.go
@@ -427,7 +427,11 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 		It("should fetch next payments - with state pageSize < total payments", func(ctx SpecContext) {
 			lastCreatedAt, _ := time.Parse(time.RFC3339Nano, samplePayments[38].Attributes.CreatedAt+"Z")
 			req := models.FetchNextPaymentsRequest{
-				State:       []byte(fmt.Sprintf(`{"lastCreatedAt": "%s"}`, lastCreatedAt.Format(time.RFC3339Nano))),
+				State: []byte(fmt.Sprintf(
+					`{"lastCreatedAt": "%s", "lastProcessedID": "%s"}`,
+					lastCreatedAt.Format(time.RFC3339Nano),
+					samplePayments[38].ID,
+				)),
 				PageSize:    40,
 				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef)),
 			}
@@ -454,6 +458,45 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 			// We fetched everything, state should be resetted
 			createdAtTime, _ := time.Parse(time.RFC3339Nano, samplePayments[49].Attributes.CreatedAt+"Z")
 			Expect(state.LastCreatedAt.UTC()).To(Equal(createdAtTime.UTC()))
+		})
+
+		It("keeps distinct transactions that share the watermark timestamp (M-CON2)", func(ctx SpecContext) {
+			const createdAtStr = "2024-01-01T00:00:00"
+			ts, _ := time.Parse(time.RFC3339Nano, createdAtStr+"Z")
+			mk := func(id string) *client.Transaction {
+				return &client.Transaction{
+					ID: id,
+					Attributes: client.TransactionAttributes{
+						AccountID: accRef,
+						Type:      "Refund",
+						Direction: "Credit",
+						Currency:  "MAD",
+						Amount:    json.Number("100"),
+						CreatedAt: createdAtStr,
+					},
+				}
+			}
+
+			req := models.FetchNextPaymentsRequest{
+				State: []byte(fmt.Sprintf(
+					`{"lastCreatedAt": "%s", "lastProcessedID": "a"}`,
+					ts.Format(time.RFC3339Nano),
+				)),
+				PageSize:    40,
+				FromPayload: json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef)),
+			}
+
+			m.EXPECT().GetTransactions(gomock.Any(), fmt.Sprintf("%d", accRef), 0, 40, ts.UTC()).Return(
+				[]*client.Transaction{mk("a"), mk("b"), mk("c")},
+				nil,
+			)
+
+			resp, err := plg.FetchNextPayments(ctx, req)
+			Expect(err).To(BeNil())
+			// "a" is the already-processed boundary row; "b" and "c" share its
+			// timestamp and must NOT be dropped.
+			Expect(resp.Payments).To(HaveLen(2))
+			Expect([]string{resp.Payments[0].Reference, resp.Payments[1].Reference}).To(ConsistOf("b", "c"))
 		})
 	})
 })

--- a/ce/plugins/moneycorp/payments_test.go
+++ b/ce/plugins/moneycorp/payments_test.go
@@ -428,7 +428,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 			lastCreatedAt, _ := time.Parse(time.RFC3339Nano, samplePayments[38].Attributes.CreatedAt+"Z")
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"lastCreatedAt": "%s", "lastProcessedID": "%s"}`,
+					`{"lastCreatedAt": "%s", "lastProcessedIDs": ["%s"]}`,
 					lastCreatedAt.Format(time.RFC3339Nano),
 					samplePayments[38].ID,
 				)),
@@ -479,7 +479,7 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 
 			req := models.FetchNextPaymentsRequest{
 				State: []byte(fmt.Sprintf(
-					`{"lastCreatedAt": "%s", "lastProcessedID": "a"}`,
+					`{"lastCreatedAt": "%s", "lastProcessedIDs": ["a"]}`,
 					ts.Format(time.RFC3339Nano),
 				)),
 				PageSize:    40,
@@ -515,6 +515,9 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 					},
 				}
 			}
+			// Five transactions sharing the same second, fetched three per page so
+			// the group spans page 0 (m0,m1,m2) and a SHORT final page 1 (m3,m4).
+			// Each cycle rescans from page 0 and skips the processed-ID set.
 			all := []*client.Transaction{mk("m0"), mk("m1"), mk("m2"), mk("m3"), mk("m4")}
 			refs := func(ps []models.PSPPayment) []string {
 				out := make([]string, len(ps))
@@ -526,31 +529,30 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 			ref := fmt.Sprintf("%d", accRef)
 			fromPayload := json.RawMessage(fmt.Sprintf(`{"reference": "%d"}`, accRef))
 
-			// Cycle 1: page 0 -> m0, m1.
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 2, time.Time{}).Return(all[0:2], nil)
-			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 2, FromPayload: fromPayload})
+			// Cycle 1: fresh state, page 0 -> m0, m1, m2.
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 3, time.Time{}).Return(all[0:3], nil)
+			resp, err := plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: []byte(`{}`), PageSize: 3, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(Equal([]string{"m0", "m1"}))
+			Expect(refs(resp.Payments)).To(Equal([]string{"m0", "m1", "m2"}))
+			Expect(resp.HasMore).To(BeTrue())
 
-			// Cycle 2: page 0 re-fetched (m1 deduped) then page 1 -> m2, m3.
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 2, ts.UTC()).Return(all[0:2], nil)
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 2, ts.UTC()).Return(all[2:4], nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			// Cycle 2: rescan page 0 (all skipped via the set) then page 1 -> m3, m4.
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
-			// Boundary m1 is deduped; m0 (a same-second sibling on the re-fetched
-			// page 0) is re-emitted by design — storage upserts dedup it. The exact
-			// assertion catches any unintended extra re-emission.
-			Expect(refs(resp.Payments)).To(Equal([]string{"m0", "m2", "m3"}))
+			Expect(refs(resp.Payments)).To(Equal([]string{"m3", "m4"}))
 
-			// Cycle 3: page 2 -> m4 (group fully drained on a short final page).
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 2, ts.UTC()).Return(all[4:5], nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			// Cycle 3: group fully drained — every row is in the processed-ID set, so
+			// the rescan returns nothing (anti-oscillation).
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 3, ts.UTC()).Return(all[3:5], nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
-			Expect(refs(resp.Payments)).To(Equal([]string{"m4"}))
+			Expect(refs(resp.Payments)).To(BeEmpty())
 
-			// Cycle 4: a newer-second transaction m5 lands on the short last page
-			// (2). The cursor must stay on page 2 rather than advance to page 3, or
-			// m5 would be stranded forever behind an empty page.
+			// Cycle 4: a newer-second transaction m5 appears on the (formerly short)
+			// page 1. The set skips m3/m4 and reaches m5 — no stranding.
 			m5 := &client.Transaction{
 				ID: "m5",
 				Attributes: client.TransactionAttributes{
@@ -562,9 +564,10 @@ var _ = Describe("Moneycorp *Plugin Payments - check pagination", func() {
 					CreatedAt: "2024-02-02T00:00:01",
 				},
 			}
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 2, ts.UTC()).Return([]*client.Transaction{all[4], m5}, nil)
-			m.EXPECT().GetTransactions(gomock.Any(), ref, 3, 2, ts.UTC()).Return([]*client.Transaction{}, nil)
-			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 2, FromPayload: fromPayload})
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 0, 3, ts.UTC()).Return(all[0:3], nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 1, 3, ts.UTC()).Return([]*client.Transaction{all[3], all[4], m5}, nil)
+			m.EXPECT().GetTransactions(gomock.Any(), ref, 2, 3, ts.UTC()).Return([]*client.Transaction{}, nil)
+			resp, err = plg.FetchNextPayments(ctx, models.FetchNextPaymentsRequest{State: resp.NewState, PageSize: 3, FromPayload: fromPayload})
 			Expect(err).To(BeNil())
 			Expect(refs(resp.Payments)).To(Equal([]string{"m5"}))
 		})


### PR DESCRIPTION
Part 2 of 2 for [EN-1095](https://formance-team.atlassian.net/browse/EN-1095). Part 1 (currency-error handling, M-CON1/M-CON5) is #781.

## Problem
Connectors filtered their watermark with `case -1, 0: continue` (skip `<=` watermark) or an exclusive server filter. Distinct transactions sharing a second-precision timestamp were silently dropped when a page/cycle boundary fell inside the group.

## Fix — qonto pattern, per connector (one commit each)
Inclusive (`>=`) watermark that excludes only the **exact** already-processed row, tracked via a new `LastProcessedID` in state. Same-second siblings are kept; storage upserts dedup harmless re-emission. Migration: old state has no `LastProcessedID`, so the boundary row is re-emitted once (idempotent) — **no recrawl**.

- **bankingcircle** — M-CON2; also fixes an entangled latent bug (watermark read from the *untrimmed* slice while payments were trimmed → overshoot/skip; now lockstep trim).
- **generic** — M-CON2 across payments + accounts + external_accounts.
- **moneycorp** — M-CON2 (payments + external_accounts); payments dedup keys on `transaction.ID` (differs from `payment.Reference` for "Payment" types) via a parallel slice.
- **modulr** — M-CON2 accounts + external_accounts (`payments.go` already reworked under EN-1088, left as-is).
- **currencycloud** — M-CON2 (×3) **and stops mutating the watermark mid-pagination** (now filters against a stable `oldState` watermark across all pages).
- **mangopay** — M-CON3: `AfterDate` is an exclusive second-precision server filter that dropped the watermark second; query `AfterDate = watermark - 1s` so it's returned. The existing `LastPage` counter pages through same-second groups (mangopay's qonto-`Page` equivalent).

## Scope notes
- **currencycloud day-truncation** (`client/transactions.go`): left day-granular and documented. It's now an over-fetch, not data loss (client dedup handles same-second). Tightening to a datetime filter needs confirming CurrencyCloud's `updated_at_from` accepts ISO8601 datetime + its inclusivity — **follow-up**, not shipped unverified.
- **mangopay siblings** (users/accounts/external_accounts) use `createdAt.Before(watermark)` = keeps `>= watermark` (inclusive); they never dropped same-second rows → left unchanged.
- **M-CON4** (increase timeline redesign) is a separate **follow-up ticket** (redesign to Column's `ending_before=LastSeenID`, not a harmonization copy).

## Merge note
`moneycorp/payments.go` is also edited by #781 (same function) — this branch will need a small rebase after #781 merges.

## Tests
TDD: existing "with state" specs updated to carry `LastProcessedID`; new same-second "siblings kept" + migration "boundary re-emitted once" regression specs per connector. All affected packages green; `go build ./...` clean.

[EN-1095]: https://formance-team.atlassian.net/browse/EN-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ