### PR TITLE
docs: add connector review rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ This guide demonstrates the process of building a basic connector for a hypothet
   - [Launching a new connector](#launching-a-new-connector)
     - [Additional Connector Configuration](#additional-connector-configuration)
   - [Special Implementation details](#special-implementation-details)
+    - [Connector implementation rules](#connector-implementation-rules)
     - [Metadata](#metadata)
       - [Use namespaces for metadata](#use-namespaces-for-metadata)
       - [Extracting Metadata values from Metadata](#extracting-metadata-values-from-metadata)
@@ -822,6 +823,19 @@ http://localhost:8080/v3/connectors/install/dummypay
 
 In order to keep the codebase neat and consistent across different implementations, there are some tips to be aware of when working on the codebase. Follow this pattern to avoid some pitfalls.
 
+### Connector implementation rules
+
+Connector implementations must preserve data correctness and operational safety across polling cycles, retries, and multi-worker deployments. Follow these rules when adding or changing a connector:
+
+- Do not advance state cursors, watermarks, or offsets after dropping data because of a recoverable PSP condition. Refresh, retry, or return a controlled error before committing progress.
+- Match the workflow tree to the PSP filtering capabilities. Do not create per-account child tasks when the PSP endpoint cannot filter by account, asset, or another parent payload field.
+- Do not silently coerce malformed PSP data or unknown enum values into valid-looking PSP models. Unknown statuses, order types, malformed amounts, and malformed fees must be skipped with structured logs or returned as controlled errors.
+- Keep PSP entity identity and timestamps stable across fetch cycles. Updates must not mutate creation timestamps or references when an entity moves between provider states.
+- Classify PSP errors explicitly. Invalid credentials or invalid configuration must be non-retryable, rate limits and nonce conflicts must use retry or backoff behavior, and provider warnings must not discard valid results.
+- Keep install fast. Prefer lazy loading and per-fetch refresh logic over network-dependent install work unless a bootstrap task is explicitly required.
+- Document PSP assumptions that are not obvious from code, especially pagination, timestamp ordering, signing, request encoding, and webhook semantics. Back them with PSP documentation or live verification.
+- Keep HTTP transport, signing, mapping, and workflow orchestration responsibilities separated. Transport wrappers should not own business mapping or mutate request bodies unless the PSP contract requires it and the behavior is documented.
+
 ### Metadata
 
 When working with a connector, there are cases where you need to save more data in the PSP model, but this property is not available in the PSP model. In this case, you will save this property and its value in the PSP Metadata property. There are also some scenarios where you need to collect more information when creating data, but these properties are not provided in the default creation model. Here, you will also use metadata. Below is how to set up the proper Metadata handling.
@@ -1069,3 +1083,10 @@ chmod +x ./speakeasy.sh
 - [ ] Ensure you don't have empty fields. Use “Unknown” as a placeholder instead.
 - [ ] Validate all status covered on the API docs are formatted to `payments` payment status.
 - [ ] Validate that `PAYIN` and PAYOUT status corresponds to the PSP API payment status. Incoming payouts should have `PAYIN` status and outgoing PAYOUT status.
+- [ ] Validate cursor, watermark, and offset advancement cannot skip rows after recoverable PSP errors.
+- [ ] Validate workflow fan-out matches the PSP filtering capabilities.
+- [ ] Validate unknown or malformed PSP values are not silently mapped to valid business states or zero amounts.
+- [ ] Validate entity references and creation timestamps remain stable across updates.
+- [ ] Validate PSP errors are classified as retryable, non-retryable, or warning-only as appropriate.
+- [ ] Validate install does not perform avoidable network work.
+- [ ] Validate non-obvious PSP assumptions are documented and backed by PSP documentation or live verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -828,12 +828,17 @@ In order to keep the codebase neat and consistent across different implementatio
 Connector implementations must preserve data correctness and operational safety across polling cycles, retries, and multi-worker deployments. Follow these rules when adding or changing a connector:
 
 - Do not advance state cursors, watermarks, or offsets after dropping data because of a recoverable PSP condition. Refresh, retry, or return a controlled error before committing progress.
+- Design pagination from the PSP ordering, end-of-stream, cursor, and page-size semantics. Keep enough state to resume without refetching from the beginning, and validate small page sizes, equal timestamps, and filtered rows before committing new state.
 - Match the workflow tree to the PSP filtering capabilities. Do not create per-account child tasks when the PSP endpoint cannot filter by account, asset, or another parent payload field.
+- Use `req.FromPayload` when a child task already carries the parent entity data needed by the fetch. Avoid extra PSP calls or database lookups unless the connector explicitly needs an engine-provided capability such as `PluginWithAccountLookup`.
 - Do not silently coerce malformed PSP data or unknown enum values into valid-looking PSP models. Unknown statuses, order types, malformed amounts, and malformed fees must be skipped with structured logs or returned as controlled errors.
 - Keep PSP entity identity and timestamps stable across fetch cycles. Updates must not mutate creation timestamps or references when an entity moves between provider states.
 - Classify PSP errors explicitly. Invalid credentials or invalid configuration must be non-retryable, rate limits and nonce conflicts must use retry or backoff behavior, and provider warnings must not discard valid results.
+- When using a PSP SDK, inject the repository's instrumented HTTP client or wrap SDK errors so metrics, tracing, and Temporal retry behavior remain correct.
 - Keep install fast. Prefer lazy loading and per-fetch refresh logic over network-dependent install work unless a bootstrap task is explicitly required.
+- Leave scheduling, polling periods, generated IDs, and storage ownership to the payments core. Connector code should emit PSP models, capabilities, workflows, and provider-specific API calls.
 - Document PSP assumptions that are not obvious from code, especially pagination, timestamp ordering, signing, request encoding, and webhook semantics. Back them with PSP documentation or live verification.
+- For webhooks, validate event coverage, idempotency key uniqueness across connector installations, and structured logging for unhandled event categories.
 - Keep HTTP transport, signing, mapping, and workflow orchestration responsibilities separated. Transport wrappers should not own business mapping or mutate request bodies unless the PSP contract requires it and the behavior is documented.
 
 ### Metadata
@@ -1084,9 +1089,14 @@ chmod +x ./speakeasy.sh
 - [ ] Validate all status covered on the API docs are formatted to `payments` payment status.
 - [ ] Validate that `PAYIN` and PAYOUT status corresponds to the PSP API payment status. Incoming payouts should have `PAYIN` status and outgoing PAYOUT status.
 - [ ] Validate cursor, watermark, and offset advancement cannot skip rows after recoverable PSP errors.
+- [ ] Validate pagination handles end-of-stream, repeated timestamps or cursors, filtered rows, and small page sizes.
 - [ ] Validate workflow fan-out matches the PSP filtering capabilities.
+- [ ] Validate child tasks use `req.FromPayload` instead of refetching when the parent payload already contains the needed data.
 - [ ] Validate unknown or malformed PSP values are not silently mapped to valid business states or zero amounts.
 - [ ] Validate entity references and creation timestamps remain stable across updates.
 - [ ] Validate PSP errors are classified as retryable, non-retryable, or warning-only as appropriate.
+- [ ] Validate SDK-based clients preserve metrics, tracing, and retry semantics through the repository HTTP wrapper or explicit error mapping.
 - [ ] Validate install does not perform avoidable network work.
+- [ ] Validate the connector does not own polling schedules, generated IDs, or storage-layer behavior.
+- [ ] Validate webhook event subscriptions, idempotency keys, and unhandled event logging.
 - [ ] Validate non-obvious PSP assumptions are documented and backed by PSP documentation or live verification.


### PR DESCRIPTION
## What

Add connector implementation rules to `CONTRIBUTING.md`, covering:

- polling state, pagination, cursors, watermarks, and page-size semantics
- workflow fan-out and `req.FromPayload` usage
- malformed provider values and unknown enum handling
- stable entity references and timestamps
- provider error classification, SDK/httpwrapper behavior, metrics, and tracing
- install behavior and connector/core ownership boundaries
- provider assumptions, webhooks, idempotency, and layer boundaries

Also extend the connector review checklist with concise checks for those rules.

## Why

Recent connector review feedback exposed recurring correctness and operational invariants that are useful beyond a single PR. I also checked prior connector-addition PRs and folded recurring themes from those review threads into the rules.

## Validation

- `git diff --check`