### PR TITLE
fix(openapi): emit openapi header in generated connectors config

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,13 +36,13 @@ compile-connector-capabilities:
 
 [group('openapi')]
 compile-api-yaml: compile-connector-configs
-    @npx openapi-merge-cli --config {{justfile_directory()}}/openapi/openapi-merge.json
+    @npx openapi-merge-cli@2.0.2 --config {{justfile_directory()}}/openapi/openapi-merge.json
     @yq -oy {{justfile_directory()}}/openapi.json > openapi.yaml
     @rm {{justfile_directory()}}/openapi.json
 
 [group('openapi')]
 compile-api-docs:
-    @npx openapi-merge-cli --config {{justfile_directory()}}/openapi/openapi-docs-merge.json
+    @npx openapi-merge-cli@2.0.2 --config {{justfile_directory()}}/openapi/openapi-docs-merge.json
     @npx -y widdershins {{justfile_directory()}}/openapi.json -o {{justfile_directory()}}/docs/api/README.md --search false --language_tabs 'http:HTTP' --summary --omitHeader
     @rm {{justfile_directory()}}/openapi.json
 

--- a/openapi/v3/v3-connectors-config.yaml
+++ b/openapi/v3/v3-connectors-config.yaml
@@ -1,3 +1,7 @@
+openapi: 3.0.3
+info:
+    title: Payments API
+    version: v3
 components:
     schemas:
         V3ConnectorConfig:

--- a/tools/compile-configs/definitions.go
+++ b/tools/compile-configs/definitions.go
@@ -1,7 +1,17 @@
 package main
 
+// V3ConnectorConfigYaml is merged with the other openapi/ partials by
+// openapi-merge-cli, which requires every input to declare a full OpenAPI
+// version — even components-only ones like this file.
 type V3ConnectorConfigYaml struct {
+	OpenAPI    string     `yaml:"openapi"`
+	Info       Info       `yaml:"info"`
 	Components Components `yaml:"components"`
+}
+
+type Info struct {
+	Title   string `yaml:"title"`
+	Version string `yaml:"version"`
 }
 
 type Components struct {

--- a/tools/compile-configs/main.go
+++ b/tools/compile-configs/main.go
@@ -42,6 +42,11 @@ func main() {
 	caser := cases.Title(language.English)
 
 	output := V3ConnectorConfigYaml{
+		OpenAPI: "3.0.3",
+		Info: Info{
+			Title:   "Payments API",
+			Version: "v3",
+		},
 		Components: Components{
 			Schemas: Schemas{
 				V3ConnectorConfig: V3ConnectorConfig{


### PR DESCRIPTION
## Problem

`openapi-merge-cli` [v2.0.2](https://www.npmjs.com/package/openapi-merge-cli) (released Aug 8) now requires **every** merge input to declare a full OpenAPI version. `tools/compile-configs` generates `openapi/v3/v3-connectors-config.yaml` as a components-only document with no header, so the merge step started failing:

```
Error merging files: Input 5 has no "openapi" field. Every input must declare a full OpenAPI
version such as "3.0.3". Supported versions: 3.0.x, 3.1.x, 3.2.x. (unsupported-openapi-version)
```

This hit `main` directly — no commit of ours triggered it — because both `npx openapi-merge-cli` invocations were unpinned and there is no `package.json`/lockfile, so every run picks up whatever is latest on npm. It broke `just pc`, `just openapi` and `just compile-api-yaml`.

Note that `v3-parameters.yaml` and `v3-schemas.yaml` are also components-only and merge fine — being a partial isn't the problem, the missing header is.

## Fix

- `tools/compile-configs` now emits the same `openapi: 3.0.3` + `info` header the other `openapi/` partials carry. Merge takes `openapi`/`info` from the first input only, so the added header is consumed and discarded.
- Pinned `openapi-merge-cli@2.0.2` in both `compile-api-yaml` and `compile-api-docs`, so a future upstream release can't break `main` again without a commit here.

## Verification

- `just openapi` passes end to end (merge → docs → validate).
- `git diff main -- openapi.yaml docs/api/README.md` is **empty** — the merged spec is byte-identical to what 2.0.1 produced. No API surface change.