### PR TITLE
fix(routable): future-date payables via send_on metadata (TS-540)

### DIFF
--- a/ee/plugins/routable/MAPPINGS.md
+++ b/ee/plugins/routable/MAPPINGS.md
@@ -181,6 +181,7 @@ All keys are defined as constants in [`mappers/metadata.go`](mappers/metadata.go
 | `com.routable.spec/external_id` | `MetadataKeyExternalID` | no | `""` | `external_id` | Caller-supplied external reference (idempotent lookup key on Routable's side). |
 | `com.routable.spec/line_item_description` | `MetadataKeyLineDescription` | no | `PSPPaymentInitiation.Description`, then `"Payment <reference>"` | `line_items[0].description` | Description on the auto-generated single-line item. Required by Routable v1; we always emit a non-empty value. |
 | `com.routable.spec/message` | `MetadataKeyMessage` | no | (omitted) | `message` | Vendor-facing email body sent to the payee's contacts when the payable is processed. A limited subset of HTML is permitted (see [Routable docs](https://developers.routable.com/docs/html-messages)). Omitted from the request body when empty. |
+| `com.routable.spec/send_on` | `MetadataKeySendOn` | no | unset → `send_on: null`, which Routable **does not execute** (see [§5.2](#52-static-body-fields-always-present)) | `send_on` | `YYYY-MM-DD` date on which **Routable** releases the payable. Validated locally; a malformed date fails as `ErrInvalidRequest` before any HTTP call. **This is not `scheduledAt`** — the engine's `scheduledAt` is honoured by sleeping *before* the plugin is called, so the two stack if you set both. |
 
 > `com.routable.spec/memo` is read-only metadata on synced payables/receivables (populated from the Routable response). Routable's v1 `POST /v1/payables` rejects `memo` as an unknown field, so we do not forward this key on create. Use `com.routable.spec/line_item_description` for the message that ends up on the payable.
 
@@ -195,8 +196,20 @@ All keys are defined as constants in [`mappers/metadata.go`](mappers/metadata.go
 | `amount` | `PSPPaymentInitiation.Amount` (minor units) → decimal string via `fromMinorUnits` ([`amounts.go`](amounts.go)) |
 | `currency_code` | `PSPPaymentInitiation.Asset` (e.g. `USD/2` → `USD`) |
 | `line_items` | Single line item with `unit_price = amount = total`, `quantity = 1`, and a non-empty `description` (see metadata table for resolution order) |
-| `send_on` | Always emitted; `null` means "send immediately" (Routable's v1 schema requires the field even when sending now) |
+| `send_on` | Always emitted. `null` — the value sent when no `send_on` is supplied — means **"do not execute"**, *not* "send immediately". See the callout below. |
 | `reference` | `PSPPaymentInitiation.Reference` (also forwarded as the `Idempotency-Key` HTTP header) |
+
+> **`send_on` semantics — `null` does NOT mean "send now".** Routable interprets `send_on` in **Pacific time** and supports exactly three behaviours ([API reference](https://developers.routable.com/reference/create-payable), [Your First Payable](https://developers.routable.com/docs/your-first-payable)):
+>
+> | `send_on` value | Routable behaviour |
+> |---|---|
+> | today's date (Pacific) | Payable is **sent immediately**. |
+> | a future date (Pacific) | Payable is **scheduled**; no email communications go out until that date. |
+> | `null` | Payable is created in **`ready_to_send`** and **is NOT executed**. Routable's own status glossary: *"the payment is waiting to be manually sent, either through the Routable Dashboard or an update to `send_on`."* |
+>
+> The plugin emits `send_on: null` whenever no date is supplied, so **the payable is created but never sent** until it is released manually in the Routable Dashboard. Callers who want the payment to go out must supply a date explicitly — today's Pacific date to send now, a future date to schedule.
+>
+> The field cannot simply be omitted instead: Routable's v1 schema marks `send_on` as `required` on every payable variant (`["delivery_method","send_on"]`, `["send_on","type"]`, …).
 
 ### 5.3 Idempotency
 

--- a/ee/plugins/routable/client/types.go
+++ b/ee/plugins/routable/client/types.go
@@ -169,9 +169,17 @@ type PayableLineItem struct {
 // CreatePayableRequest is the body for POST /v1/payables. IdempotencyKey is
 // sent via the Idempotency-Key header (see Client.CreatePayable).
 //
-// SendOn is documented as a YYYY-MM-DD date, with a nil pointer meaning
-// "send immediately". Routable's v1 schema marks the field required even
-// when sending immediately, so we always emit it as JSON null (not omitted).
+// SendOn is a YYYY-MM-DD date interpreted by Routable in PACIFIC time:
+//   - today's date  => the payable is sent immediately
+//   - a future date => the payable is scheduled for that date
+//   - nil (JSON null) => the payable is created in `ready_to_send` and is
+//     NOT executed until released manually in the Routable Dashboard, or
+//     until send_on is updated.
+//
+// A nil pointer therefore does NOT mean "send immediately". The field is
+// still always emitted (no omitempty) because Routable's v1 schema marks
+// send_on required on every payable variant.
+// https://developers.routable.com/reference/create-payable
 type CreatePayableRequest struct {
 	Type                string            `json:"type"`
 	DeliveryMethod      string            `json:"delivery_method"`

--- a/ee/plugins/routable/mappers/metadata.go
+++ b/ee/plugins/routable/mappers/metadata.go
@@ -1,6 +1,11 @@
 package mappers
 
-import "github.com/formancehq/payments/ee/plugins/routable/client"
+import (
+	"fmt"
+	"time"
+
+	"github.com/formancehq/payments/ee/plugins/routable/client"
+)
 
 const MetadataPrefix = "com.routable.spec/"
 
@@ -14,7 +19,34 @@ const (
 	MetadataKeyMessage          = MetadataPrefix + "message"
 	MetadataKeyLineDescription  = MetadataPrefix + "line_item_description"
 	MetadataKeyActingTeamMember = MetadataPrefix + "acting_team_member"
+	MetadataKeySendOn           = MetadataPrefix + "send_on"
 )
+
+// SendOnLayout is the only date format Routable's v1 `send_on` accepts.
+const SendOnLayout = "2006-01-02"
+
+// ParseSendOn resolves the send_on metadata key into the value for
+// CreatePayableRequest.SendOn. A missing or empty key yields nil, leaving
+// the existing default untouched.
+//
+// The date is validated here rather than left to Routable so a typo fails
+// as a non-retriable ErrInvalidRequest (see payable_create.go) instead of
+// burning Temporal retries on a 400 that can never succeed.
+//
+// Note this is Routable-side scheduling — Routable holds the payable until
+// the date — and is deliberately NOT wired to PaymentInitiation.ScheduledAt,
+// which the engine implements by sleeping before the plugin is ever called.
+// Setting both stacks the two delays.
+func ParseSendOn(meta map[string]string) (*string, error) {
+	raw, ok := meta[MetadataKeySendOn]
+	if !ok || raw == "" {
+		return nil, nil
+	}
+	if _, err := time.Parse(SendOnLayout, raw); err != nil {
+		return nil, fmt.Errorf("invalid %s %q: expected a YYYY-MM-DD date", MetadataKeySendOn, raw)
+	}
+	return &raw, nil
+}
 
 // Self-describing aliases written on synced PSPPayment metadata so
 // dashboards and operators don't have to know Routable's wire

--- a/ee/plugins/routable/mappers/metadata_test.go
+++ b/ee/plugins/routable/mappers/metadata_test.go
@@ -115,3 +115,54 @@ func assertAliasMetadata(t *testing.T, m map[string]string, wantPIRef, wantPayab
 		}
 	}
 }
+
+// TestParseSendOn covers the TS-540 contract: absent/empty means
+// unset, a well-formed YYYY-MM-DD is passed
+// through verbatim, and anything else is rejected locally so the caller
+// can wrap it as a non-retriable ErrInvalidRequest.
+func TestParseSendOn(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    map[string]string
+		want    string // "" means expect nil
+		wantErr bool
+	}{
+		{name: "nil metadata leaves send_on unset", meta: nil},
+		{name: "absent key leaves send_on unset", meta: map[string]string{MetadataKeyType: "wire"}},
+		{name: "empty value leaves send_on unset", meta: map[string]string{MetadataKeySendOn: ""}},
+		{name: "valid date passes through", meta: map[string]string{MetadataKeySendOn: "2026-09-01"}, want: "2026-09-01"},
+		{name: "leap day is valid", meta: map[string]string{MetadataKeySendOn: "2028-02-29"}, want: "2028-02-29"},
+		{name: "slashes rejected", meta: map[string]string{MetadataKeySendOn: "01/09/2026"}, wantErr: true},
+		{name: "unpadded rejected", meta: map[string]string{MetadataKeySendOn: "2026-9-1"}, wantErr: true},
+		{name: "out of range month rejected", meta: map[string]string{MetadataKeySendOn: "2026-13-45"}, wantErr: true},
+		{name: "non-leap Feb 29 rejected", meta: map[string]string{MetadataKeySendOn: "2027-02-29"}, wantErr: true},
+		{name: "rfc3339 rejected", meta: map[string]string{MetadataKeySendOn: "2026-09-01T00:00:00Z"}, wantErr: true},
+		{name: "free text rejected", meta: map[string]string{MetadataKeySendOn: "tomorrow"}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSendOn(tc.meta)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSendOn(%v) = %v, want error", tc.meta, got)
+				}
+				if got != nil {
+					t.Errorf("ParseSendOn returned %q alongside an error; must return nil", *got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSendOn(%v) unexpected error: %v", tc.meta, err)
+			}
+			switch {
+			case tc.want == "" && got != nil:
+				t.Errorf("ParseSendOn = %q, want nil (send immediately)", *got)
+			case tc.want != "" && got == nil:
+				t.Errorf("ParseSendOn = nil, want %q", tc.want)
+			case tc.want != "" && *got != tc.want:
+				t.Errorf("ParseSendOn = %q, want %q", *got, tc.want)
+			}
+		})
+	}
+}

--- a/ee/plugins/routable/payable_create.go
+++ b/ee/plugins/routable/payable_create.go
@@ -47,9 +47,18 @@ func (p *Plugin) initiatePayable(ctx context.Context, pi models.PSPPaymentInitia
 		lineDescription = "Payment " + pi.Reference
 	}
 
-	// SendOn nil => JSON null => "send now". An explicit YYYY-MM-DD can
-	// be wired through metadata for future-dated payables.
-	var sendOn *string
+	// An explicit YYYY-MM-DD in metadata future-dates the payable at
+	// Routable (TS-540).
+	//
+	// Absent, SendOn stays nil => JSON null, and Routable puts the payable
+	// in `ready_to_send`: it is created but WILL NOT BE EXECUTED until
+	// someone releases it in the Routable Dashboard or send_on is updated.
+	// null does NOT mean "send now" — sending today is `send_on` = today's
+	// date in Pacific time. See MAPPINGS.md §5.1.
+	sendOn, err := mappers.ParseSendOn(pi.Metadata)
+	if err != nil {
+		return nil, 0, errorsutils.NewWrappedError(err, models.ErrInvalidRequest)
+	}
 
 	req := client.CreatePayableRequest{
 		Type:                mappers.FieldOr(pi.Metadata, mappers.MetadataKeyType, mappers.DefaultPayableType),

--- a/ee/plugins/routable/payouts_test.go
+++ b/ee/plugins/routable/payouts_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 			Expect(req.ActingTeamMember).To(Equal("tm_default"))
 			Expect(req.IdempotencyKey).To(Equal("pi_1"))
 			// Routable's v1 schema requires both: line_items[0].description
-			// non-empty AND send_on present (null = send-now).
+			// non-empty AND send_on present (null = ready_to_send, i.e. held).
 			Expect(req.LineItems).To(HaveLen(1))
 			Expect(req.LineItems[0].Description).NotTo(BeEmpty())
 			return &client.Payable{ID: "pa_1", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
@@ -77,6 +77,9 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 		Expect(*resp.PollingPayoutID).To(Equal("pa_1"))
 	})
 
+	// send_on stays JSON null when no date is supplied. Note this leaves the
+	// payable in Routable's `ready_to_send` — created but NOT executed until
+	// released manually; null is not "send now". See MAPPINGS.md §5.2.
 	It("synthesizes a non-empty line description and emits send_on as JSON null when the PI has neither", func(ctx SpecContext) {
 		bare := pi()
 		bare.Description = "" // no description from PI
@@ -96,6 +99,57 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 		body, err := json.Marshal(captured)
 		Expect(err).To(BeNil())
 		Expect(string(body)).To(ContainSubstring(`"send_on":null`))
+	})
+
+	// TS-540: future-dating a payable is opt-in via metadata. This is
+	// Routable-side scheduling (Routable holds the payable) and is NOT
+	// PaymentInitiation.ScheduledAt, which the engine honours by sleeping
+	// before the plugin is ever called — setting both stacks the delays.
+	It("forwards an explicit send_on date from metadata", func(ctx SpecContext) {
+		scheduled := pi()
+		scheduled.Metadata = map[string]string{mappers.MetadataKeySendOn: "2026-09-01"}
+
+		var captured client.CreatePayableRequest
+		mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+			captured = req
+			return &client.Payable{ID: "pa_s", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+		})
+
+		_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: scheduled})
+		Expect(err).To(BeNil())
+		Expect(captured.SendOn).NotTo(BeNil())
+		Expect(*captured.SendOn).To(Equal("2026-09-01"))
+		body, err := json.Marshal(captured)
+		Expect(err).To(BeNil())
+		Expect(string(body)).To(ContainSubstring(`"send_on":"2026-09-01"`))
+	})
+
+	It("leaves send_on at its default when the metadata value is empty", func(ctx SpecContext) {
+		blank := pi()
+		blank.Metadata = map[string]string{mappers.MetadataKeySendOn: ""}
+
+		var captured client.CreatePayableRequest
+		mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+			captured = req
+			return &client.Payable{ID: "pa_e", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+		})
+
+		_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: blank})
+		Expect(err).To(BeNil())
+		Expect(captured.SendOn).To(BeNil(), "an empty value must fall back to the default, not an empty-string date")
+	})
+
+	// A malformed date must fail before the HTTP call: Routable would 400,
+	// and without ErrInvalidRequest Temporal would retry a request that can
+	// never succeed. No EXPECT() here — any call to CreatePayable fails the test.
+	It("rejects a malformed send_on before any network call and wraps ErrInvalidRequest", func(ctx SpecContext) {
+		for _, bad := range []string{"01/09/2026", "2026-9-1", "tomorrow", "2026-13-45", "2026-09-01T00:00:00Z"} {
+			invalid := pi()
+			invalid.Metadata = map[string]string{mappers.MetadataKeySendOn: bad}
+			_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: invalid})
+			Expect(err).To(HaveOccurred(), "send_on %q must be rejected", bad)
+			Expect(errors.Is(err, models.ErrInvalidRequest)).To(BeTrue(), "send_on %q must wrap ErrInvalidRequest", bad)
+		}
 	})
 
 	It("returns the Payment immediately when the response is terminal", func(ctx SpecContext) {

--- a/ee/plugins/routable/transfers_test.go
+++ b/ee/plugins/routable/transfers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/ee/plugins/routable/client"
+	"github.com/formancehq/payments/ee/plugins/routable/mappers"
 	"github.com/formancehq/payments/pkg/domain/plugins"
 	"github.com/formancehq/payments/pkg/domain/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -86,6 +87,32 @@ var _ = Describe("Routable createTransfer", func() {
 		bad = pi()
 		bad.DestinationAccount = nil
 		_, err = plg.createTransfer(ctx, models.CreateTransferRequest{PaymentInitiation: bad})
+		Expect(errors.Is(err, models.ErrInvalidRequest)).To(BeTrue())
+	})
+
+	// TS-540: send_on is wired in the shared initiatePayable, so it must be
+	// live on the transfer surface too, not just payouts.
+	It("forwards send_on from metadata on createTransfer", func(ctx SpecContext) {
+		scheduled := pi()
+		scheduled.Metadata = map[string]string{mappers.MetadataKeySendOn: "2026-09-01"}
+
+		var captured client.CreatePayableRequest
+		mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+			captured = req
+			return &client.Payable{ID: "pa_ts", Status: "pending", Amount: "50.00", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+		})
+
+		_, err := plg.createTransfer(ctx, models.CreateTransferRequest{PaymentInitiation: scheduled})
+		Expect(err).To(BeNil())
+		Expect(captured.SendOn).NotTo(BeNil())
+		Expect(*captured.SendOn).To(Equal("2026-09-01"))
+	})
+
+	It("rejects a malformed send_on on createTransfer", func(ctx SpecContext) {
+		invalid := pi()
+		invalid.Metadata = map[string]string{mappers.MetadataKeySendOn: "01/09/2026"}
+		_, err := plg.createTransfer(ctx, models.CreateTransferRequest{PaymentInitiation: invalid})
+		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, models.ErrInvalidRequest)).To(BeTrue())
 	})
 


### PR DESCRIPTION
## Context

A customer testing the Formance–Routable connector reported that they need to pass `send_on` to Routable and had no way to do it.

They were right, and looking into it turned up a second, more serious problem underneath.

## 1. `send_on` was never settable (TS-540)

`initiatePayable` hard-coded `SendOn` to `nil`:

```go
// SendOn nil => JSON null => "send now". An explicit YYYY-MM-DD can
// be wired through metadata for future-dated payables.
var sendOn *string
```

The comment describes the intended escape hatch, but it was never wired — there was no `send_on` metadata key. No config, metadata, or API path could future-date a payable.

This PR wires it to a new `com.routable.spec/send_on` key, resolved in `mappers.ParseSendOn`. The date is validated against `YYYY-MM-DD` locally and wrapped in `ErrInvalidRequest`, so a typo fails fast and non-retriably instead of looping Temporal retries against a permanent 400. Absent or empty, `SendOn` stays `nil` and the wire body is byte-for-byte unchanged.

No API or SDK change: customers set it through the existing free-form `metadata` map on the transfer/payout.

## 2. `send_on: null` does not mean "send immediately"

This is the part worth a careful look.

`client/types.go` documented `nil` as "send immediately", and the plugin emits `null` on every payable created without a date. Per [Routable's API reference](https://developers.routable.com/reference/create-payable), `send_on` is interpreted in **Pacific time** and has three behaviours:

| `send_on` | Routable behaviour |
|---|---|
| today's date (Pacific) | sent immediately |
| a future date (Pacific) | scheduled; no emails until that date |
| `null` | created in `ready_to_send` and **not executed** |

Routable's status glossary for `ready_to_send`: *"the payment is waiting to be manually sent, either through the Routable Dashboard or an update to `send_on`."* And [Your First Payable](https://developers.routable.com/docs/your-first-payable): a `send_on` of `null` *"means the payment **will not be sent at all** until you trigger it via a subsequent API call or action on the Routable Dashboard."*

So Routable payables created through Formance without an explicit date are held pending manual release. That is very likely the actual symptom the customer hit.

**This PR does not change that behaviour** — deliberately. Defaulting to today's Pacific date would silently start executing payables that currently sit in `ready_to_send`, which is a surprising change for anyone relying on the manual-release flow. Instead the semantics are documented plainly in `MAPPINGS.md` §5.1/§5.2 and on `CreatePayableRequest.SendOn`, and callers who want a payment to go out now set the metadata key to today's Pacific date.

Happy to flip the default in a follow-up if we'd rather — it's a product call, not a technical one.

Note the field cannot simply be omitted instead: Routable's v1 schema marks `send_on` `required` on every payable variant.

## Interaction with `scheduledAt`

`PaymentInitiation.ScheduledAt` already exists and is engine-honoured — `create_payout.go` / `create_transfer.go` `workflow.Sleep` until the time, *then* call the plugin. The two mechanisms differ in where the payment waits:

| | `scheduledAt` (Formance) | `send_on` (Routable) |
|---|---|---|
| Who holds it | Temporal timer in the engine | Routable, as a pending payable |
| Exists at PSP before the date | No | Yes |
| Cancel before release | Cancel in Formance | Needs a Routable-side cancel |

They do not reconcile — they **stack**. `FromPaymentInitiationToPSPPaymentInitiation` drops `ScheduledAt` (folding it into `CreatedAt`), so `PSPPaymentInitiation` has no `ScheduledAt` field and the plugin is structurally blind to it. Setting both `scheduledAt: Sept 1` and `send_on: Sept 15` means the engine sleeps until the 1st, then Routable holds until the 15th. The plugin cannot detect the conflict to warn — any guard rail has to live in the API or engine layer.

Unifying these behind a capability flag (so the engine skips `workflow.Sleep` for connectors with native scheduling) is a cross-connector design question, intentionally out of scope. Documented in the metadata table so callers aren't surprised.

## Testing

- `ParseSendOn` table test: 11 cases — absent/empty/nil metadata, valid date, leap day, and rejections for slashes, unpadded, out-of-range month, non-leap Feb 29, RFC3339, free text
- `createPayout`: forwards the date, `"send_on":"2026-09-01"` on the wire; empty value falls back to the default; malformed date rejected before any network call
- `createTransfer`: same, since `initiatePayable` is shared
- Existing `"send_on":null` assertion still passes — the default is unchanged
- `just tests` green for the plugin; `just pc` clean (0 lint issues, no generated-file drift)

## Not covered

No end-to-end run against the Routable sandbox — only the request body is asserted. Worth a sandbox check of a future-dated payable before we tell the customer it's live.
