### PR TITLE
fix(plaid): bind webhook JWT to body hash and fresh iat

### DIFF
--- a/ce/plugins/plaid/webhooks.go
+++ b/ce/plugins/plaid/webhooks.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -15,6 +18,11 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/plaid/plaid-go/v34/plaid"
+)
+
+const (
+	plaidWebhookMaxAge     = 5 * time.Minute
+	plaidWebhookFutureSkew = time.Minute
 )
 
 type supportedWebhook struct {
@@ -100,7 +108,48 @@ func (p *Plugin) verifyWebhook(ctx context.Context, req models.VerifyWebhookRequ
 		return models.VerifyWebhookResponse{}, fmt.Errorf("invalid token: %w", models.ErrInvalidRequest)
 	}
 
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return models.VerifyWebhookResponse{}, fmt.Errorf("invalid token claims: %w", models.ErrInvalidRequest)
+	}
+
+	if err := verifyPlaidWebhookIAT(claims, time.Now()); err != nil {
+		return models.VerifyWebhookResponse{}, err
+	}
+	if err := verifyPlaidWebhookBodyHash(claims, req.Webhook.Body); err != nil {
+		return models.VerifyWebhookResponse{}, err
+	}
+
 	return models.VerifyWebhookResponse{}, nil
+}
+
+// Plaid signs iat plus request_body_sha256, not the HTTP body itself.
+// https://plaid.com/docs/api/webhooks/webhook-verification/
+func verifyPlaidWebhookIAT(claims jwt.MapClaims, now time.Time) error {
+	iat, err := claims.GetIssuedAt()
+	if err != nil || iat == nil {
+		return fmt.Errorf("missing iat: %w", models.ErrInvalidRequest)
+	}
+	if now.Sub(iat.Time) > plaidWebhookMaxAge {
+		return fmt.Errorf("webhook iat is older than 5 minutes: %w", models.ErrInvalidRequest)
+	}
+	if iat.Time.After(now.Add(plaidWebhookFutureSkew)) {
+		return fmt.Errorf("webhook iat is in the future: %w", models.ErrInvalidRequest)
+	}
+	return nil
+}
+
+func verifyPlaidWebhookBodyHash(claims jwt.MapClaims, body []byte) error {
+	want, ok := claims["request_body_sha256"].(string)
+	if !ok || want == "" {
+		return fmt.Errorf("missing request_body_sha256: %w", models.ErrInvalidRequest)
+	}
+	sum := sha256.Sum256(body)
+	got := hex.EncodeToString(sum[:])
+	if subtle.ConstantTimeCompare([]byte(strings.ToLower(got)), []byte(strings.ToLower(want))) != 1 {
+		return fmt.Errorf("request_body_sha256 mismatch: %w", models.ErrInvalidRequest)
+	}
+	return nil
 }
 
 func (p *Plugin) translateWebhook(ctx context.Context, req models.TranslateWebhookRequest) (models.TranslateWebhookResponse, error) {

--- a/ce/plugins/plaid/webhooks_test.go
+++ b/ce/plugins/plaid/webhooks_test.go
@@ -1,14 +1,48 @@
 package plaid
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"errors"
+	"strings"
+	"time"
 
 	"github.com/formancehq/payments/ce/plugins/plaid/client"
 	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/plaid/plaid-go/v34/plaid"
 	gomock "go.uber.org/mock/gomock"
 )
+
+func encodePlaidCoord(b []byte) string {
+	if len(b) < 32 {
+		padded := make([]byte, 32)
+		copy(padded[32-len(b):], b)
+		b = padded
+	}
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}
+
+func signPlaidWebhookJWT(priv *ecdsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = kid
+	s, err := token.SignedString(priv)
+	Expect(err).To(BeNil())
+	return s
+}
+
+func plaidJWK(priv *ecdsa.PrivateKey) *plaid.JWKPublicKey {
+	key := plaid.NewJWKPublicKeyWithDefaults()
+	key.SetX(encodePlaidCoord(priv.PublicKey.X.Bytes()))
+	key.SetY(encodePlaidCoord(priv.PublicKey.Y.Bytes()))
+	return key
+}
 
 var _ = Describe("Plaid *Plugin Webhooks", func() {
 	Context("create webhooks", func() {
@@ -93,6 +127,87 @@ var _ = Describe("Plaid *Plugin Webhooks", func() {
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("invalid token"))
 			Expect(resp).To(Equal(models.VerifyWebhookResponse{}))
+		})
+
+		It("should accept a signed JWT whose iat is fresh and body hash matches", func(ctx SpecContext) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).To(BeNil())
+			body := []byte(`{"webhook_type":"TRANSACTIONS","webhook_code":"SYNC_UPDATES_AVAILABLE"}`)
+			sum := sha256.Sum256(body)
+			token := signPlaidWebhookJWT(priv, "kid-1", jwt.MapClaims{
+				"iat":                 time.Now().Unix(),
+				"request_body_sha256": hex.EncodeToString(sum[:]),
+			})
+			m.EXPECT().GetWebhookVerificationKey(ctx, "kid-1").Return(plaidJWK(priv), nil)
+
+			resp, err := plg.VerifyWebhook(ctx, models.VerifyWebhookRequest{
+				Webhook: models.PSPWebhook{
+					Headers: map[string][]string{"Plaid-Verification": {token}},
+					Body:    body,
+				},
+			})
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(models.VerifyWebhookResponse{}))
+		})
+
+		It("should reject a signed JWT when the body hash does not match", func(ctx SpecContext) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).To(BeNil())
+			body := []byte(`{"webhook_type":"ITEM","webhook_code":"ERROR"}`)
+			other := sha256.Sum256([]byte(`{"forged":true}`))
+			token := signPlaidWebhookJWT(priv, "kid-1", jwt.MapClaims{
+				"iat":                 time.Now().Unix(),
+				"request_body_sha256": hex.EncodeToString(other[:]),
+			})
+			m.EXPECT().GetWebhookVerificationKey(ctx, "kid-1").Return(plaidJWK(priv), nil)
+
+			_, err = plg.VerifyWebhook(ctx, models.VerifyWebhookRequest{
+				Webhook: models.PSPWebhook{
+					Headers: map[string][]string{"Plaid-Verification": {token}},
+					Body:    body,
+				},
+			})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("request_body_sha256 mismatch"))
+		})
+
+		It("should reject a signed JWT with no request_body_sha256", func(ctx SpecContext) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).To(BeNil())
+			token := signPlaidWebhookJWT(priv, "kid-1", jwt.MapClaims{
+				"iat": time.Now().Unix(),
+			})
+			m.EXPECT().GetWebhookVerificationKey(ctx, "kid-1").Return(plaidJWK(priv), nil)
+
+			_, err = plg.VerifyWebhook(ctx, models.VerifyWebhookRequest{
+				Webhook: models.PSPWebhook{
+					Headers: map[string][]string{"Plaid-Verification": {token}},
+					Body:    []byte(`{}`),
+				},
+			})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("missing request_body_sha256"))
+		})
+
+		It("should reject a signed JWT whose iat is older than 5 minutes", func(ctx SpecContext) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).To(BeNil())
+			body := []byte(`{"webhook_type":"TRANSACTIONS"}`)
+			sum := sha256.Sum256(body)
+			token := signPlaidWebhookJWT(priv, "kid-1", jwt.MapClaims{
+				"iat":                 time.Now().Add(-6 * time.Minute).Unix(),
+				"request_body_sha256": hex.EncodeToString(sum[:]),
+			})
+			m.EXPECT().GetWebhookVerificationKey(ctx, "kid-1").Return(plaidJWK(priv), nil)
+
+			_, err = plg.VerifyWebhook(ctx, models.VerifyWebhookRequest{
+				Webhook: models.PSPWebhook{
+					Headers: map[string][]string{"Plaid-Verification": {token}},
+					Body:    body,
+				},
+			})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("older than 5 minutes"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Plaid webhook JWTs are `{iat, request_body_sha256}`. The signature covers those claims, not the HTTP body.

`verifyWebhook` checked ES256 and `token.Valid`, then returned. A captured `Plaid-Verification` JWT therefore authenticated any body, and a missing or stale `iat` never failed closed.

This matches Plaid's verification steps: reject when `iat` is older than 5 minutes, then constant-time compare SHA-256 of the raw body to `request_body_sha256`.

https://plaid.com/docs/api/webhooks/webhook-verification/

Threat model: the webhook URL is the product ingest surface. The attacker already has network reach to that path. They do not hold Plaid's signing key. Without the body hash they only need one captured JWT (logs, proxy, replay) to attach to a forged ITEM/TRANSACTIONS payload.

## Test plan

- [x] `go test ./ce/plugins/plaid/...` green
- [x] Revert-tested: dropping the body-hash check makes the mismatch spec fail (`Expected nil not to be nil`)
- [x] Fresh signed JWT + matching hash accepts
- [x] Matching signature + wrong hash rejects
- [x] Missing `request_body_sha256` rejects
- [x] `iat` older than 5 minutes rejects


Made with [Cursor](https://cursor.com)