### PR TITLE
fix(routable): map payment methods and preserve failures

### DIFF
--- a/ee/plugins/routable/MAPPINGS.md
+++ b/ee/plugins/routable/MAPPINGS.md
@@ -105,7 +105,7 @@ Implemented in [`payments.go`](payments.go) (`payableToPSPPayment`).
 | `CreatedAt` | `created_at` | Forwarded as-is. |
 | `Type` | constant `PAYMENT_TYPE_PAYOUT` | All Routable payables are money-out flows. Overridden to `PAYMENT_TYPE_TRANSFER` only when the row was created via `CreateTransfer` (see [`transfers.go`](transfers.go)). |
 | `Amount` | `amount` × `precision(currency_code)` | Decimal → minor units. Unsupported currencies cause the row to be skipped with a log line. |
-| `Asset` | `currency_code` | `USD/2`, `EUR/2`, `KWD/3`, … |
+| `Asset` | `currency_code` | `USD/2`, `EUR/2`, `KWD/3`, … Routable defines an omitted/null value as USD, and the mapper applies that default. |
 | `Scheme` | `delivery_method` | Mapped via [`scheme.go`](scheme.go) → `deliveryMethodToScheme` (`ach*` → `PAYMENT_SCHEME_ACH`, everything else → `PAYMENT_SCHEME_OTHER`). |
 | `Status` | `status` | Mapped via [`status.go`](status.go) → `payableStatus`. See [§4](#4-status-mapping). |
 | `SourceAccountReference` | `withdraw_from_account.id` | Routable settings account ID (matches a `PSPAccount` of internal type). |

--- a/ee/plugins/routable/MAPPINGS.md
+++ b/ee/plugins/routable/MAPPINGS.md
@@ -93,7 +93,7 @@ Implemented in [`external_accounts.go`](external_accounts.go) (`companyToPSPAcco
 | `Metadata` | `object`, `type`, `status`, `country_code`, `is_vendor`, `is_customer`, `is_archived`, `external_id`, `business_name`, `display_name`, `registered_address.{line_1,line_2,city,state,postal_code,country}` | See [`metadata.go`](metadata.go) → `companyMetadata`. |
 | `Raw` | full JSON | Verbatim Routable response. |
 
-> **No N+1.** Unlike the legacy Generic-Connector adapter (`connector-routable`), we do **not** fan out to `GET /v1/companies/{id}/payment-methods` per row during list. Payment-method resolution happens on demand at payable-creation time only.
+> **No N+1.** Unlike the legacy Generic-Connector adapter (`connector-routable`), we do **not** fan out to `GET /v1/companies/{id}/payment-methods` per row during list. The caller supplies the selected payment-method ID when creating a route that requires one.
 
 ### 3.4 Payable → `PSPPayment` (PAYOUT)
 
@@ -110,8 +110,8 @@ Implemented in [`payments.go`](payments.go) (`payableToPSPPayment`).
 | `Status` | `status` | Mapped via [`status.go`](status.go) → `payableStatus`. See [§4](#4-status-mapping). |
 | `SourceAccountReference` | `withdraw_from_account.id` | Routable settings account ID (matches a `PSPAccount` of internal type). |
 | `DestinationAccountReference` | `pay_to_company.id` | Routable company ID (matches a `PSPAccount` of external type). |
-| `Metadata` | `type`, `delivery_method`, `status`, `external_id`, `memo`, `reference`, plus the correlation aliases `payment_initiation_reference` (= `external_id`) and `payable_id` (= the Routable UUID) | See [`metadata.go`](metadata.go) → `payableMetadata`. The aliases make the Transfer ↔ Payment link discoverable without grepping for Routable-specific keys; see [§5.5](#55-correlating-a-transfer-paymentinitiation-with-the-synced-payment). |
-| `Raw` | full JSON | Verbatim Routable response. |
+| `Metadata` | `type`, `delivery_method`, `status`, `external_id`, `memo`, `reference`, `pay_to_payment_method`, `failure_detail`, plus the correlation aliases `payment_initiation_reference` (= `external_id`) and `payable_id` (= the Routable UUID) | `failure_detail` is retained as JSON for failed payments. See [`metadata.go`](metadata.go) → `payableMetadata`. |
+| `Raw` | full JSON | Verbatim Routable response, including unmodeled and provider-specific failure fields. |
 
 ### 3.5 Receivable → `PSPPayment` (PAYIN)
 
@@ -175,13 +175,14 @@ All keys are defined as constants in [`mappers/metadata.go`](mappers/metadata.go
 
 | Metadata key | Const | Required | Default | Maps to Routable field | Purpose |
 |---|---|---|---|---|---|
-| `com.routable.spec/type` | `MetadataKeyType` | no | `ach` | `type` | Payable rail (`ach`, `wire`, `check`, `international`, `external`, `vendor_choice`). |
-| `com.routable.spec/delivery_method` | `MetadataKeyDeliveryMethod` | no | `ach_standard` | `delivery_method` | Specific delivery option (`ach_standard`, `ach_same_day`, `wire`, `check`, …). Must be compatible with `type`. |
+| `com.routable.spec/type` | `MetadataKeyType` | no | `ach` | `type` | Payable rail (`ach`, `wire`, `check`, `international`, `paypal`, `external`, `vendor_choice`). |
+| `com.routable.spec/delivery_method` | `MetadataKeyDeliveryMethod` | no | `ach_standard` | `delivery_method` | Specific delivery option (`ach_standard`, `international_ach`, `paypal_direct`, …). Must be compatible with `type`. |
 | `com.routable.spec/acting_team_member` | `MetadataKeyActingTeamMember` | conditional¹ | config `actingTeamMember` | `acting_team_member` | Routable team member ID initiating the payable. |
 | `com.routable.spec/external_id` | `MetadataKeyExternalID` | no | `""` | `external_id` | Caller-supplied external reference (idempotent lookup key on Routable's side). |
 | `com.routable.spec/line_item_description` | `MetadataKeyLineDescription` | no | `PSPPaymentInitiation.Description`, then `"Payment <reference>"` | `line_items[0].description` | Description on the auto-generated single-line item. Required by Routable v1; we always emit a non-empty value. |
 | `com.routable.spec/message` | `MetadataKeyMessage` | no | (omitted) | `message` | Vendor-facing email body sent to the payee's contacts when the payable is processed. A limited subset of HTML is permitted (see [Routable docs](https://developers.routable.com/docs/html-messages)). Omitted from the request body when empty. |
 | `com.routable.spec/send_on` | `MetadataKeySendOn` | no | unset → `send_on: null`, which Routable **does not execute** (see [§5.2](#52-static-body-fields-always-present)) | `send_on` | `YYYY-MM-DD` date on which **Routable** releases the payable. Validated locally; a malformed date fails as `ErrInvalidRequest` before any HTTP call. **This is not `scheduledAt`** — the engine's `scheduledAt` is honoured by sleeping *before* the plugin is called, so the two stack if you set both. |
+| `com.routable.spec/pay_to_payment_method` | `MetadataKeyPayToPaymentMethod` | conditional | none | `pay_to_payment_method` | Routable payment-method UUID selected by the caller. Required for PayPal; international routes may use it to select an existing vendor payment method. |
 
 > `com.routable.spec/memo` is read-only metadata on synced payables/receivables (populated from the Routable response). Routable's v1 `POST /v1/payables` rejects `memo` as an unknown field, so we do not forward this key on create. Use `com.routable.spec/line_item_description` for the message that ends up on the payable.
 
@@ -226,6 +227,8 @@ Routable's `POST /v1/payables` answers in two distinct shapes; the plugin branch
 | `201 Created` (sync) with non-terminal status (`pending`, `processing`, …) | `PollingPayoutID` / `PollingTransferID` = `Payment.Reference` | Engine schedules a polling round; the first poll returns the Payment, links it to the PI, and ends. The initial sync mapping is discarded — its `Reference` carries forward as the polling token. |
 
 Once a Payment is linked, subsequent status transitions (PENDING → PROCESSING → SUCCEEDED, etc.) are picked up by the `FETCH_PAYMENTS` cursor (§3.6) rather than by re-polling. `PollPayoutStatus` returns an empty response only when `GET /v1/payables/{id}` returns 404 — Routable's eventual-consistency window after a 202; see [`client.go`](client/client.go) (`ErrPayableNotFound`).
+
+Provider error envelopes returned while initiating a payable are retained in the failed PaymentInitiation adjustment error as `raw_response=<JSON>`, alongside the parsed field errors and Routable `request_id`. This makes the original rejection discoverable without relying on transient logs.
 
 ### 5.5 Correlating a Transfer (PaymentInitiation) with the synced Payment
 

--- a/ee/plugins/routable/client/client.go
+++ b/ee/plugins/routable/client/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
 	"github.com/formancehq/payments/pkg/domain/httpwrapper"
 	"github.com/formancehq/payments/pkg/domain/metrics"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -138,12 +139,10 @@ func (c *client) do(ctx context.Context, method, path string, query url.Values, 
 		return statusCode, nil
 	}
 
-	// Attach the Routable error envelope when the response carried one.
-	// Transport errors (DNS, timeout, connection refused) leave apiErr
-	// at its zero value, in which case appending the formatted envelope
-	// just produces a misleading "empty body" suffix.
+	// Keep provider feedback first because the engine persists the first cause;
+	// retain the HTTP error as a second target for errors.Is classification.
 	if apiErr.hasContent() {
-		return statusCode, fmt.Errorf("%w: %s", doErr, apiErr.Error())
+		return statusCode, errorsutils.NewWrappedError(&apiErr, doErr)
 	}
 	return statusCode, doErr
 }

--- a/ee/plugins/routable/client/client_test.go
+++ b/ee/plugins/routable/client/client_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
+	"github.com/formancehq/payments/pkg/domain/httpwrapper"
 )
 
 // newTestServer spins up a Routable-shaped httptest server that asserts the
@@ -25,6 +28,19 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) (Client, *httptest.Se
 		handler(w, r)
 	}))
 	return New("routable-test", "test-key", srv.URL), srv
+}
+
+func validPayPalPayableRequest() CreatePayableRequest {
+	return CreatePayableRequest{
+		Type:                "paypal",
+		DeliveryMethod:      "paypal_direct",
+		PayToCompany:        "co_1",
+		PayToPaymentMethod:  "pm_1",
+		WithdrawFromAccount: "acc_1",
+		Amount:              "10.00",
+		LineItems:           []PayableLineItem{{Amount: "10.00", UnitPrice: "10.00", Description: "test"}},
+		ActingTeamMember:    "tm_1",
+	}
 }
 
 func TestListAccounts(t *testing.T) {
@@ -64,7 +80,7 @@ func TestGetPayableNotFound(t *testing.T) {
 	}
 }
 
-func TestCreatePayableSendsIdempotencyKey(t *testing.T) {
+func TestCreatePayableForwardsRequest(t *testing.T) {
 	var captured struct {
 		Key  string
 		Body CreatePayableRequest
@@ -81,6 +97,7 @@ func TestCreatePayableSendsIdempotencyKey(t *testing.T) {
 		Type:                "ach",
 		DeliveryMethod:      "ach_standard",
 		PayToCompany:        "co_1",
+		PayToPaymentMethod:  "pm_1",
 		WithdrawFromAccount: "acc_1",
 		Amount:              "10.00",
 		CurrencyCode:        "USD",
@@ -103,6 +120,9 @@ func TestCreatePayableSendsIdempotencyKey(t *testing.T) {
 	}
 	if captured.Body.PayToCompany != "co_1" {
 		t.Fatalf("body not forwarded: %+v", captured.Body)
+	}
+	if captured.Body.PayToPaymentMethod != "pm_1" {
+		t.Fatalf("payment method not forwarded: %+v", captured.Body)
 	}
 }
 
@@ -211,6 +231,53 @@ func TestErrorSuffixOnlyWhenAPIBodyPresent(t *testing.T) {
 			t.Fatalf("error should not include placeholder suffix, got %q", err.Error())
 		}
 	})
+}
+
+func TestAPIErrorIsThePersistableCause(t *testing.T) {
+	const body = `{"title":"Invalid request","status":400,"request_id":"req_42","errors":[{"path":"pay_to_payment_method","detail":"is required"}]}`
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, body)
+	})
+	defer srv.Close()
+
+	_, _, err := c.CreatePayable(context.Background(), validPayPalPayableRequest())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	cause := errorsutils.Cause(err)
+	if !strings.Contains(cause.Error(), "pay_to_payment_method: is required") {
+		t.Fatalf("persisted cause lost field feedback: %q", cause.Error())
+	}
+	if !strings.Contains(cause.Error(), "request_id=req_42") {
+		t.Fatalf("persisted cause lost request ID: %q", cause.Error())
+	}
+	if !strings.Contains(cause.Error(), "raw_response="+body) {
+		t.Fatalf("persisted cause lost raw response: %q", cause.Error())
+	}
+	if !errors.Is(err, httpwrapper.ErrStatusCodeClientError) {
+		t.Fatalf("error lost HTTP classification: %v", err)
+	}
+}
+
+func TestAPIErrorPreservesRawWhenKnownFieldShapeChanges(t *testing.T) {
+	const body = `{"title":"Invalid request","status":"400","request_id":"req_42","provider_extension":{"code":"new_shape"}}`
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, body)
+	})
+	defer srv.Close()
+
+	_, _, err := c.CreatePayable(context.Background(), validPayPalPayableRequest())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cause := errorsutils.Cause(err); !strings.Contains(cause.Error(), "raw_response="+body) {
+		t.Fatalf("persisted cause lost raw response: %q", cause.Error())
+	}
+	if !errors.Is(err, httpwrapper.ErrStatusCodeClientError) {
+		t.Fatalf("error lost HTTP classification: %v", err)
+	}
 }
 
 func TestListPayablesPassesStatusChangedAtGte(t *testing.T) {

--- a/ee/plugins/routable/client/error.go
+++ b/ee/plugins/routable/client/error.go
@@ -12,14 +12,9 @@ import (
 // poll workflow uses errors.Is to keep polling instead of failing.
 var ErrPayableNotFound = errors.New("payable not found")
 
-// hasContent reports whether the envelope carries anything worth surfacing
-// in a wrapped error message. An "empty" envelope is the zero value, and
-// appending it to a transport error just produces a misleading suffix.
+// hasContent reports whether provider feedback is available. Typed fields
+// cover known envelopes; Raw retains unknown or schema-drifted JSON.
 func (e ErrorResponse) hasContent() bool {
-	raw := bytes.TrimSpace(e.Raw)
-	if len(raw) > 0 && !bytes.Equal(raw, []byte("null")) {
-		return true
-	}
 	if e.Title != "" || e.Message != "" || e.Code != "" || e.RequestID != "" {
 		return true
 	}
@@ -28,7 +23,8 @@ func (e ErrorResponse) hasContent() bool {
 			return true
 		}
 	}
-	return false
+	raw := bytes.TrimSpace(e.Raw)
+	return len(raw) > 0 && !bytes.Equal(raw, []byte("null"))
 }
 
 // Error renders the Routable error response into a single line that keeps

--- a/ee/plugins/routable/client/error.go
+++ b/ee/plugins/routable/client/error.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,6 +16,10 @@ var ErrPayableNotFound = errors.New("payable not found")
 // in a wrapped error message. An "empty" envelope is the zero value, and
 // appending it to a transport error just produces a misleading suffix.
 func (e ErrorResponse) hasContent() bool {
+	raw := bytes.TrimSpace(e.Raw)
+	if len(raw) > 0 && !bytes.Equal(raw, []byte("null")) {
+		return true
+	}
 	if e.Title != "" || e.Message != "" || e.Code != "" || e.RequestID != "" {
 		return true
 	}
@@ -66,6 +72,12 @@ func (e ErrorResponse) Error() string {
 
 	if e.RequestID != "" {
 		fmt.Fprintf(&b, " (request_id=%s)", e.RequestID)
+	}
+	if len(e.Raw) > 0 {
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, e.Raw); err == nil {
+			fmt.Fprintf(&b, "; raw_response=%s", compact.String())
+		}
 	}
 	return b.String()
 }

--- a/ee/plugins/routable/client/error_test.go
+++ b/ee/plugins/routable/client/error_test.go
@@ -7,6 +7,7 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,8 @@ var _ = Describe("ErrorResponse.Error", func() {
 			Expect(in.Error()).To(Equal(expected))
 		},
 		Entry("empty body", ErrorResponse{}, "routable api error: empty body"),
+		Entry("null body", ErrorResponse{Raw: json.RawMessage("null")}, "routable api error: empty body"),
+		Entry("empty JSON object", ErrorResponse{Raw: json.RawMessage("{}")}, "routable api error; raw_response={}"),
 		Entry("message only", ErrorResponse{Message: "boom"}, "routable api error: boom"),
 		Entry("code + message",
 			ErrorResponse{Code: "validation", Message: "invalid"},

--- a/ee/plugins/routable/client/types.go
+++ b/ee/plugins/routable/client/types.go
@@ -1,6 +1,9 @@
 package client
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Domain models for the Routable API. Field names mirror the Routable JSON
 // schema (https://developers.routable.com/reference). We only model the
@@ -93,22 +96,44 @@ type PayableAccount struct {
 	Type   string `json:"type,omitempty"`
 }
 
+// PayablePaymentMethod identifies the payment destination embedded in a
+// Payable response.
+type PayablePaymentMethod struct {
+	ID string `json:"id"`
+}
+
 // Payable is a Routable outgoing payment. API: GET /v1/payables.
 type Payable struct {
-	Object              string          `json:"object"`
-	ID                  string          `json:"id"`
-	Type                string          `json:"type"`
-	DeliveryMethod      string          `json:"delivery_method"`
-	Status              string          `json:"status"`
-	ExternalID          string          `json:"external_id,omitempty"`
-	Amount              string          `json:"amount"`
-	CurrencyCode        string          `json:"currency_code"`
-	PayToCompany        *PayableCompany `json:"pay_to_company,omitempty"`
-	WithdrawFromAccount *PayableAccount `json:"withdraw_from_account,omitempty"`
-	Memo                string          `json:"memo,omitempty"`
-	Reference           string          `json:"reference,omitempty"`
-	StatusChangedAt     *time.Time      `json:"status_changed_at,omitempty"`
-	CreatedAt           time.Time       `json:"created_at"`
+	Object              string                `json:"object"`
+	ID                  string                `json:"id"`
+	Type                string                `json:"type"`
+	DeliveryMethod      string                `json:"delivery_method"`
+	Status              string                `json:"status"`
+	ExternalID          string                `json:"external_id,omitempty"`
+	Amount              string                `json:"amount"`
+	CurrencyCode        string                `json:"currency_code"`
+	PayToCompany        *PayableCompany       `json:"pay_to_company,omitempty"`
+	PayToPaymentMethod  *PayablePaymentMethod `json:"pay_to_payment_method,omitempty"`
+	WithdrawFromAccount *PayableAccount       `json:"withdraw_from_account,omitempty"`
+	Memo                string                `json:"memo,omitempty"`
+	Reference           string                `json:"reference,omitempty"`
+	FailureDetail       json.RawMessage       `json:"failure_detail,omitempty"`
+	StatusChangedAt     *time.Time            `json:"status_changed_at,omitempty"`
+	CreatedAt           time.Time             `json:"created_at"`
+	Raw                 json.RawMessage       `json:"-"`
+}
+
+// UnmarshalJSON retains the complete provider object. The typed fields drive
+// normal mapping; Raw keeps failure details and future Routable fields intact.
+func (p *Payable) UnmarshalJSON(data []byte) error {
+	type payableAlias Payable
+	var decoded payableAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = Payable(decoded)
+	p.Raw = append(json.RawMessage(nil), data...)
+	return nil
 }
 
 type ListPayablesResponse struct {
@@ -184,14 +209,15 @@ type CreatePayableRequest struct {
 	Type                string            `json:"type"`
 	DeliveryMethod      string            `json:"delivery_method"`
 	PayToCompany        string            `json:"pay_to_company"`
+	PayToPaymentMethod  string            `json:"pay_to_payment_method,omitempty"`
 	WithdrawFromAccount string            `json:"withdraw_from_account"`
 	Amount              string            `json:"amount"`
 	CurrencyCode        string            `json:"currency_code,omitempty"`
-	LineItems        []PayableLineItem `json:"line_items"`
-	SendOn           *string           `json:"send_on"`
-	ActingTeamMember string            `json:"acting_team_member"`
-	Reference        string            `json:"reference,omitempty"`
-	ExternalID       string            `json:"external_id,omitempty"`
+	LineItems           []PayableLineItem `json:"line_items"`
+	SendOn              *string           `json:"send_on"`
+	ActingTeamMember    string            `json:"acting_team_member"`
+	Reference           string            `json:"reference,omitempty"`
+	ExternalID          string            `json:"external_id,omitempty"`
 
 	// Message is Routable's vendor-facing email body sent to the payee's
 	// contacts when the payable is processed. HTML subset permitted; see
@@ -229,7 +255,24 @@ type ErrorResponse struct {
 	// Per-field details. Routable populates either {field, message} (legacy)
 	// or {where, path, detail} (v1) — we keep both to round-trip whatever
 	// the API returns.
-	Errors []FieldError `json:"errors,omitempty"`
+	Errors []FieldError    `json:"errors,omitempty"`
+	Raw    json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON keeps the complete provider error for durable payout failure
+// feedback while retaining typed fields for readable diagnostics.
+func (e *ErrorResponse) UnmarshalJSON(data []byte) error {
+	raw := append(json.RawMessage(nil), data...)
+	// Preserve the body even when a known field changes shape and typed decoding fails.
+	e.Raw = raw
+	type errorResponseAlias ErrorResponse
+	var decoded errorResponseAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*e = ErrorResponse(decoded)
+	e.Raw = raw
+	return nil
 }
 
 type FieldError struct {

--- a/ee/plugins/routable/mappers/mappers_test.go
+++ b/ee/plugins/routable/mappers/mappers_test.go
@@ -262,6 +262,28 @@ func TestPayableToPSPPayment_PreservesFailureEvidence(t *testing.T) {
 	}
 }
 
+func TestPayableToPSPPayment_PayPalWithoutCurrencyDefaultsToUSD(t *testing.T) {
+	const raw = `{"object":"Payable","id":"pa_paypal","type":"paypal","delivery_method":"paypal_direct","status":"ready_to_send","amount":"594.40","created_at":"2026-08-19T00:00:00Z"}`
+	var payable client.Payable
+	if err := json.Unmarshal([]byte(raw), &payable); err != nil {
+		t.Fatalf("unmarshal payable: %v", err)
+	}
+
+	got, err := PayableToPSPPayment(payable)
+	if err != nil {
+		t.Fatalf("map payable: %v", err)
+	}
+	if got.Asset != "USD/2" {
+		t.Errorf("Asset = %q, want USD/2", got.Asset)
+	}
+	if got.Amount == nil || got.Amount.Cmp(big.NewInt(59440)) != 0 {
+		t.Errorf("Amount = %v, want 59440", got.Amount)
+	}
+	if string(got.Raw) != raw {
+		t.Errorf("Raw response changed:\n got: %s\nwant: %s", got.Raw, raw)
+	}
+}
+
 // Invariant: an unsupported currency on a payable surfaces as an error
 // (skip-and-log path in the parent fetcher), never a silent wrong-
 // precision Payment.

--- a/ee/plugins/routable/mappers/mappers_test.go
+++ b/ee/plugins/routable/mappers/mappers_test.go
@@ -239,6 +239,29 @@ func TestPayableToPSPPayment_FullShape(t *testing.T) {
 	}
 }
 
+func TestPayableToPSPPayment_PreservesFailureEvidence(t *testing.T) {
+	const raw = `{"id":"pa_failed","type":"paypal","delivery_method":"paypal_direct","status":"failed","amount":"66.66","currency_code":"USD","pay_to_payment_method":{"id":"pm_42","type":"paypal"},"failure_detail":{"code":"recipient_not_found","message":"PayPal recipient was not found"},"created_at":"2026-08-19T00:00:00Z","provider_extension":"kept"}`
+	var payable client.Payable
+	if err := json.Unmarshal([]byte(raw), &payable); err != nil {
+		t.Fatalf("unmarshal payable: %v", err)
+	}
+
+	got, err := PayableToPSPPayment(payable)
+	if err != nil {
+		t.Fatalf("map payable: %v", err)
+	}
+	if string(got.Raw) != raw {
+		t.Errorf("Raw response changed:\n got: %s\nwant: %s", got.Raw, raw)
+	}
+	if got.Metadata[MetadataKeyPayToPaymentMethod] != "pm_42" {
+		t.Errorf("payment method metadata missing: %v", got.Metadata)
+	}
+	wantFailure := `{"code":"recipient_not_found","message":"PayPal recipient was not found"}`
+	if got.Metadata[MetadataKeyFailureDetail] != wantFailure {
+		t.Errorf("failure detail = %q, want %q", got.Metadata[MetadataKeyFailureDetail], wantFailure)
+	}
+}
+
 // Invariant: an unsupported currency on a payable surfaces as an error
 // (skip-and-log path in the parent fetcher), never a silent wrong-
 // precision Payment.

--- a/ee/plugins/routable/mappers/metadata.go
+++ b/ee/plugins/routable/mappers/metadata.go
@@ -12,14 +12,15 @@ const MetadataPrefix = "com.routable.spec/"
 // Metadata keys read from PSPPaymentInitiation.Metadata when initiating
 // a payable. See MAPPINGS.md §5 for the per-key semantics and defaults.
 const (
-	MetadataKeyType             = MetadataPrefix + "type"
-	MetadataKeyDeliveryMethod   = MetadataPrefix + "delivery_method"
-	MetadataKeyExternalID       = MetadataPrefix + "external_id"
-	MetadataKeyMemo             = MetadataPrefix + "memo"
-	MetadataKeyMessage          = MetadataPrefix + "message"
-	MetadataKeyLineDescription  = MetadataPrefix + "line_item_description"
-	MetadataKeyActingTeamMember = MetadataPrefix + "acting_team_member"
-	MetadataKeySendOn           = MetadataPrefix + "send_on"
+	MetadataKeyType               = MetadataPrefix + "type"
+	MetadataKeyDeliveryMethod     = MetadataPrefix + "delivery_method"
+	MetadataKeyExternalID         = MetadataPrefix + "external_id"
+	MetadataKeyMemo               = MetadataPrefix + "memo"
+	MetadataKeyMessage            = MetadataPrefix + "message"
+	MetadataKeyLineDescription    = MetadataPrefix + "line_item_description"
+	MetadataKeyActingTeamMember   = MetadataPrefix + "acting_team_member"
+	MetadataKeySendOn             = MetadataPrefix + "send_on"
+	MetadataKeyPayToPaymentMethod = MetadataPrefix + "pay_to_payment_method"
 )
 
 // SendOnLayout is the only date format Routable's v1 `send_on` accepts.
@@ -62,6 +63,8 @@ const (
 	MetadataKeyPaymentInitiationReference = MetadataPrefix + "payment_initiation_reference"
 	MetadataKeyRoutablePayableID          = MetadataPrefix + "payable_id"
 )
+
+const MetadataKeyFailureDetail = MetadataPrefix + "failure_detail"
 
 const (
 	DefaultPayableType    = "ach"
@@ -115,7 +118,7 @@ func SettingsAccountMetadata(a client.Account) map[string]string {
 }
 
 func PayableMetadata(p client.Payable) map[string]string {
-	return stripEmpty(map[string]string{
+	m := map[string]string{
 		MetadataPrefix + "type":               p.Type,
 		MetadataPrefix + "delivery_method":    p.DeliveryMethod,
 		MetadataPrefix + "status":             p.Status,
@@ -124,7 +127,14 @@ func PayableMetadata(p client.Payable) map[string]string {
 		MetadataKeyRoutablePayableID:          p.ID,
 		MetadataPrefix + "memo":               p.Memo,
 		MetadataPrefix + "reference":          p.Reference,
-	})
+	}
+	if p.PayToPaymentMethod != nil {
+		m[MetadataKeyPayToPaymentMethod] = p.PayToPaymentMethod.ID
+	}
+	if len(p.FailureDetail) > 0 && string(p.FailureDetail) != "null" {
+		m[MetadataKeyFailureDetail] = string(p.FailureDetail)
+	}
+	return stripEmpty(m)
 }
 
 func ReceivableMetadata(r client.Receivable) map[string]string {

--- a/ee/plugins/routable/mappers/payable.go
+++ b/ee/plugins/routable/mappers/payable.go
@@ -18,7 +18,13 @@ func PayableToPSPPayment(pa client.Payable) (models.PSPPayment, error) {
 			return models.PSPPayment{}, fmt.Errorf("marshaling raw: %w", err)
 		}
 	}
-	precision, err := PrecisionFor(pa.CurrencyCode)
+	currencyCode := pa.CurrencyCode
+	if currencyCode == "" {
+		// Routable's common payable response makes this nullable and
+		// defaults it to USD.
+		currencyCode = "USD"
+	}
+	precision, err := PrecisionFor(currencyCode)
 	if err != nil {
 		return models.PSPPayment{}, err
 	}
@@ -33,7 +39,7 @@ func PayableToPSPPayment(pa client.Payable) (models.PSPPayment, error) {
 		CreatedAt: StatusChangedAtOrCreated(pa.StatusChangedAt, pa.CreatedAt),
 		Type:      models.PAYMENT_TYPE_PAYOUT,
 		Amount:    amount,
-		Asset:     FormatAsset(pa.CurrencyCode),
+		Asset:     FormatAsset(currencyCode),
 		Scheme:    DeliveryMethodToScheme(pa.DeliveryMethod),
 		Status:    PayableStatus(pa.Status),
 		Metadata:  PayableMetadata(pa),

--- a/ee/plugins/routable/mappers/payable.go
+++ b/ee/plugins/routable/mappers/payable.go
@@ -10,9 +10,13 @@ import (
 )
 
 func PayableToPSPPayment(pa client.Payable) (models.PSPPayment, error) {
-	raw, err := json.Marshal(pa)
-	if err != nil {
-		return models.PSPPayment{}, fmt.Errorf("marshaling raw: %w", err)
+	raw := append(json.RawMessage(nil), pa.Raw...)
+	if len(raw) == 0 {
+		var err error
+		raw, err = json.Marshal(pa)
+		if err != nil {
+			return models.PSPPayment{}, fmt.Errorf("marshaling raw: %w", err)
+		}
 	}
 	precision, err := PrecisionFor(pa.CurrencyCode)
 	if err != nil {

--- a/ee/plugins/routable/payable_create.go
+++ b/ee/plugins/routable/payable_create.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/formancehq/payments/ee/plugins/routable/client"
 	"github.com/formancehq/payments/ee/plugins/routable/mappers"
-	"github.com/formancehq/payments/pkg/domain/models"
 	errorsutils "github.com/formancehq/payments/pkg/domain/errors"
+	"github.com/formancehq/payments/pkg/domain/models"
 )
 
 // initiatePayable is shared by createPayout and createTransfer. It
@@ -64,6 +64,7 @@ func (p *Plugin) initiatePayable(ctx context.Context, pi models.PSPPaymentInitia
 		Type:                mappers.FieldOr(pi.Metadata, mappers.MetadataKeyType, mappers.DefaultPayableType),
 		DeliveryMethod:      mappers.FieldOr(pi.Metadata, mappers.MetadataKeyDeliveryMethod, mappers.DefaultDeliveryMethod),
 		PayToCompany:        pi.DestinationAccount.Reference,
+		PayToPaymentMethod:  models.ExtractNamespacedMetadata(pi.Metadata, mappers.MetadataKeyPayToPaymentMethod),
 		WithdrawFromAccount: pi.SourceAccount.Reference,
 		Amount:              amount,
 		CurrencyCode:        currencyCode,

--- a/ee/plugins/routable/payouts_test.go
+++ b/ee/plugins/routable/payouts_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/payments/ee/plugins/routable/client"
 	"github.com/formancehq/payments/ee/plugins/routable/mappers"
-	"github.com/formancehq/payments/pkg/domain/plugins"
 	"github.com/formancehq/payments/pkg/domain/models"
+	"github.com/formancehq/payments/pkg/domain/plugins"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -215,6 +215,36 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 		_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: piWithOverrides})
 		Expect(err).To(BeNil())
 	})
+
+	DescribeTable("maps payment-method based payable routes",
+		func(ctx SpecContext, payableType, deliveryMethod string) {
+			withRoute := pi()
+			withRoute.Metadata = map[string]string{
+				mappers.MetadataKeyType:               payableType,
+				mappers.MetadataKeyDeliveryMethod:     deliveryMethod,
+				mappers.MetadataKeyPayToPaymentMethod: "pm_42",
+				mappers.MetadataKeySendOn:             "2026-08-19",
+			}
+
+			mock.EXPECT().CreatePayable(gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, req client.CreatePayableRequest) (*client.Payable, int, error) {
+				Expect(req.Type).To(Equal(payableType))
+				Expect(req.DeliveryMethod).To(Equal(deliveryMethod))
+				Expect(req.PayToPaymentMethod).To(Equal("pm_42"))
+				Expect(req.SendOn).NotTo(BeNil())
+				Expect(*req.SendOn).To(Equal("2026-08-19"))
+				Expect(req.LineItems).To(ConsistOf(client.PayableLineItem{
+					UnitPrice: "123.45", Amount: "123.45", Quantity: 1,
+					Description: "rent",
+				}))
+				return &client.Payable{ID: "pa_route", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+			})
+
+			_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: withRoute})
+			Expect(err).To(BeNil())
+		},
+		Entry("PayPal direct", "paypal", "paypal_direct"),
+		Entry("international ACH", "international", "international_ach"),
+	)
 
 	It("forwards com.routable.spec/message to Routable.message when set", func(ctx SpecContext) {
 		piWithMsg := pi()

--- a/ee/plugins/routable/payouts_test.go
+++ b/ee/plugins/routable/payouts_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 	})
 
 	DescribeTable("maps payment-method based payable routes",
-		func(ctx SpecContext, payableType, deliveryMethod string) {
+		func(ctx SpecContext, payableType, deliveryMethod, responseCurrency string) {
 			withRoute := pi()
 			withRoute.Metadata = map[string]string{
 				mappers.MetadataKeyType:               payableType,
@@ -236,14 +236,14 @@ var _ = Describe("Routable createPayout / pollPayableStatus", func() {
 					UnitPrice: "123.45", Amount: "123.45", Quantity: 1,
 					Description: "rent",
 				}))
-				return &client.Payable{ID: "pa_route", Status: "pending", Amount: "123.45", CurrencyCode: "USD", CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
+				return &client.Payable{ID: "pa_route", Type: payableType, Status: "pending", Amount: "123.45", CurrencyCode: responseCurrency, CreatedAt: time.Now().UTC()}, http.StatusCreated, nil
 			})
 
 			_, err := plg.createPayout(ctx, models.CreatePayoutRequest{PaymentInitiation: withRoute})
 			Expect(err).To(BeNil())
 		},
-		Entry("PayPal direct", "paypal", "paypal_direct"),
-		Entry("international ACH", "international", "international_ach"),
+		Entry("PayPal direct without response currency", "paypal", "paypal_direct", ""),
+		Entry("international ACH", "international", "international_ach", "USD"),
 	)
 
 	It("forwards com.routable.spec/message to Routable.message when set", func(ctx SpecContext) {

--- a/internal/connectors/engine/workflow/create_payout_test.go
+++ b/internal/connectors/engine/workflow/create_payout_test.go
@@ -267,6 +267,8 @@ func (s *UnitTestSuite) Test_CreatePayout_StoragePaymentInitiationsAdjustmentsSt
 }
 
 func (s *UnitTestSuite) Test_CreatePayout_PluginCreatePayout_Error() {
+	const providerFailure = `raw_response={"request_id":"req_42"}`
+
 	s.env.OnActivity(activities.StoragePaymentInitiationsGetActivity, mock.Anything, s.paymentInitiationID).Once().Return(&s.paymentInitiationPayout, nil)
 	s.env.OnActivity(activities.StorageAccountsGetActivity, mock.Anything, *s.paymentInitiationPayout.SourceAccountID).Once().Return(&s.account, nil)
 	s.env.OnActivity(activities.StorageAccountsGetActivity, mock.Anything, *s.paymentInitiationPayout.DestinationAccountID).Once().Return(&s.account, nil)
@@ -276,10 +278,11 @@ func (s *UnitTestSuite) Test_CreatePayout_PluginCreatePayout_Error() {
 	})
 	s.env.OnActivity(activities.PluginCreatePayoutActivity, mock.Anything, mock.Anything).Once().Return(
 		nil,
-		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", errors.New("error-test")),
+		temporal.NewNonRetryableApplicationError("error-test", "PLUGIN", errors.New(providerFailure)),
 	)
 	s.env.OnActivity(activities.StoragePaymentInitiationsAdjustmentsStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, adj models.PaymentInitiationAdjustment) error {
 		s.Equal(models.PAYMENT_INITIATION_ADJUSTMENT_STATUS_FAILED, adj.Status)
+		s.ErrorContains(adj.Error, providerFailure)
 		return nil
 	})
 	s.env.OnActivity(activities.StorageTasksStoreActivity, mock.Anything, mock.Anything).Once().Return(func(ctx context.Context, task models.Task) error {


### PR DESCRIPTION
## Summary

- forward `com.routable.spec/pay_to_payment_method` to Routable for PayPal and international payable creation
- retain the selected payment method, `failure_detail`, and the complete provider payload on synced payouts
- persist Routable's raw JSON rejection, request ID, and field errors in failed PaymentInitiation adjustments while preserving HTTP error classification
- apply Routable's documented USD default when a payable response omits or nulls `currency_code`

## Scope

This keeps route-policy validation with Routable so provider contract changes do not drift into the connector and upstream rejection details remain available. Throughput changes and provider-wide HTTP-wrapper changes are intentionally excluded.

## Test plan

- [x] `go test -race ./ee/plugins/routable/...`
- [x] `go test -race ./internal/connectors/engine/workflow`
- [x] `go test -tags contract -run '^$' ./ee/plugins/routable/client`
- [x] `golangci-lint run --build-tags it --timeout 5m --new-from-rev origin/main` (0 issues)
- [x] `nix develop --impure --command just pc`
- [x] `git diff --check origin/main...HEAD`
