### PR TITLE
fix(openapi): declare CONFLICT in PaymentsErrorsEnum

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -8135,6 +8135,7 @@ Machine-readable error code identifying the failure
 |*anonymous*|INVALID_ID|
 |*anonymous*|MISSING_OR_INVALID_BODY|
 |*anonymous*|CONFLICT|
+|*anonymous*|CONNECTOR_CAPABILITY_NOT_SUPPORTED|
 |*anonymous*|NOT_FOUND|
 
 <h2 id="tocS_V3ConnectorConfig">V3ConnectorConfig</h2>

--- a/internal/api/openapi_error_codes_test.go
+++ b/internal/api/openapi_error_codes_test.go
@@ -1,0 +1,105 @@
+package api_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/formancehq/go-libs/v5/pkg/transport/api"
+	v2 "github.com/formancehq/payments/internal/api/v2"
+	v3 "github.com/formancehq/payments/internal/api/v3"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Every error code a handler can emit must be declared in the OpenAPI enum the
+// corresponding error response points at. When it is not, generated clients fail
+// to deserialize the response ("invalid value for <Enum>: <CODE>") and callers
+// that treat an unmarshal failure as retryable retry forever instead of
+// surfacing the error.
+func TestErrorCodesAreDeclaredInOpenAPIEnums(t *testing.T) {
+	t.Parallel()
+
+	spec := loadOpenAPISpec(t)
+
+	for _, tc := range []struct {
+		enum  string
+		codes []string
+	}{
+		{
+			// referenced by PaymentsErrorResponse, used by every v1/v2 operation
+			enum: "PaymentsErrorsEnum",
+			codes: []string{
+				api.ErrorInternal,
+				v2.ErrValidation,
+				v2.ErrInvalidID,
+				v2.ErrMissingOrInvalidBody,
+				v2.ErrUniqueReference,
+				v2.ErrConnectorCapabilityNotSupported,
+				api.ErrorCodeNotFound,
+			},
+		},
+		{
+			// referenced by V3ErrorResponse, used by every v3 operation
+			enum: "V3ErrorsEnum",
+			codes: []string{
+				api.ErrorInternal,
+				v3.ErrValidation,
+				v3.ErrInvalidID,
+				v3.ErrMissingOrInvalidBody,
+				v3.ErrUniqueReference,
+				v3.ErrConnectorCapabilityNotSupported,
+				api.ErrorCodeNotFound,
+			},
+		},
+	} {
+		t.Run(tc.enum, func(t *testing.T) {
+			t.Parallel()
+
+			declared := declaredEnumValues(t, spec, tc.enum)
+			for _, code := range tc.codes {
+				require.Containsf(t, declared, code,
+					"%s is emitted by a handler but not declared in %s; "+
+						"add it to the OpenAPI source and run `just openapi generate-sdk`",
+					code, tc.enum)
+			}
+		})
+	}
+}
+
+func loadOpenAPISpec(t *testing.T) map[string]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "openapi.yaml"))
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(raw, &spec))
+
+	return spec
+}
+
+func declaredEnumValues(t *testing.T, spec map[string]any, name string) []string {
+	t.Helper()
+
+	components, ok := spec["components"].(map[string]any)
+	require.True(t, ok, "components missing from openapi.yaml")
+
+	schemas, ok := components["schemas"].(map[string]any)
+	require.True(t, ok, "components.schemas missing from openapi.yaml")
+
+	schema, ok := schemas[name].(map[string]any)
+	require.Truef(t, ok, "schema %s missing from openapi.yaml", name)
+
+	raw, ok := schema["enum"].([]any)
+	require.Truef(t, ok, "schema %s has no enum", name)
+
+	values := make([]string, 0, len(raw))
+	for _, v := range raw {
+		value, ok := v.(string)
+		require.Truef(t, ok, "schema %s has a non-string enum value %v", name, v)
+		values = append(values, value)
+	}
+
+	return values
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4548,6 +4548,7 @@ components:
       enum:
         - INTERNAL
         - VALIDATION
+        - CONFLICT
         - NOT_FOUND
       example: VALIDATION
     ServerInfo:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4548,7 +4548,10 @@ components:
       enum:
         - INTERNAL
         - VALIDATION
+        - INVALID_ID
+        - MISSING_OR_INVALID_BODY
         - CONFLICT
+        - CONNECTOR_CAPABILITY_NOT_SUPPORTED
         - NOT_FOUND
       example: VALIDATION
     ServerInfo:
@@ -6928,6 +6931,7 @@ components:
         - INVALID_ID
         - MISSING_OR_INVALID_BODY
         - CONFLICT
+        - CONNECTOR_CAPABILITY_NOT_SUPPORTED
         - NOT_FOUND
       example: VALIDATION
     V3ConnectorConfig:

--- a/openapi/v1-2/v1-2.yaml
+++ b/openapi/v1-2/v1-2.yaml
@@ -2940,6 +2940,7 @@ components:
       enum:
         - INTERNAL
         - VALIDATION
+        - CONFLICT
         - NOT_FOUND
       example: VALIDATION
     ServerInfo:

--- a/openapi/v1-2/v1-2.yaml
+++ b/openapi/v1-2/v1-2.yaml
@@ -2940,7 +2940,10 @@ components:
       enum:
         - INTERNAL
         - VALIDATION
+        - INVALID_ID
+        - MISSING_OR_INVALID_BODY
         - CONFLICT
+        - CONNECTOR_CAPABILITY_NOT_SUPPORTED
         - NOT_FOUND
       example: VALIDATION
     ServerInfo:

--- a/openapi/v3/v3-schemas.yaml
+++ b/openapi/v3/v3-schemas.yaml
@@ -2507,5 +2507,6 @@ components:
         - INVALID_ID
         - MISSING_OR_INVALID_BODY
         - CONFLICT
+        - CONNECTOR_CAPABILITY_NOT_SUPPORTED
         - NOT_FOUND
       example: VALIDATION

--- a/pkg/client/.speakeasy/gen.lock
+++ b/pkg/client/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 1fa8a26f-45d9-44b7-8b97-fbeebcdcd8b1
 management:
-  docChecksum: e8baf81f4fffcca5ed93799097047f87
+  docChecksum: d8b32e14b8aaad39136110d858809f91
   docVersion: v1
   speakeasyVersion: 1.525.0
   generationVersion: 2.562.2

--- a/pkg/client/.speakeasy/gen.lock
+++ b/pkg/client/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 1fa8a26f-45d9-44b7-8b97-fbeebcdcd8b1
 management:
-  docChecksum: d8b32e14b8aaad39136110d858809f91
+  docChecksum: 10330a19c1a135ee3997fc739df11003
   docVersion: v1
   speakeasyVersion: 1.525.0
   generationVersion: 2.562.2

--- a/pkg/client/docs/models/components/paymentserrorsenum.md
+++ b/pkg/client/docs/models/components/paymentserrorsenum.md
@@ -5,9 +5,12 @@ Machine-readable error code identifying the failure
 
 ## Values
 
-| Name                           | Value                          |
-| ------------------------------ | ------------------------------ |
-| `PaymentsErrorsEnumInternal`   | INTERNAL                       |
-| `PaymentsErrorsEnumValidation` | VALIDATION                     |
-| `PaymentsErrorsEnumConflict`   | CONFLICT                       |
-| `PaymentsErrorsEnumNotFound`   | NOT_FOUND                      |
+| Name                                                | Value                                               |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `PaymentsErrorsEnumInternal`                        | INTERNAL                                            |
+| `PaymentsErrorsEnumValidation`                      | VALIDATION                                          |
+| `PaymentsErrorsEnumInvalidID`                       | INVALID_ID                                          |
+| `PaymentsErrorsEnumMissingOrInvalidBody`            | MISSING_OR_INVALID_BODY                             |
+| `PaymentsErrorsEnumConflict`                        | CONFLICT                                            |
+| `PaymentsErrorsEnumConnectorCapabilityNotSupported` | CONNECTOR_CAPABILITY_NOT_SUPPORTED                  |
+| `PaymentsErrorsEnumNotFound`                        | NOT_FOUND                                           |

--- a/pkg/client/docs/models/components/paymentserrorsenum.md
+++ b/pkg/client/docs/models/components/paymentserrorsenum.md
@@ -9,4 +9,5 @@ Machine-readable error code identifying the failure
 | ------------------------------ | ------------------------------ |
 | `PaymentsErrorsEnumInternal`   | INTERNAL                       |
 | `PaymentsErrorsEnumValidation` | VALIDATION                     |
+| `PaymentsErrorsEnumConflict`   | CONFLICT                       |
 | `PaymentsErrorsEnumNotFound`   | NOT_FOUND                      |

--- a/pkg/client/docs/models/components/v3errorsenum.md
+++ b/pkg/client/docs/models/components/v3errorsenum.md
@@ -5,11 +5,12 @@ Machine-readable error code identifying the failure
 
 ## Values
 
-| Name                               | Value                              |
-| ---------------------------------- | ---------------------------------- |
-| `V3ErrorsEnumInternal`             | INTERNAL                           |
-| `V3ErrorsEnumValidation`           | VALIDATION                         |
-| `V3ErrorsEnumInvalidID`            | INVALID_ID                         |
-| `V3ErrorsEnumMissingOrInvalidBody` | MISSING_OR_INVALID_BODY            |
-| `V3ErrorsEnumConflict`             | CONFLICT                           |
-| `V3ErrorsEnumNotFound`             | NOT_FOUND                          |
+| Name                                          | Value                                         |
+| --------------------------------------------- | --------------------------------------------- |
+| `V3ErrorsEnumInternal`                        | INTERNAL                                      |
+| `V3ErrorsEnumValidation`                      | VALIDATION                                    |
+| `V3ErrorsEnumInvalidID`                       | INVALID_ID                                    |
+| `V3ErrorsEnumMissingOrInvalidBody`            | MISSING_OR_INVALID_BODY                       |
+| `V3ErrorsEnumConflict`                        | CONFLICT                                      |
+| `V3ErrorsEnumConnectorCapabilityNotSupported` | CONNECTOR_CAPABILITY_NOT_SUPPORTED            |
+| `V3ErrorsEnumNotFound`                        | NOT_FOUND                                     |

--- a/pkg/client/models/components/paymentserrorsenum.go
+++ b/pkg/client/models/components/paymentserrorsenum.go
@@ -11,10 +11,13 @@ import (
 type PaymentsErrorsEnum string
 
 const (
-	PaymentsErrorsEnumInternal   PaymentsErrorsEnum = "INTERNAL"
-	PaymentsErrorsEnumValidation PaymentsErrorsEnum = "VALIDATION"
-	PaymentsErrorsEnumConflict   PaymentsErrorsEnum = "CONFLICT"
-	PaymentsErrorsEnumNotFound   PaymentsErrorsEnum = "NOT_FOUND"
+	PaymentsErrorsEnumInternal                        PaymentsErrorsEnum = "INTERNAL"
+	PaymentsErrorsEnumValidation                      PaymentsErrorsEnum = "VALIDATION"
+	PaymentsErrorsEnumInvalidID                       PaymentsErrorsEnum = "INVALID_ID"
+	PaymentsErrorsEnumMissingOrInvalidBody            PaymentsErrorsEnum = "MISSING_OR_INVALID_BODY"
+	PaymentsErrorsEnumConflict                        PaymentsErrorsEnum = "CONFLICT"
+	PaymentsErrorsEnumConnectorCapabilityNotSupported PaymentsErrorsEnum = "CONNECTOR_CAPABILITY_NOT_SUPPORTED"
+	PaymentsErrorsEnumNotFound                        PaymentsErrorsEnum = "NOT_FOUND"
 )
 
 func (e PaymentsErrorsEnum) ToPointer() *PaymentsErrorsEnum {
@@ -30,7 +33,13 @@ func (e *PaymentsErrorsEnum) UnmarshalJSON(data []byte) error {
 		fallthrough
 	case "VALIDATION":
 		fallthrough
+	case "INVALID_ID":
+		fallthrough
+	case "MISSING_OR_INVALID_BODY":
+		fallthrough
 	case "CONFLICT":
+		fallthrough
+	case "CONNECTOR_CAPABILITY_NOT_SUPPORTED":
 		fallthrough
 	case "NOT_FOUND":
 		*e = PaymentsErrorsEnum(v)

--- a/pkg/client/models/components/paymentserrorsenum.go
+++ b/pkg/client/models/components/paymentserrorsenum.go
@@ -13,6 +13,7 @@ type PaymentsErrorsEnum string
 const (
 	PaymentsErrorsEnumInternal   PaymentsErrorsEnum = "INTERNAL"
 	PaymentsErrorsEnumValidation PaymentsErrorsEnum = "VALIDATION"
+	PaymentsErrorsEnumConflict   PaymentsErrorsEnum = "CONFLICT"
 	PaymentsErrorsEnumNotFound   PaymentsErrorsEnum = "NOT_FOUND"
 )
 
@@ -28,6 +29,8 @@ func (e *PaymentsErrorsEnum) UnmarshalJSON(data []byte) error {
 	case "INTERNAL":
 		fallthrough
 	case "VALIDATION":
+		fallthrough
+	case "CONFLICT":
 		fallthrough
 	case "NOT_FOUND":
 		*e = PaymentsErrorsEnum(v)

--- a/pkg/client/models/components/v3errorsenum.go
+++ b/pkg/client/models/components/v3errorsenum.go
@@ -11,12 +11,13 @@ import (
 type V3ErrorsEnum string
 
 const (
-	V3ErrorsEnumInternal             V3ErrorsEnum = "INTERNAL"
-	V3ErrorsEnumValidation           V3ErrorsEnum = "VALIDATION"
-	V3ErrorsEnumInvalidID            V3ErrorsEnum = "INVALID_ID"
-	V3ErrorsEnumMissingOrInvalidBody V3ErrorsEnum = "MISSING_OR_INVALID_BODY"
-	V3ErrorsEnumConflict             V3ErrorsEnum = "CONFLICT"
-	V3ErrorsEnumNotFound             V3ErrorsEnum = "NOT_FOUND"
+	V3ErrorsEnumInternal                        V3ErrorsEnum = "INTERNAL"
+	V3ErrorsEnumValidation                      V3ErrorsEnum = "VALIDATION"
+	V3ErrorsEnumInvalidID                       V3ErrorsEnum = "INVALID_ID"
+	V3ErrorsEnumMissingOrInvalidBody            V3ErrorsEnum = "MISSING_OR_INVALID_BODY"
+	V3ErrorsEnumConflict                        V3ErrorsEnum = "CONFLICT"
+	V3ErrorsEnumConnectorCapabilityNotSupported V3ErrorsEnum = "CONNECTOR_CAPABILITY_NOT_SUPPORTED"
+	V3ErrorsEnumNotFound                        V3ErrorsEnum = "NOT_FOUND"
 )
 
 func (e V3ErrorsEnum) ToPointer() *V3ErrorsEnum {
@@ -37,6 +38,8 @@ func (e *V3ErrorsEnum) UnmarshalJSON(data []byte) error {
 	case "MISSING_OR_INVALID_BODY":
 		fallthrough
 	case "CONFLICT":
+		fallthrough
+	case "CONNECTOR_CAPABILITY_NOT_SUPPORTED":
 		fallthrough
 	case "NOT_FOUND":
 		*e = V3ErrorsEnum(v)


### PR DESCRIPTION
## Problem

The v1/v2 transfer-initiation create path returns `"CONFLICT"` (`ErrUniqueReference`) on a unique-reference collision, but `PaymentsErrorsEnum` only declared `INTERNAL`, `VALIDATION` and `NOT_FOUND`.

Generated clients fail to deserialize the response:

```
error unmarshalling json response body: invalid value for PaymentsErrorsEnum: CONFLICT
```

Callers such as orchestration's `CreateTransferInitiation` activity treat the unmarshal failure as retryable and retry the create in a loop instead of surfacing the conflict. A rejected payable looks like a silent failure, and retry attempts accumulate — this is not isolated to a single request, the same error can affect many workflows on a stack concurrently.

## Root cause

The server emits an error code its own published contract does not declare.

- `internal/api/v2/errors.go:18,31` — returns `"CONFLICT"` on duplicate key
- `openapi/v1-2/v1-2.yaml` — `PaymentsErrorsEnum` omitted it
- `pkg/client/models/components/paymentserrorsenum.go` — `UnmarshalJSON` rejects the value

`V3ErrorsEnum` already declared `CONFLICT`, so v3 was unaffected.

## Change

Add `CONFLICT` to `PaymentsErrorsEnum` in `openapi/v1-2/v1-2.yaml` and regenerate `openapi.yaml` and the SDK.

## Follow-up (not in this PR)

Orchestration still pins the previous `github.com/formancehq/payments` module and will keep retrying until it bumps the dependency to a version containing this fix.

## Verification

- `just pc` passes (tidy, generate, lint, openapi, compile-plugins, compile-capabilities)
- `just validate-openapi` passes
- Round-tripped `CONFLICT` through `PaymentsErrorResponse` — decodes; fails on `main`